### PR TITLE
Make package checks portable on Windows

### DIFF
--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -1,6 +1,7 @@
 import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
+import { gunzipSync } from "node:zlib"
 
 const root = resolve(import.meta.dir, "..")
 const temporaryDirectory = mkdtempSync(join(tmpdir(), "encephalon-package-check-"))
@@ -17,6 +18,25 @@ const collectFiles = (directory: string): string[] =>
     const path = resolve(directory, entry.name)
     return entry.isDirectory() ? collectFiles(path) : [path]
   })
+
+const packedMode = (tarball: string, expectedPath: string) => {
+  const archive = gunzipSync(readFileSync(tarball))
+  const field = (offset: number, length: number) =>
+    archive.subarray(offset, offset + length).toString("utf8").split("\0", 1)[0] ?? ""
+  const octal = (offset: number, length: number) => Number.parseInt(field(offset, length).trim() || "0", 8)
+  let offset = 0
+  while (offset + 512 <= archive.length) {
+    const name = field(offset, 100)
+    if (name.length === 0) return undefined
+    const prefix = field(offset + 345, 155)
+    const path = prefix.length > 0 ? `${prefix}/${name}` : name
+    const mode = octal(offset + 100, 8)
+    const size = octal(offset + 124, 12)
+    if (path === expectedPath) return mode
+    offset += 512 + Math.ceil(size / 512) * 512
+  }
+  return undefined
+}
 
 try {
   const packageJson = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8")) as {
@@ -82,15 +102,16 @@ try {
     .map((file) => file.path)
     .filter((path) => !allowedRootFiles.has(path) && !path.startsWith("dist/") && !path.startsWith("skills/"))
   if (unexpected.length > 0) throw new Error(`The tarball contains unexpected files: ${unexpected.join(", ")}`)
+  const tarball = resolve(temporaryDirectory, pack.filename)
   const packedCli = pack.files.find((file) => file.path === "dist/cli.mjs")
-  if (packedCli === undefined || (packedCli.mode !== undefined && (packedCli.mode & 0o111) === 0)) {
+  const packedCliMode = packedMode(tarball, "package/dist/cli.mjs")
+  if (packedCli === undefined || packedCliMode === undefined || (packedCliMode & 0o111) === 0) {
     throw new Error("The packed CLI is missing or not executable.")
   }
 
   const consumer = resolve(temporaryDirectory, "consumer")
   mkdirSync(resolve(consumer, ".git"), { recursive: true })
   writeFileSync(resolve(consumer, "package.json"), '{"name":"encephalon-smoke","private":true,"type":"module"}\n')
-  const tarball = resolve(temporaryDirectory, pack.filename)
   run(["npm", "install", "--ignore-scripts", "--no-audit", "--no-fund", "--save-dev", tarball], consumer)
   run([
     "node",

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -54,7 +54,9 @@ try {
     if (!existsSync(resolve(root, path))) throw new Error(`Required package file ${path} is missing.`)
   })
   const cliPath = resolve(root, "dist", "cli.mjs")
-  if (!readFileSync(cliPath, "utf8").startsWith("#!/usr/bin/env node\n") || (lstatSync(cliPath).mode & 0o111) === 0) {
+  const lacksNodeShebang = !readFileSync(cliPath, "utf8").startsWith("#!/usr/bin/env node\n")
+  const lacksExecutableMode = process.platform !== "win32" && (lstatSync(cliPath).mode & 0o111) === 0
+  if (lacksNodeShebang || lacksExecutableMode) {
     throw new Error("The CLI must have a Node shebang and executable mode.")
   }
   const bundledSource = collectFiles(resolve(root, "dist"))

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -105,7 +105,9 @@ try {
   const tarball = resolve(temporaryDirectory, pack.filename)
   const packedCli = pack.files.find((file) => file.path === "dist/cli.mjs")
   const packedCliMode = packedMode(tarball, "package/dist/cli.mjs")
-  if (packedCli === undefined || packedCliMode === undefined || (packedCliMode & 0o111) === 0) {
+  const lacksPackedExecutableMode =
+    process.platform !== "win32" && (packedCliMode === undefined || (packedCliMode & 0o111) === 0)
+  if (packedCli === undefined || lacksPackedExecutableMode) {
     throw new Error("The packed CLI is missing or not executable.")
   }
 


### PR DESCRIPTION
## Summary

- keeps the Node shebang check on every platform
- reads executable mode directly from the compressed tar header on Unix release hosts
- validates Windows through npm bin presence, lifecycle-disabled installation, and actual CLI execution

## Root cause

Windows does not expose Unix execute bits in source metadata and therefore produces npm tar headers without them. npm installs Windows command shims instead. The release is published from macOS, where the checker directly enforces the tar header's executable mode.

## Verification

- Windows passes install, typecheck, all tests, and build
- Ubuntu and macOS pass the complete package checker with direct tar-mode validation
- bun run typecheck
- bun run test: 30 Node tests and 3 Bun package tests
- bun run build
- bun run check:package