### PR TITLE
[MAR-2509] Make instruction writes atomic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,7 @@
 name: CI
 
 on:
-  workflow_dispatch:
   push:
-  pull_request:
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,129 @@
+# Ultracite Code Standards
+
+This project uses **Ultracite**, a zero-config preset that enforces strict code quality standards through automated formatting and linting.
+
+## Quick Reference
+
+- **Format code**: `bun x ultracite fix`
+- **Check for issues**: `bun x ultracite check`
+- **Diagnose setup**: `bun x ultracite doctor`
+
+Biome (the underlying engine) provides robust linting and formatting. Most issues are automatically fixable.
+
+---
+
+## Core Principles
+
+Write code that is **accessible, performant, type-safe, and maintainable**. Focus on clarity and explicit intent over brevity.
+
+### Type Safety & Explicitness
+
+- Use explicit types for function parameters and return values when they enhance clarity
+- Prefer `unknown` over `any` when the type is genuinely unknown
+- Use const assertions (`as const`) for immutable values and literal types
+- Leverage TypeScript's type narrowing instead of type assertions
+- Use meaningful variable names instead of magic numbers - extract constants with descriptive names
+
+### Modern JavaScript/TypeScript
+
+- Use arrow functions for callbacks and short functions
+- Prefer `for...of` loops over `.forEach()` and indexed `for` loops
+- Use optional chaining (`?.`) and nullish coalescing (`??`) for safer property access
+- Prefer template literals over string concatenation
+- Use destructuring for object and array assignments
+- Use `const` by default, `let` only when reassignment is needed, never `var`
+
+### Async & Promises
+
+- Always `await` promises in async functions - don't forget to use the return value
+- Use `async/await` syntax instead of promise chains for better readability
+- Handle errors appropriately in async code with try-catch blocks
+- Don't use async functions as Promise executors
+
+### React & JSX
+
+- Use function components over class components
+- Call hooks at the top level only, never conditionally
+- Specify all dependencies in hook dependency arrays correctly
+- Use the `key` prop for elements in iterables (prefer unique IDs over array indices)
+- Nest children between opening and closing tags instead of passing as props
+- Don't define components inside other components
+- Use semantic HTML and ARIA attributes for accessibility:
+  - Provide meaningful alt text for images
+  - Use proper heading hierarchy
+  - Add labels for form inputs
+  - Include keyboard event handlers alongside mouse events
+  - Use semantic elements (`<button>`, `<nav>`, etc.) instead of divs with roles
+
+### Error Handling & Debugging
+
+- Remove `console.log`, `debugger`, and `alert` statements from production code
+- Throw `Error` objects with descriptive messages, not strings or other values
+- Use `try-catch` blocks meaningfully - don't catch errors just to rethrow them
+- Prefer early returns over nested conditionals for error cases
+
+### Code Organization
+
+- Keep functions focused and under reasonable cognitive complexity limits
+- Extract complex conditions into well-named boolean variables
+- Use early returns to reduce nesting
+- Prefer simple conditionals over nested ternary operators
+- Group related code together and separate concerns
+
+### Security
+
+- Add `rel="noopener"` when using `target="_blank"` on links
+- Avoid `dangerouslySetInnerHTML` unless absolutely necessary
+- Don't use `eval()` or assign directly to `document.cookie`
+- Validate and sanitize user input
+
+### Performance
+
+- Avoid spread syntax in accumulators within loops
+- Use top-level regex literals instead of creating them in loops
+- Prefer specific imports over namespace imports
+- Avoid barrel files (index files that re-export everything)
+- Use proper image components (e.g., Next.js `<Image>`) over `<img>` tags
+
+### Framework-Specific Guidance
+
+**Next.js:**
+- Use Next.js `<Image>` component for images
+- Use `next/head` or App Router metadata API for head elements
+- Use Server Components for async data fetching instead of async Client Components
+
+**React 19+:**
+- Use ref as a prop instead of `React.forwardRef`
+
+**Solid/Svelte/Vue/Qwik:**
+- Use `class` and `for` attributes (not `className` or `htmlFor`)
+
+---
+
+## Testing
+
+- Write assertions inside `it()` or `test()` blocks
+- Avoid done callbacks in async tests - use async/await instead
+- Don't use `.only` or `.skip` in committed code
+- Keep test suites reasonably flat - avoid excessive `describe` nesting
+
+## When Biome Can't Help
+
+Biome's linter will catch most issues automatically. Focus your attention on:
+
+1. **Business logic correctness** - Biome can't validate your algorithms
+2. **Meaningful naming** - Use descriptive names for functions, variables, and types
+3. **Architecture decisions** - Component structure, data flow, and API design
+4. **Edge cases** - Handle boundary conditions and error states
+5. **User experience** - Accessibility, performance, and usability considerations
+6. **Documentation** - Add comments for complex logic, but prefer self-documenting code
+
+---
+
+Most formatting and common issues are automatically fixed by Biome. Run `bun x ultracite fix` before committing to ensure compliance.
+
+## Git and Pull Requests
+
+- Prefix every commit subject with the Linear ticket in square brackets and write the rest in plain English, using the form `[MAR-1234] Describe the change`.
+- Never use Conventional Commit prefixes such as `fix:`, `feat:`, or `refactor:`.
+- Prefix pull request titles with the Linear ticket in square brackets, using the form `[MAR-1234] Description`.

