### PR TITLE
Enable manual CI verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
   pull_request:
 


### PR DESCRIPTION
## Summary

- adds an explicit manual trigger to the existing cross-platform CI workflow
- allows the release workflow to be rerun without creating a synthetic source change

## Verification

The pull request itself runs the existing Node 24 matrix on Ubuntu, macOS, and Windows.