### PR TITLE
Normalise the npm binary manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,4 @@ jobs:
       - run: bun run test
       - run: bun run build
       - run: bun run check:package
+      - run: bun run check:publish

--- a/README.md
+++ b/README.md
@@ -175,9 +175,10 @@ bun run typecheck
 bun run test
 bun run build
 bun run check:package
+bun run check:publish
 ```
 
-`check:package` inspects the npm tarball, installs it with lifecycle scripts disabled, imports the public API, and runs the bundled CLI using Node.
+`check:package` inspects the npm tarball, installs it with lifecycle scripts disabled, imports the public API, and runs the bundled CLI using Node. `check:publish` exercises npm's publish-time manifest normalisation without uploading anything.
 
 ## Licence
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -211,7 +211,7 @@ The package manifest must contain, at minimum:
     "node": ">=24.15.0"
   },
   "bin": {
-    "encephalon": "./dist/cli.mjs"
+    "encephalon": "dist/cli.mjs"
   },
   "exports": {
     ".": {
@@ -227,6 +227,8 @@ The package manifest must contain, at minimum:
   ]
 }
 ```
+
+The binary target deliberately omits a leading `./`. npm resolves the path from the package root either way, but its publish-time manifest normaliser rewrites the prefixed form and emits a warning; the canonical manifest therefore uses the already-normalised spelling.
 
 The final manifest must also include the exact public repository URL, issue tracker, useful keywords, and a `packageManager` entry for the maintainer Bun version.
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1294,9 +1294,10 @@ Create a GitHub Actions matrix for Ubuntu, macOS, and Windows using Node 24. CI 
 5. Run TypeScript typechecking.
 6. Run the test suite.
 7. Build the Node ESM distribution.
-8. Inspect package contents with `npm pack --dry-run` or equivalent machine-readable output.
-9. Install the actual tarball into a temporary Git repository with scripts disabled.
-10. Run help/version, init, validate, add, prepare, list, show, search, and gather through Node.
+8. Inspect package contents with machine-readable `npm pack` output.
+9. Run `npm publish --dry-run` after the build and package inspection so npm's publish-time manifest normalisation is part of the release gate without uploading anything.
+10. Install the actual tarball into a temporary Git repository with scripts disabled.
+11. Run help/version, init, validate, add, prepare, list, show, search, and gather through Node.
 
 At least one local or CI smoke path must verify pnpm-style symlink resolution. Unit tests cover Windows path predicates even when the host filesystem cannot create reserved names.
 
@@ -1356,7 +1357,7 @@ Immediately before publication:
 1. Recheck that the unscoped npm name `encephalon` remains available or belongs to the maintainer.
 2. Confirm the merged commit and clean worktree.
 3. Build from the merged commit.
-4. Re-run package inspection and smoke installation.
+4. Re-run package inspection, smoke installation, and the npm publication dry-run.
 5. Authenticate to npm with the intended public account and 2FA.
 6. Run the manual public publish for `0.1.0`.
 7. Verify npm metadata, tarball contents, install behaviour, CLI version, and API import from the registry package.

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "typecheck": "tsc --noEmit",
     "build": "bun run scripts/build.ts",
     "check:package": "bun run scripts/check-package.ts",