--- a/encephalon/workflow/77f71585-914f-4acf-8116-884c688abed5.json
+++ b/encephalon/workflow/77f71585-914f-4acf-8116-884c688abed5.json
@@ -1,0 +1,20 @@
+{
+  "createdAt": "2026-08-08T00:46:37.357Z",
+  "id": "77f71585-914f-4acf-8116-884c688abed5",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Prevent repeat PR review issues found on MAR-2509.",
+    "lessons": [
+      "For managed instruction-file publication, do not rely on a preflight-only snapshot before replacing a user-owned file; capture and revalidate the current target at publication time so concurrent edits return REPOSITORY_CHANGED instead of being overwritten.",
+      "Preserve mutable filesystem metadata from the file captured at publication time, not from the earlier plan, because owners can change permissions without changing bytes.",
+      "When adding repository workflow guidance, keep Git commit subjects and PR titles prefixed with the Linear ticket in square brackets, for example [MAR-1234] Describe the change."
+    ],
+    "verification": [
+      "Search Encephalon before adding durable workflow lessons.",
+      "Add regression tests for each review comment when possible.",
+      "Use one commit per review-comment fix so replies can point to the exact change."
+    ]
+  },
+  "source": "agent",
+  "subject": "review.github-pr-feedback"
+}

--- a/encephalon/workflow/77f71585-914f-4acf-8116-884c688abed5.json
+++ b/encephalon/workflow/77f71585-914f-4acf-8116-884c688abed5.json
@@ -7,6 +7,7 @@
     "lessons": [
       "For managed instruction-file publication, do not rely on a preflight-only snapshot before replacing a user-owned file; capture and revalidate the current target at publication time so concurrent edits return REPOSITORY_CHANGED instead of being overwritten.",
       "Preserve mutable filesystem metadata from the file captured at publication time, not from the earlier plan, because owners can change permissions without changing bytes.",
+      "After renaming a user-owned file to a backup path, treat that backup inode as still mutable through existing open descriptors; revalidate it before cleanup and leave it recoverable if the bytes changed.",
       "When adding repository workflow guidance, keep Git commit subjects and PR titles prefixed with the Linear ticket in square brackets, for example [MAR-1234] Describe the change."
     ],
     "verification": [

--- a/encephalon/workflow/77f71585-914f-4acf-8116-884c688abed5.json
+++ b/encephalon/workflow/77f71585-914f-4acf-8116-884c688abed5.json
@@ -8,6 +8,7 @@
       "For managed instruction-file publication, do not rely on a preflight-only snapshot before replacing a user-owned file; capture and revalidate the current target at publication time so concurrent edits return REPOSITORY_CHANGED instead of being overwritten.",
       "Preserve mutable filesystem metadata from the file captured at publication time, not from the earlier plan, because owners can change permissions without changing bytes.",
       "After renaming a user-owned file to a backup path, treat that backup inode as still mutable through existing open descriptors; revalidate it before cleanup and leave it recoverable if the bytes changed.",
+      "When restoring a moved-aside backup after a failed publication, use create-if-absent publication instead of check-then-rename so recovery cannot overwrite a target recreated by another writer.",
       "When adding repository workflow guidance, keep Git commit subjects and PR titles prefixed with the Linear ticket in square brackets, for example [MAR-1234] Describe the change."
     ],
     "verification": [

--- a/encephalon/workflow/77f71585-914f-4acf-8116-884c688abed5.json
+++ b/encephalon/workflow/77f71585-914f-4acf-8116-884c688abed5.json
@@ -9,6 +9,7 @@
       "Preserve mutable filesystem metadata from the file captured at publication time, not from the earlier plan, because owners can change permissions without changing bytes.",
       "After renaming a user-owned file to a backup path, treat that backup inode as still mutable through existing open descriptors; revalidate it before cleanup and leave it recoverable if the bytes changed.",
       "When restoring a moved-aside backup after a failed publication, use create-if-absent publication instead of check-then-rename so recovery cannot overwrite a target recreated by another writer.",
+      "Do not apply a final permission snapshot after publication if the source inode can still be changed through old descriptors; report pre-final mode drift and leave post-final drift recoverable on the backup instead.",
       "When adding repository workflow guidance, keep Git commit subjects and PR titles prefixed with the Linear ticket in square brackets, for example [MAR-1234] Describe the change."
     ],
     "verification": [

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
     }
   },
   "files": [

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -325,20 +325,61 @@ const fsyncDirectory = (path: string) => {
   }
 }
 