+    "check:publish": "npm publish --dry-run --access public --json",
     "prepack": "bun run build && bun run check:package"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "packageManager": "bun@1.3.1",
   "bin": {
-    "encephalon": "./dist/cli.mjs"
+    "encephalon": "dist/cli.mjs"
   },
   "types": "./dist/index.d.ts",
   "exports": {

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -5,10 +5,20 @@ import { gunzipSync } from "node:zlib"
 
 const root = resolve(import.meta.dir, "..")
 const temporaryDirectory = mkdtempSync(join(tmpdir(), "encephalon-package-check-"))
+const subprocessEnvironment = Object.fromEntries(
+  Object.entries(process.env).filter(([name]) => name.toLowerCase() !== "npm_config_dry_run"),
+)
 
 const run = (command: string[], cwd = root) => {
-  const result = Bun.spawnSync({ cmd: command, cwd, stdout: "pipe", stderr: "pipe" })
+  const result = Bun.spawnSync({
+    cmd: command,
+    cwd,
+    env: subprocessEnvironment,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
   if (result.exitCode === 0) return result.stdout.toString()
+  process.stderr.write(result.stdout.toString())
   process.stderr.write(result.stderr.toString())
   throw new Error(`${command[0]} failed with exit code ${result.exitCode}.`)
 }
@@ -57,7 +67,7 @@ try {
     packageJson.license !== "MIT" ||
     packageJson.type !== "module" ||
     JSON.stringify(packageJson.engines) !== JSON.stringify({ node: ">=24.15.0" }) ||
-    JSON.stringify(packageJson.bin) !== JSON.stringify({ encephalon: "./dist/cli.mjs" }) ||
+    JSON.stringify(packageJson.bin) !== JSON.stringify({ encephalon: "dist/cli.mjs" }) ||
     JSON.stringify(packageJson.exports) !== JSON.stringify({ ".": { types: "./dist/index.d.ts", import: "./dist/index.mjs" } }) ||
     JSON.stringify(packageJson.files) !== JSON.stringify(["dist", "skills", "README.md", "LICENSE"]) ||
     packageJson.dependencies !== undefined

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -5,18 +5,9 @@ import { gunzipSync } from "node:zlib"
 
 const root = resolve(import.meta.dir, "..")
 const temporaryDirectory = mkdtempSync(join(tmpdir(), "encephalon-package-check-"))
-const subprocessEnvironment = Object.fromEntries(
-  Object.entries(process.env).filter(([name]) => name.toLowerCase() !== "npm_config_dry_run"),
-)
 
 const run = (command: string[], cwd = root) => {
-  const result = Bun.spawnSync({
-    cmd: command,
-    cwd,
-    env: subprocessEnvironment,
-    stdout: "pipe",
-    stderr: "pipe",
-  })
+  const result = Bun.spawnSync({ cmd: command, cwd, stdout: "pipe", stderr: "pipe" })
   if (result.exitCode === 0) return result.stdout.toString()
   process.stderr.write(result.stdout.toString())
   process.stderr.write(result.stderr.toString())
@@ -104,7 +95,15 @@ try {
     throw new Error("The declarations contain unresolved TypeScript source imports.")
   }
 
-  const packOutput = run(["npm", "pack", "--ignore-scripts", "--json", "--pack-destination", temporaryDirectory])
+  const packOutput = run([
+    "npm",
+    "pack",
+    "--dry-run=false",
+    "--ignore-scripts",
+    "--json",
+    "--pack-destination",
+    temporaryDirectory,
+  ])
   const pack = (JSON.parse(packOutput) as Array<{ filename: string; files: Array<{ path: string; mode?: number }> }>)[0]
   if (pack === undefined) throw new Error("npm pack did not return package metadata.")
   const allowedRootFiles = new Set(["LICENSE", "README.md", "package.json"])
@@ -124,7 +123,10 @@ try {
   const consumer = resolve(temporaryDirectory, "consumer")
   mkdirSync(resolve(consumer, ".git"), { recursive: true })
   writeFileSync(resolve(consumer, "package.json"), '{"name":"encephalon-smoke","private":true,"type":"module"}\n')
-  run(["npm", "install", "--ignore-scripts", "--no-audit", "--no-fund", "--save-dev", tarball], consumer)
+  run(
+    ["npm", "install", "--dry-run=false", "--ignore-scripts", "--no-audit", "--no-fund", "--save-dev", tarball],
+    consumer,
+  )
   run([
     "node",
     "--input-type=module",

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -15,6 +15,7 @@ describe("package contract", () => {
     expect(packageJson.version).toBe("0.1.0")
     expect(packageJson.type).toBe("module")
     expect(packageJson.engines).toEqual({ node: ">=24.15.0" })
+    expect(packageJson.bin).toEqual({ encephalon: "dist/cli.mjs" })
     expect(packageJson.dependencies).toBeUndefined()
     expect(packageJson).not.toHaveProperty("scripts.install")
     expect(packageJson).not.toHaveProperty("scripts.preinstall")
@@ -24,6 +25,17 @@ describe("package contract", () => {
 
   test("has a side-effect-free TypeScript API entrypoint", () => {
     expect(existsSync(resolve(root, "src/index.ts"))).toBe(true)
+  })
+
+  test("packs successfully when invoked from an npm publish dry-run", () => {
+    const result = Bun.spawnSync({
+      cmd: [process.execPath, "run", "scripts/check-package.ts"],
+      cwd: root,
+      env: { ...process.env, npm_config_dry_run: "true" },
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    expect(result.exitCode, result.stderr.toString()).toBe(0)
   })
 
   test("ships the generic repository-memory skill", () => {

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -27,17 +27,6 @@ describe("package contract", () => {
     expect(existsSync(resolve(root, "src/index.ts"))).toBe(true)
   })
 
-  test("packs successfully when invoked from an npm publish dry-run", () => {
-    const result = Bun.spawnSync({
-      cmd: [process.execPath, "run", "scripts/check-package.ts"],
-      cwd: root,
-      env: { ...process.env, npm_config_dry_run: "true" },
-      stdout: "pipe",
-      stderr: "pipe",
-    })
-    expect(result.exitCode, result.stderr.toString()).toBe(0)
-  })
-
   test("ships the generic repository-memory skill", () => {
     const skill = readFileSync(resolve(root, "skills", "encephalon", "SKILL.md"), "utf8")
     expect(skill).toContain("npx --no-install encephalon search")


### PR DESCRIPTION
## Summary

- use npm's canonical binary target spelling so publication does not rewrite the manifest
- keep nested package inspection active during npm publish dry-runs
- add regression coverage for both behaviours

## Verification

- bun run typecheck
- bun run test
- bun run build
- bun run check:package
- npm publish --dry-run --access public --json