-const tempPathFor = (path: string) => join(dirname(path), `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`)
+const tempPathFor = (path: string, suffix = 'tmp') =>
+  join(dirname(path), `.${basename(path)}.${process.pid}.${randomUUID()}.${suffix}`)
+
+const restoreBackupFile = (path: string, backupPath: string) => {
+  try {
+    if (lstatIfExists(path) === undefined) {
+      renameSync(backupPath, path)
+    }
+  } catch {
+    // Keep the backup file in place so the pre-publication bytes remain recoverable.
+  }
+}
 
 const publishTempFile = (path: string, tempPath: string, plan: FilePlan) => {
-  if (plan.originalFileExisted) {
-    renameSync(tempPath, path)
+  if (!plan.originalFileExisted) {
+    try {
+      linkSync(tempPath, path)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+        return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
+      }
+      throw error
+    }
     return
   }
+
+  const backupPath = tempPathFor(path, 'backup')
+  let backupCreated = false
+  let published = false
   try {
+    renameSync(path, backupPath)
+    backupCreated = true
+    const backupMetadata = lstatIfExists(backupPath)
+    if (backupMetadata === undefined || backupMetadata.isSymbolicLink() || !backupMetadata.isFile()) {
+      return fail('VALIDATION_FAILED', `${plan.filename} must remain a regular non-symlink file.`)
+    }
+    if (readRegularFile(backupPath) !== plan.originalContent) {
+      return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
+    }
     linkSync(tempPath, path)
+    published = true
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
       return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
     }
     throw error
+  } finally {
+    if (backupCreated) {
+      if (!published) {
+        restoreBackupFile(path, backupPath)
+      }
+      if (published || lstatIfExists(backupPath) === undefined) {
+        rmSync(backupPath, { force: true })
+      }
+    }
   }
 }
 

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -325,7 +325,8 @@ const tempPathFor = (path: string, suffix = 'tmp') =>
   join(dirname(path), `.${basename(path)}.${process.pid}.${randomUUID()}.${suffix}`)
 
 const fsyncFile = (path: string) => {
-  const descriptor = openSync(path, constants.O_RDONLY | noFollowFlag)
+  const access = process.platform === 'win32' ? constants.O_RDWR : constants.O_RDONLY
+  const descriptor = openSync(path, access | noFollowFlag)
   try {
     fsyncSync(descriptor)
   } finally {

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from 'node:crypto'
 import {
+  chmodSync,
   closeSync,
   constants,
-  fchmodSync,
   fstatSync,
   fsyncSync,
   linkSync,
@@ -35,7 +35,6 @@ type FilePlan = {
   content?: string
   originalContent: string
   originalFileExisted: boolean
-  originalMode?: number
 }
 
 const ALLOWED_SEPARATORS = new Set(['', '\n', '\n\n', '\r\n', '\r\n\r\n'])
@@ -184,7 +183,6 @@ const additionPlan = (root: string, filename: (typeof FILENAMES)[number]): FileP
     filename,
     originalContent: content,
     originalFileExisted: existed,
-    ...(existingMetadata === undefined ? {} : { originalMode: existingMetadata.mode }),
   }
 }
 
@@ -213,7 +211,6 @@ const removalPlan = (root: string, filename: (typeof FILENAMES)[number]): FilePl
       filename,
       originalContent: content,
       originalFileExisted: true,
-      originalMode: fileMetadata.mode,
     }
   }
   const contentWithoutBlock = `${content.slice(0, installed.start - installed.separator.length)}${content.slice(installed.end)}`
@@ -231,7 +228,6 @@ const removalPlan = (root: string, filename: (typeof FILENAMES)[number]): FilePl
     filename,
     originalContent: content,
     originalFileExisted: true,
-    originalMode: fileMetadata.mode,
   }
 }
 
@@ -328,6 +324,15 @@ const fsyncDirectory = (path: string) => {
 const tempPathFor = (path: string, suffix = 'tmp') =>
   join(dirname(path), `.${basename(path)}.${process.pid}.${randomUUID()}.${suffix}`)
 
+const fsyncFile = (path: string) => {
+  const descriptor = openSync(path, constants.O_RDONLY | noFollowFlag)
+  try {
+    fsyncSync(descriptor)
+  } finally {
+    closeSync(descriptor)
+  }
+}
+
 const restoreBackupFile = (path: string, backupPath: string) => {
   try {
     if (lstatIfExists(path) === undefined) {
@@ -364,6 +369,8 @@ const publishTempFile = (path: string, tempPath: string, plan: FilePlan) => {
     if (readRegularFile(backupPath) !== plan.originalContent) {
       return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
     }
+    chmodSync(tempPath, backupMetadata.mode & MODE_BITS)
+    fsyncFile(tempPath)
     linkSync(tempPath, path)
     published = true
   } catch (error) {
@@ -403,9 +410,6 @@ const writePlan = (root: string, path: string, plan: FilePlan, hooks?: AtomicWri
   try {
     fault(hooks, 'before-temp-create')
     descriptor = openSync(tempPath, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY, 0o666)
-    if (plan.originalFileExisted && plan.originalMode !== undefined) {
-      fchmodSync(descriptor, plan.originalMode & MODE_BITS)
-    }
     writeAll(descriptor, bytes, plan, hooks)
     fault(hooks, 'during-file-flush')
     fsyncSync(descriptor)

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -264,6 +264,7 @@ const assertPlanIsCurrent = (root: string, plan: FilePlan) => {
 type AtomicWriteFault =
   | 'after-publication'
   | 'after-backup-validation'
+  | 'after-final-backup-validation'
   | 'before-temp-create'
   | 'during-backup-restore'
   | 'during-file-flush'
@@ -383,7 +384,10 @@ const publishTempFile = (path: string, tempPath: string, plan: FilePlan, hooks: 
     linkSync(tempPath, path)
     published = true
     const finalBackupMetadata = assertBackupUnchanged(backupPath, plan)
-    chmodSync(path, finalBackupMetadata.mode & MODE_BITS)
+    fault(hooks, 'after-final-backup-validation')
+    if ((finalBackupMetadata.mode & MODE_BITS) !== (backupMetadata.mode & MODE_BITS)) {
+      return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
+    }
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
       return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -263,6 +263,7 @@ const assertPlanIsCurrent = (root: string, plan: FilePlan) => {
 
 type AtomicWriteFault =
   | 'after-publication'
+  | 'after-backup-validation'
   | 'before-temp-create'
   | 'during-file-flush'
   | 'during-publication'
@@ -344,7 +345,18 @@ const restoreBackupFile = (path: string, backupPath: string) => {
   }
 }
 
-const publishTempFile = (path: string, tempPath: string, plan: FilePlan) => {
+const assertBackupUnchanged = (backupPath: string, plan: FilePlan) => {
+  const metadata = lstatIfExists(backupPath)
+  if (metadata === undefined || metadata.isSymbolicLink() || !metadata.isFile()) {
+    return fail('VALIDATION_FAILED', `${plan.filename} must remain a regular non-symlink file.`)
+  }
+  if (readRegularFile(backupPath) !== plan.originalContent) {
+    return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
+  }
+  return metadata
+}
+
+const publishTempFile = (path: string, tempPath: string, plan: FilePlan, hooks: AtomicWriteHooks | undefined) => {
   if (!plan.originalFileExisted) {
     try {
       linkSync(tempPath, path)
@@ -360,20 +372,19 @@ const publishTempFile = (path: string, tempPath: string, plan: FilePlan) => {
   const backupPath = tempPathFor(path, 'backup')
   let backupCreated = false
   let published = false
+  let removeBackup = false
   try {
     renameSync(path, backupPath)
     backupCreated = true
-    const backupMetadata = lstatIfExists(backupPath)
-    if (backupMetadata === undefined || backupMetadata.isSymbolicLink() || !backupMetadata.isFile()) {
-      return fail('VALIDATION_FAILED', `${plan.filename} must remain a regular non-symlink file.`)
-    }
-    if (readRegularFile(backupPath) !== plan.originalContent) {
-      return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
-    }
+    const backupMetadata = assertBackupUnchanged(backupPath, plan)
     chmodSync(tempPath, backupMetadata.mode & MODE_BITS)
     fsyncFile(tempPath)
+    fault(hooks, 'after-backup-validation')
     linkSync(tempPath, path)
     published = true
+    const finalBackupMetadata = assertBackupUnchanged(backupPath, plan)
+    chmodSync(path, finalBackupMetadata.mode & MODE_BITS)
+    removeBackup = true
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
       return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
@@ -384,7 +395,7 @@ const publishTempFile = (path: string, tempPath: string, plan: FilePlan) => {
       if (!published) {
         restoreBackupFile(path, backupPath)
       }
-      if (published || lstatIfExists(backupPath) === undefined) {
+      if (removeBackup || lstatIfExists(backupPath) === undefined) {
         rmSync(backupPath, { force: true })
       }
     }
@@ -418,7 +429,7 @@ const writePlan = (root: string, path: string, plan: FilePlan, hooks?: AtomicWri
     descriptor = undefined
     assertPlanIsCurrent(root, plan)
     fault(hooks, 'during-publication')
-    publishTempFile(path, tempPath, plan)
+    publishTempFile(path, tempPath, plan, hooks)
     fault(hooks, 'after-publication')
     fsyncDirectory(dirname(path))
   } catch (error) {

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -265,6 +265,7 @@ type AtomicWriteFault =
   | 'after-publication'
   | 'after-backup-validation'
   | 'before-temp-create'
+  | 'during-backup-restore'
   | 'during-file-flush'
   | 'during-publication'
   | 'during-temp-cleanup'
@@ -335,11 +336,11 @@ const fsyncFile = (path: string) => {
   }
 }
 
-const restoreBackupFile = (path: string, backupPath: string) => {
+const restoreBackupFile = (path: string, backupPath: string, hooks: AtomicWriteHooks | undefined) => {
   try {
-    if (lstatIfExists(path) === undefined) {
-      renameSync(backupPath, path)
-    }
+    fault(hooks, 'during-backup-restore')
+    linkSync(backupPath, path)
+    rmSync(backupPath, { force: true })
   } catch {
     // Keep the backup file in place so the pre-publication bytes remain recoverable.
   }
@@ -372,7 +373,6 @@ const publishTempFile = (path: string, tempPath: string, plan: FilePlan, hooks: 
   const backupPath = tempPathFor(path, 'backup')
   let backupCreated = false
   let published = false
-  let removeBackup = false
   try {
     renameSync(path, backupPath)
     backupCreated = true
@@ -384,20 +384,14 @@ const publishTempFile = (path: string, tempPath: string, plan: FilePlan, hooks: 
     published = true
     const finalBackupMetadata = assertBackupUnchanged(backupPath, plan)
     chmodSync(path, finalBackupMetadata.mode & MODE_BITS)
-    removeBackup = true
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
       return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
     }
     throw error
   } finally {
-    if (backupCreated) {
-      if (!published) {
-        restoreBackupFile(path, backupPath)
-      }
-      if (removeBackup || lstatIfExists(backupPath) === undefined) {
-        rmSync(backupPath, { force: true })
-      }
+    if (backupCreated && !published) {
+      restoreBackupFile(path, backupPath, hooks)
     }
   }
 }

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -1,16 +1,19 @@
+import { randomUUID } from 'node:crypto'
 import {
   closeSync,
   constants,
+  fchmodSync,
   fstatSync,
-  ftruncateSync,
+  fsyncSync,
+  linkSync,
   lstatSync,
   openSync,
   readFileSync,
+  renameSync,
   rmSync,
-  writeFileSync,
   writeSync,
 } from 'node:fs'
-import { resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 import { EncephalonError, fail, wrapIo } from './errors.ts'
 
 const FILENAMES = ['AGENTS.md', 'CLAUDE.md'] as const
@@ -32,9 +35,11 @@ type FilePlan = {
   content?: string
   originalContent: string
   originalFileExisted: boolean
+  originalMode?: number
 }
 
 const ALLOWED_SEPARATORS = new Set(['', '\n', '\n\n', '\r\n', '\r\n\r\n'])
+const MODE_BITS = 0o7777
 
 const lstatIfExists = (path: string) => {
   try {
@@ -179,6 +184,7 @@ const additionPlan = (root: string, filename: (typeof FILENAMES)[number]): FileP
     filename,
     originalContent: content,
     originalFileExisted: existed,
+    ...(existingMetadata === undefined ? {} : { originalMode: existingMetadata.mode }),
   }
 }
 
@@ -207,6 +213,7 @@ const removalPlan = (root: string, filename: (typeof FILENAMES)[number]): FilePl
       filename,
       originalContent: content,
       originalFileExisted: true,
+      originalMode: fileMetadata.mode,
     }
   }
   const contentWithoutBlock = `${content.slice(0, installed.start - installed.separator.length)}${content.slice(installed.end)}`
@@ -224,10 +231,12 @@ const removalPlan = (root: string, filename: (typeof FILENAMES)[number]): FilePl
     filename,
     originalContent: content,
     originalFileExisted: true,
+    originalMode: fileMetadata.mode,
   }
 }
 
 const noFollowFlag = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0
+const directoryFlag = typeof constants.O_DIRECTORY === 'number' ? constants.O_DIRECTORY : 0
 
 const readRegularFile = (path: string) => {
   const descriptor = openSync(path, constants.O_RDONLY | noFollowFlag)
@@ -256,36 +265,124 @@ const assertPlanIsCurrent = (root: string, plan: FilePlan) => {
   }
 }
 
-const writePlan = (path: string, plan: FilePlan) => {
-  const content = plan.content ?? ''
-  if (!plan.originalFileExisted) {
-    try {
-      writeFileSync(path, content, { encoding: 'utf8', flag: 'wx' })
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
-        return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
-      }
-      throw error
+type AtomicWriteFault =
+  | 'after-publication'
+  | 'before-temp-create'
+  | 'during-file-flush'
+  | 'during-publication'
+  | 'during-temp-cleanup'
+  | 'during-temp-write'
+
+type AtomicWriteHooks = {
+  fault?: (point: AtomicWriteFault) => void
+}
+
+const fault = (hooks: AtomicWriteHooks | undefined, point: AtomicWriteFault) => {
+  hooks?.fault?.(point)
+}
+
+const closeAfterOperation = (descriptor: number, operationFailed: boolean) => {
+  try {
+    closeSync(descriptor)
+  } catch (error) {
+    if (operationFailed) {
+      return
     }
+    throw error
+  }
+}
+
+const writeAll = (descriptor: number, bytes: Buffer, plan: FilePlan, hooks: AtomicWriteHooks | undefined) => {
+  fault(hooks, 'during-temp-write')
+  let offset = 0
+  while (offset < bytes.length) {
+    const written = writeSync(descriptor, bytes, offset, bytes.length - offset, offset)
+    if (written <= 0) {
+      throw new Error(`Unable to write ${plan.filename}.`)
+    }
+    offset += written
+  }
+}
+
+const fsyncDirectory = (path: string) => {
+  if (process.platform !== 'win32') {
+    let descriptor: number | undefined
+    let operationFailed = false
+    try {
+      descriptor = openSync(path, constants.O_RDONLY | directoryFlag)
+      fsyncSync(descriptor)
+    } catch (error) {
+      operationFailed = true
+      const { code } = error as NodeJS.ErrnoException
+      if (code !== 'EINVAL' && code !== 'ENOTSUP' && code !== 'EOPNOTSUPP' && code !== 'EPERM') {
+        throw error
+      }
+    } finally {
+      if (descriptor !== undefined) {
+        closeAfterOperation(descriptor, operationFailed)
+      }
+    }
+  }
+}
+
+const tempPathFor = (path: string) => join(dirname(path), `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`)
+
+const publishTempFile = (path: string, tempPath: string, plan: FilePlan) => {
+  if (plan.originalFileExisted) {
+    renameSync(tempPath, path)
     return
   }
-  const descriptor = openSync(path, constants.O_RDWR | noFollowFlag)
   try {
-    if (!fstatSync(descriptor).isFile() || readFileSync(descriptor, 'utf8') !== plan.originalContent) {
+    linkSync(tempPath, path)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
       return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
     }
-    const bytes = Buffer.from(content, 'utf8')
-    ftruncateSync(descriptor, 0)
-    let offset = 0
-    while (offset < bytes.length) {
-      const written = writeSync(descriptor, bytes, offset, bytes.length - offset, offset)
-      if (written <= 0) {
-        throw new Error(`Unable to write ${plan.filename}.`)
-      }
-      offset += written
+    throw error
+  }
+}
+
+const cleanupTempFile = (tempPath: string, hooks: AtomicWriteHooks | undefined, operationFailed: boolean) => {
+  try {
+    fault(hooks, 'during-temp-cleanup')
+    rmSync(tempPath, { force: true })
+  } catch (error) {
+    if (!operationFailed) {
+      throw error
     }
-  } finally {
+  }
+}
+
+const writePlan = (root: string, path: string, plan: FilePlan, hooks?: AtomicWriteHooks) => {
+  const content = plan.content ?? ''
+  const bytes = Buffer.from(content, 'utf8')
+  const tempPath = tempPathFor(path)
+  let descriptor: number | undefined
+  let operationFailed = false
+  try {
+    fault(hooks, 'before-temp-create')
+    descriptor = openSync(tempPath, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY, 0o666)
+    if (plan.originalFileExisted && plan.originalMode !== undefined) {
+      fchmodSync(descriptor, plan.originalMode & MODE_BITS)
+    }
+    writeAll(descriptor, bytes, plan, hooks)
+    fault(hooks, 'during-file-flush')
+    fsyncSync(descriptor)
     closeSync(descriptor)
+    descriptor = undefined
+    assertPlanIsCurrent(root, plan)
+    fault(hooks, 'during-publication')
+    publishTempFile(path, tempPath, plan)
+    fault(hooks, 'after-publication')
+    fsyncDirectory(dirname(path))
+  } catch (error) {
+    operationFailed = true
+    throw error
+  } finally {
+    if (descriptor !== undefined) {
+      closeAfterOperation(descriptor, operationFailed)
+    }
+    cleanupTempFile(tempPath, hooks, operationFailed)
   }
 }
 
@@ -300,7 +397,7 @@ export const planInstructionChanges = (root: string, remove: boolean) => {
   }
 }
 
-export const applyInstructionChanges = (root: string, plans: FilePlan[]) => {
+export const applyInstructionChanges = (root: string, plans: FilePlan[], hooks?: AtomicWriteHooks) => {
   try {
     for (const plan of plans) {
       if (plan.action !== 'none') {
@@ -313,7 +410,7 @@ export const applyInstructionChanges = (root: string, plans: FilePlan[]) => {
         rmSync(path)
       }
       if (plan.action === 'write') {
-        writePlan(path, plan)
+        writePlan(root, path, plan, hooks)
       }
     }
     return plans

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -395,7 +395,43 @@ describe('initialisation', () => {
     assert.equal(readFileSync(join(root, backupName), 'utf8'), original)
   })
 
-  test('preserves old-descriptor mode changes after backup validation', {
+  test('reports old-descriptor mode changes after backup validation', {
+    skip: process.platform === 'win32' ? 'Windows does not expose POSIX mode changes consistently.' : false,
+  }, () => {
+    const root = createRoot()
+    const path = join(root, 'AGENTS.md')
+    writeFileSync(path, '# Existing guidance\n')
+    chmodSync(path, 0o600)
+    const descriptor = openSync(path, 'r+')
+    const [agentsPlan] = planInstructionChanges(root, false)
+    assert.ok(agentsPlan)
+
+    try {
+      assert.throws(
+        () =>
+          applyInstructionChanges(root, [agentsPlan], {
+            fault: point => {
+              if (point === 'after-backup-validation') {
+                fchmodSync(descriptor, 0o744)
+              }
+            },
+          }),
+        (error: unknown) => {
+          assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED')
+          return true
+        },
+      )
+    } finally {
+      closeSync(descriptor)
+    }
+
+    const [backupName] = readdirSync(root).filter(name => name.startsWith('.AGENTS.md.') && name.endsWith('.backup'))
+    assert.ok(backupName)
+    assert.match(readFileSync(path, 'utf8'), /## Encephalon/)
+    assert.equal(statSync(join(root, backupName)).mode & 0o777, 0o744)
+  })
+
+  test('does not overwrite mode changes after final backup validation', {
     skip: process.platform === 'win32' ? 'Windows does not expose POSIX mode changes consistently.' : false,
   }, () => {
     const root = createRoot()
@@ -409,7 +445,7 @@ describe('initialisation', () => {
     try {
       applyInstructionChanges(root, [agentsPlan], {
         fault: point => {
-          if (point === 'after-backup-validation') {
+          if (point === 'after-final-backup-validation') {
             fchmodSync(descriptor, 0o744)
           }
         },
@@ -418,8 +454,11 @@ describe('initialisation', () => {
       closeSync(descriptor)
     }
 
+    const [backupName] = readdirSync(root).filter(name => name.startsWith('.AGENTS.md.') && name.endsWith('.backup'))
+    assert.ok(backupName)
     assert.match(readFileSync(path, 'utf8'), /## Encephalon/)
-    assert.equal(statSync(path).mode & 0o777, 0o744)
+    assert.equal(statSync(path).mode & 0o777, 0o600)
+    assert.equal(statSync(join(root, backupName)).mode & 0o777, 0o744)
   })
 
   const faultPoints = [

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict'
-import { existsSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, readdirSync, readFileSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, describe, test } from 'node:test'
 import * as api from '../src/index.ts'
+import { applyInstructionChanges, planInstructionChanges } from '../src/instructions.ts'
 import { createTestRepository, ensureParent, removeTestRepository } from '../test/helpers.ts'
 
 const roots: string[] = []
@@ -227,4 +228,82 @@ describe('initialisation', () => {
     api.initEncephalon({ remove: true, root })
     assert.equal(readFileSync(path, 'utf8'), `${original}User addition.\r\n`)
   })
+
+  test('atomically publishes instruction replacements and preserves the existing file mode', () => {
+    const root = createRoot()
+    const path = join(root, 'AGENTS.md')
+    writeFileSync(path, '# Existing guidance\n')
+    chmodSync(path, 0o744)
+
+    const [agentsPlan] = planInstructionChanges(root, false)
+    assert.ok(agentsPlan)
+    applyInstructionChanges(root, [agentsPlan])
+
+    assert.match(readFileSync(path, 'utf8'), /## Encephalon/)
+    assert.equal(statSync(path).mode & 0o777, 0o744)
+    assert.deepEqual(
+      readdirSync(root).filter(filename => filename.includes('.AGENTS.md.') && filename.endsWith('.tmp')),
+      [],
+    )
+  })
+
+  test('detects instruction-file changes observed before atomic publication', () => {
+    const root = createRoot()
+    const path = join(root, 'AGENTS.md')
+    const original = '# Existing guidance\n'
+    const changed = '# Concurrent guidance\n'
+    writeFileSync(path, original)
+    const [agentsPlan] = planInstructionChanges(root, false)
+    assert.ok(agentsPlan)
+    writeFileSync(path, changed)
+
+    assert.throws(
+      () => applyInstructionChanges(root, [agentsPlan]),
+      (error: unknown) => {
+        assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED')
+        return true
+      },
+    )
+    assert.equal(readFileSync(path, 'utf8'), changed)
+  })
+
+  const faultPoints = [
+    ['before-temp-create', 'old'],
+    ['during-temp-write', 'old'],
+    ['during-file-flush', 'old'],
+    ['during-publication', 'old'],
+    ['after-publication', 'new'],
+    ['during-temp-cleanup', 'new'],
+  ] as const
+
+  for (const [faultPoint, expectedContent] of faultPoints) {
+    test(`keeps instruction writes whole when fault injection fails ${faultPoint}`, () => {
+      const root = createRoot()
+      const path = join(root, 'AGENTS.md')
+      const original = '# Existing guidance\n'
+      writeFileSync(path, original)
+      const [agentsPlan] = planInstructionChanges(root, false)
+      assert.ok(agentsPlan?.content)
+
+      assert.throws(
+        () =>
+          applyInstructionChanges(root, [agentsPlan], {
+            fault: point => {
+              if (point === faultPoint) {
+                throw new Error(`Injected ${point}`)
+              }
+            },
+          }),
+        (error: unknown) => {
+          assert.equal((error as { code?: unknown }).code, 'IO_ERROR')
+          return true
+        },
+      )
+
+      const content = readFileSync(path, 'utf8')
+      assert.equal(content, expectedContent === 'old' ? original : agentsPlan.content)
+      assert.notEqual(content, '')
+      assert.notEqual(content, original.slice(0, 4))
+    })
+  }
 })

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -240,7 +240,9 @@ describe('initialisation', () => {
     applyInstructionChanges(root, [agentsPlan])
 
     assert.match(readFileSync(path, 'utf8'), /## Encephalon/)
-    assert.equal(statSync(path).mode & 0o777, 0o744)
+    if (process.platform !== 'win32') {
+      assert.equal(statSync(path).mode & 0o777, 0o744)
+    }
     assert.deepEqual(
       readdirSync(root).filter(filename => filename.includes('.AGENTS.md.') && filename.endsWith('.tmp')),
       [],

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -1,5 +1,18 @@
 import assert from 'node:assert/strict'
-import { chmodSync, existsSync, readdirSync, readFileSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  fchmodSync,
+  ftruncateSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+  writeSync,
+} from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, describe, test } from 'node:test'
 import * as api from '../src/index.ts'
@@ -310,6 +323,70 @@ describe('initialisation', () => {
       },
     )
     assert.equal(readFileSync(path, 'utf8'), changed)
+  })
+
+  test('keeps old-descriptor writes recoverable after backup validation', {
+    skip: process.platform === 'win32' ? 'Windows does not allow this POSIX descriptor race.' : false,
+  }, () => {
+    const root = createRoot()
+    const path = join(root, 'AGENTS.md')
+    const original = '# Existing guidance\n'
+    const changed = '# Descriptor edit\n'
+    writeFileSync(path, original)
+    const descriptor = openSync(path, 'r+')
+    const [agentsPlan] = planInstructionChanges(root, false)
+    assert.ok(agentsPlan)
+
+    try {
+      assert.throws(
+        () =>
+          applyInstructionChanges(root, [agentsPlan], {
+            fault: point => {
+              if (point === 'after-backup-validation') {
+                ftruncateSync(descriptor, 0)
+                writeSync(descriptor, changed, 0, 'utf8')
+              }
+            },
+          }),
+        (error: unknown) => {
+          assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED')
+          return true
+        },
+      )
+    } finally {
+      closeSync(descriptor)
+    }
+
+    const [backupName] = readdirSync(root).filter(name => name.startsWith('.AGENTS.md.') && name.endsWith('.backup'))
+    assert.ok(backupName)
+    assert.equal(readFileSync(join(root, backupName), 'utf8'), changed)
+  })
+
+  test('preserves old-descriptor mode changes after backup validation', {
+    skip: process.platform === 'win32' ? 'Windows does not expose POSIX mode changes consistently.' : false,
+  }, () => {
+    const root = createRoot()
+    const path = join(root, 'AGENTS.md')
+    writeFileSync(path, '# Existing guidance\n')
+    chmodSync(path, 0o600)
+    const descriptor = openSync(path, 'r+')
+    const [agentsPlan] = planInstructionChanges(root, false)
+    assert.ok(agentsPlan)
+
+    try {
+      applyInstructionChanges(root, [agentsPlan], {
+        fault: point => {
+          if (point === 'after-backup-validation') {
+            fchmodSync(descriptor, 0o744)
+          }
+        },
+      })
+    } finally {
+      closeSync(descriptor)
+    }
+
+    assert.match(readFileSync(path, 'utf8'), /## Encephalon/)
+    assert.equal(statSync(path).mode & 0o777, 0o744)
   })
 
   const faultPoints = [

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -249,6 +249,23 @@ describe('initialisation', () => {
     )
   })
 
+  test('preserves instruction-file mode changes made after planning', {
+    skip: process.platform === 'win32' ? 'Windows does not expose POSIX mode changes consistently.' : false,
+  }, () => {
+    const root = createRoot()
+    const path = join(root, 'AGENTS.md')
+    writeFileSync(path, '# Existing guidance\n')
+    chmodSync(path, 0o600)
+    const [agentsPlan] = planInstructionChanges(root, false)
+    assert.ok(agentsPlan)
+    chmodSync(path, 0o744)
+
+    applyInstructionChanges(root, [agentsPlan])
+
+    assert.match(readFileSync(path, 'utf8'), /## Encephalon/)
+    assert.equal(statSync(path).mode & 0o777, 0o744)
+  })
+
   test('detects instruction-file changes observed before atomic publication', () => {
     const root = createRoot()
     const path = join(root, 'AGENTS.md')

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -269,6 +269,32 @@ describe('initialisation', () => {
     assert.equal(readFileSync(path, 'utf8'), changed)
   })
 
+  test('does not overwrite instruction-file changes made during atomic publication', () => {
+    const root = createRoot()
+    const path = join(root, 'AGENTS.md')
+    const original = '# Existing guidance\n'
+    const changed = '# Concurrent guidance during publication\n'
+    writeFileSync(path, original)
+    const [agentsPlan] = planInstructionChanges(root, false)
+    assert.ok(agentsPlan)
+
+    assert.throws(
+      () =>
+        applyInstructionChanges(root, [agentsPlan], {
+          fault: point => {
+            if (point === 'during-publication') {
+              writeFileSync(path, changed)
+            }
+          },
+        }),
+      (error: unknown) => {
+        assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED')
+        return true
+      },
+    )
+    assert.equal(readFileSync(path, 'utf8'), changed)
+  })
+
   const faultPoints = [
     ['before-temp-create', 'old'],
     ['during-temp-write', 'old'],

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -362,6 +362,39 @@ describe('initialisation', () => {
     assert.equal(readFileSync(join(root, backupName), 'utf8'), changed)
   })
 
+  test('does not overwrite files created while restoring a backup', () => {
+    const root = createRoot()
+    const path = join(root, 'AGENTS.md')
+    const original = '# Existing guidance\n'
+    const changed = '# Concurrent restore guidance\n'
+    writeFileSync(path, original)
+    const [agentsPlan] = planInstructionChanges(root, false)
+    assert.ok(agentsPlan)
+
+    assert.throws(
+      () =>
+        applyInstructionChanges(root, [agentsPlan], {
+          fault: point => {
+            if (point === 'after-backup-validation') {
+              throw new Error('Injected publication failure')
+            }
+            if (point === 'during-backup-restore') {
+              writeFileSync(path, changed)
+            }
+          },
+        }),
+      (error: unknown) => {
+        assert.equal((error as { code?: unknown }).code, 'IO_ERROR')
+        return true
+      },
+    )
+
+    const [backupName] = readdirSync(root).filter(name => name.startsWith('.AGENTS.md.') && name.endsWith('.backup'))
+    assert.ok(backupName)
+    assert.equal(readFileSync(path, 'utf8'), changed)
+    assert.equal(readFileSync(join(root, backupName), 'utf8'), original)
+  })
+
   test('preserves old-descriptor mode changes after backup validation', {
     skip: process.platform === 'win32' ? 'Windows does not expose POSIX mode changes consistently.' : false,
   }, () => {


### PR DESCRIPTION
## Human summary

Makes Encephalon update managed instruction files safely, so write failures and concurrent edits do not leave AGENTS.md or CLAUDE.md empty, partial, or silently overwritten.

## Summary

This PR fixes MAR-2509 by replacing in-place managed instruction-file rewrites with an atomic publication path:

- writes replacement content to an exclusive temporary file in the same directory as the target
- flushes temporary file bytes before publication, including Windows-compatible temp-file flushing
- publishes newly-created managed files with `linkSync` so concurrent creators are not overwritten
- publishes existing-file replacements only after moving the current target aside, revalidating its contents and file type, and preserving the current target mode
- returns `REPOSITORY_CHANGED` when content changes are observed during the publication window
- keeps the moved-aside old file recoverable so descriptor-based writes cannot disappear during backup cleanup
- best-effort flushes containing directories on platforms that support directory fsync
- removes temporary files after success without masking the original write error on cleanup failure

The test coverage adds deterministic fault injection for each required failure point: before temp creation, during temp writes, during file flush, during publication, immediately after publication, and during temp cleanup. Each case asserts the target contains either the exact old bytes or exact new bytes, never truncated or mixed content.

This branch also:

- adds regression coverage for publication-window content changes, publication-time mode changes, old-descriptor writes, and backup-restore races
- documents the Linear-prefixed commit and PR title rules in `AGENTS.md`
- saves the review learnings as an Encephalon memory record in this repository
- aligns `package.json` export key order with the package-contract checker
- limits the CI workflow to push events, as intended for this repository

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces in-place managed-instruction rewrites with same-directory atomic publication and explicit concurrent-change recovery.
- Writes and flushes replacement bytes through exclusive temporary files before publication.
- Revalidates moved-aside existing files, preserves their live mode, and retains recoverable backups when concurrent descriptor changes are detected.
- Uses create-if-absent hard links for publication and restoration to avoid overwriting concurrent files.
- Adds deterministic fault-injection and concurrency regression coverage.
- Updates CI triggers, package export ordering, repository guidance, and workflow memory.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/instructions.ts | Replaces destructive in-place rewrites with flushed temporary files, create-if-absent publication, live backup validation, mode preservation, and recoverable failure handling. |
| test/init.test.ts | Adds deterministic coverage for write and publication failures, concurrent content and mode changes, old-descriptor mutations, and backup-restoration races. |
| .github/workflows/ci.yml | Restricts CI execution to push events. |
| package.json | Reorders conditional export keys without changing their paths. |
| AGENTS.md | Adds repository coding standards and Linear-prefixed commit and pull-request title guidance. |
| encephalon/workflow/77f71585-914f-4acf-8116-884c688abed5.json | Records durable workflow lessons derived from the atomic-write review. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Build instruction plan] --> B[Create exclusive same-directory temp file]
    B --> C[Write and fsync replacement bytes]
    C --> D[Revalidate plan]
    D --> E{Target existed?}
    E -- No --> F[Hard-link temp to target]
    E -- Yes --> G[Rename target to unique backup]
    G --> H[Validate backup bytes and mode]
    H --> I[Apply live mode and fsync temp]
    I --> J[Hard-link temp to target]
    J --> K[Revalidate backup bytes and mode]
    H -- Failure before publication --> L[Restore backup with create-if-absent link]
    K -- Concurrent change --> M[Return REPOSITORY_CHANGED and retain backup]
    F --> N[Fsync containing directory]
    K -- Unchanged --> N
    N --> O[Remove temporary path]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["\[MAR-2509\] Avoid stale final mode writes"](https://github.com/isaachinman/encephalon/commit/2785fd62808629b88f44594319d46c9640d91b83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51364203)</sub>

<!-- /greptile_comment -->