### PR TITLE
[MAR-2510] Make record staging recoverable

### DIFF
--- a/encephalon/workflow/2ca67690-910d-4a50-9c40-c4d8cad56910.json
+++ b/encephalon/workflow/2ca67690-910d-4a50-9c40-c4d8cad56910.json
@@ -1,0 +1,29 @@
+{
+  "createdAt": "2026-08-08T01:32:54.007Z",
+  "id": "2ca67690-910d-4a50-9c40-c4d8cad56910",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Prevent repeat PR review issues found on MAR-2509 and MAR-2510.",
+    "lessons": [
+      "For managed instruction-file publication, do not rely on a preflight-only snapshot before replacing a user-owned file; capture and revalidate the current target at publication time so concurrent edits return REPOSITORY_CHANGED instead of being overwritten.",
+      "Preserve mutable filesystem metadata from the file captured at publication time, not from the earlier plan, because owners can change permissions without changing bytes.",
+      "After renaming a user-owned file to a backup path, treat that backup inode as still mutable through existing open descriptors; revalidate it before cleanup and leave it recoverable if the bytes changed.",
+      "When restoring a moved-aside backup after a failed publication, use create-if-absent publication instead of check-then-rename so recovery cannot overwrite a target recreated by another writer.",
+      "Do not apply a final permission snapshot after publication if the source inode can still be changed through old descriptors; report pre-final mode drift and leave post-final drift recoverable on the backup instead.",
+      "When adding repository workflow guidance, keep Git commit subjects and PR titles prefixed with the Linear ticket in square brackets, for example [MAR-1234] Describe the change.",
+      "For append-only canonical record publication, treat successful hard-link creation as the commit point. Any post-publication cleanup or directory fsync failure must be best-effort and must not make the caller observe a failed mutation that will collide with RECORD_EXISTS on retry."
+    ],
+    "verification": [
+      "Search Encephalon before adding durable workflow lessons.",
+      "Add regression tests for each review comment when possible.",
+      "Use one commit per review-comment fix so replies can point to the exact change.",
+      "For publication paths, add tests for failures both before and after the commit point so successful commits are not misreported as failures."
+    ]
+  },
+  "searchText": "PR review hardening lessons for Encephalon record and instruction publication",
+  "source": "agent",
+  "subject": "review.github-pr-feedback",
+  "supersedes": [
+    "77f71585-914f-4acf-8116-884c688abed5"
+  ]
+}

--- a/encephalon/workflow/a46c2d81-6579-4f27-a927-5dc07644cf38.json
+++ b/encephalon/workflow/a46c2d81-6579-4f27-a927-5dc07644cf38.json
@@ -1,0 +1,30 @@
+{
+  "createdAt": "2026-08-08T01:37:15.886Z",
+  "id": "a46c2d81-6579-4f27-a927-5dc07644cf38",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Prevent repeat PR review issues found on MAR-2509 and MAR-2510.",
+    "lessons": [
+      "For managed instruction-file publication, do not rely on a preflight-only snapshot before replacing a user-owned file; capture and revalidate the current target at publication time so concurrent edits return REPOSITORY_CHANGED instead of being overwritten.",
+      "Preserve mutable filesystem metadata from the file captured at publication time, not from the earlier plan, because owners can change permissions without changing bytes.",
+      "After renaming a user-owned file to a backup path, treat that backup inode as still mutable through existing open descriptors; revalidate it before cleanup and leave it recoverable if the bytes changed.",
+      "When restoring a moved-aside backup after a failed publication, use create-if-absent publication instead of check-then-rename so recovery cannot overwrite a target recreated by another writer.",
+      "Do not apply a final permission snapshot after publication if the source inode can still be changed through old descriptors; report pre-final mode drift and leave post-final drift recoverable on the backup instead.",
+      "When adding repository workflow guidance, keep Git commit subjects and PR titles prefixed with the Linear ticket in square brackets, for example [MAR-1234] Describe the change.",
+      "For append-only canonical record publication, treat successful hard-link creation as the commit point. Any post-publication cleanup or directory fsync failure must be best-effort and must not make the caller observe a failed mutation that will collide with RECORD_EXISTS on retry.",
+      "Cache hydration is derived state after canonical record publication. If hydration fails after the record commit point, return the committed record and let the next read rebuild cache state instead of reporting the mutation as failed."
+    ],
+    "verification": [
+      "Search Encephalon before adding durable workflow lessons.",
+      "Add regression tests for each review comment when possible.",
+      "Use one commit per review-comment fix so replies can point to the exact change.",
+      "For publication paths, add tests for failures both before and after the commit point so successful commits are not misreported as failures."
+    ]
+  },
+  "searchText": "PR review hardening lessons for Encephalon record and instruction publication",
+  "source": "agent",
+  "subject": "review.github-pr-feedback",
+  "supersedes": [
+    "2ca67690-910d-4a50-9c40-c4d8cad56910"
+  ]
+}

--- a/src/records.ts
+++ b/src/records.ts
@@ -37,6 +37,7 @@ type RecordWriteFault =
   | 'after-publication'
   | 'before-publication'
   | 'during-cleanup'
+  | 'during-hydration'
   | 'during-publication-flush'
   | 'during-staging-write'
 
@@ -483,7 +484,12 @@ export const addRecordResolved = (root: string, input: AddRecordInput, options: 
     throw cleanupError
   }
   if (options.hydrate !== false) {
-    hydrateResolvedRepository(root, false)
+    try {
+      fault(options.hooks, 'during-hydration')
+      hydrateResolvedRepository(root, false)
+    } catch {
+      // Cache rebuild is derived state after the record commit point; the next read can rebuild it.
+    }
   }
   return candidate
 }

--- a/src/records.ts
+++ b/src/records.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import {
   closeSync,
+  constants,
   existsSync,
   fsyncSync,
   linkSync,
@@ -32,6 +33,22 @@ type RecordScan = {
   errors: ValidationIssue[]
 }
 
+type RecordWriteFault = 'after-publication' | 'before-publication' | 'during-cleanup' | 'during-staging-write'
+
+type RecordWriteHooks = {
+  fault?: (point: RecordWriteFault) => void
+}
+
+type AddRecordOptions = {
+  hooks?: RecordWriteHooks
+  hydrate?: boolean
+}
+
+const STAGING_DIRECTORY = '_staging'
+const RESERVED_DIRECTORIES = new Set(['_artifacts', STAGING_DIRECTORY])
+const directoryFlag = constants.O_DIRECTORY ?? 0
+const noFollowFlag = constants.O_NOFOLLOW ?? 0
+
 const posixRelative = (root: string, path: string) => relative(root, path).replaceAll('\\', '/')
 
 const issue = (code: string, message: string, path?: string, recordId?: string): ValidationIssue => ({
@@ -40,6 +57,63 @@ const issue = (code: string, message: string, path?: string, recordId?: string):
   ...(path === undefined ? {} : { path }),
   ...(recordId === undefined ? {} : { recordId }),
 })
+
+const fault = (hooks: RecordWriteHooks | undefined, point: RecordWriteFault) => hooks?.fault?.(point)
+
+const assertRealDirectory = (root: string, path: string) => {
+  const metadata = lstatSync(path)
+  if (metadata.isDirectory() && !metadata.isSymbolicLink()) {
+    return
+  }
+  return fail('VALIDATION_FAILED', `${posixRelative(root, path)} must be a real non-symlink directory.`)
+}
+
+const ensureDirectoryChain = (root: string, segments: string[]) => {
+  let current = root
+  for (const segment of segments) {
+    current = resolve(current, segment)
+    try {
+      mkdirSync(current)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+        throw error
+      }
+    }
+    assertRealDirectory(root, current)
+  }
+  return current
+}
+
+const fsyncDirectory = (path: string) => {
+  if (process.platform !== 'win32') {
+    let descriptor: number | undefined
+    try {
+      descriptor = openSync(path, constants.O_RDONLY | directoryFlag)
+      fsyncSync(descriptor)
+    } catch (error) {
+      const { code } = error as NodeJS.ErrnoException
+      if (code !== 'EINVAL' && code !== 'ENOTSUP' && code !== 'EOPNOTSUPP' && code !== 'EPERM') {
+        throw error
+      }
+    } finally {
+      if (descriptor !== undefined) {
+        closeSync(descriptor)
+      }
+    }
+  }
+}
+
+const cleanupStagingDirectory = (root: string, hooks?: RecordWriteHooks) => {
+  const stagingDirectory = resolve(root, 'encephalon', STAGING_DIRECTORY)
+  if (existsSync(stagingDirectory)) {
+    assertRealDirectory(root, stagingDirectory)
+    for (const entry of readdirSync(stagingDirectory, { withFileTypes: true })) {
+      fault(hooks, 'during-cleanup')
+      rmSync(resolve(stagingDirectory, entry.name), { force: true, recursive: true })
+    }
+    fsyncDirectory(stagingDirectory)
+  }
+}
 
 const readRecord = (root: string, path: string): BrainRecord => {
   const relativePath = posixRelative(root, path)
@@ -69,13 +143,17 @@ const scanCanonicalRecords = (root: string): RecordScan => {
       .sort((first, second) => first.name.localeCompare(second.name))
       .reduce<RecordScan>(
         (result, kindEntry) => {
-          if (kindEntry.name === '_artifacts') {
+          if (RESERVED_DIRECTORIES.has(kindEntry.name)) {
             return kindEntry.isDirectory() && !kindEntry.isSymbolicLink()
               ? result
               : {
                   errors: [
                     ...result.errors,
-                    issue('INVALID_RECORD_LAYOUT', '_artifacts must be a real directory.', 'encephalon/_artifacts'),
+                    issue(
+                      'INVALID_RECORD_LAYOUT',
+                      `${kindEntry.name} must be a real directory.`,
+                      `encephalon/${kindEntry.name}`,
+                    ),
                   ],
                   records: result.records,
                 }
@@ -133,7 +211,7 @@ const scanCanonicalRecords = (root: string): RecordScan => {
               ...result.errors,
               issue(
                 'INVALID_RECORD_LAYOUT',
-                'The brain root may contain only kind directories and the reserved _artifacts directory.',
+                'The brain root may contain only kind directories and reserved internal directories.',
                 posixRelative(root, kindPath),
               ),
             ],
@@ -308,11 +386,7 @@ export const readRecords = (input: RootInput = {}) => {
   })
 }
 
-export const addRecordResolved = (
-  root: string,
-  input: AddRecordInput,
-  options: { hydrate?: boolean } = {},
-): BrainRecord => {
+export const addRecordResolved = (root: string, input: AddRecordInput, options: AddRecordOptions = {}): BrainRecord => {
   const recordFile = createRecordFile(input)
   const relativePath = `encephalon/${recordFile.kind}/${recordFile.id}.json`
   const path = resolve(root, ...relativePath.split('/'))
@@ -322,6 +396,7 @@ export const addRecordResolved = (
     })
   }
 
+  cleanupStagingDirectory(root, options.hooks)
   const scan = scanCanonicalRecords(root)
   if (scan.errors.length > 0) {
     return fail('VALIDATION_FAILED', 'Existing canonical records are invalid.', {
@@ -346,29 +421,56 @@ export const addRecordResolved = (
   }
 
   const formatted = formatRecordFile(recordFile)
-  const kindDirectory = resolve(root, 'encephalon', recordFile.kind)
-  const stagingDirectory = resolve(root, 'encephalon', '_artifacts', recordFile.kind, recordFile.id)
-  const stagingPath = resolve(stagingDirectory, `.encephalon-record-${randomUUID()}.tmp`)
-  mkdirSync(kindDirectory, { recursive: true })
-  mkdirSync(stagingDirectory, { recursive: true })
+  const kindDirectory = ensureDirectoryChain(root, ['encephalon', recordFile.kind])
+  const stagingDirectory = ensureDirectoryChain(root, ['encephalon', STAGING_DIRECTORY])
+  const stagingPath = resolve(stagingDirectory, `record-${process.pid}-${randomUUID()}.tmp`)
+  let published = false
+  let operationFailed = false
+  let cleanupError: unknown
   try {
-    const descriptor = openSync(stagingPath, 'wx', 0o644)
+    assertRealDirectory(root, stagingDirectory)
+    const descriptor = openSync(
+      stagingPath,
+      constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | noFollowFlag,
+      0o644,
+    )
     try {
+      fault(options.hooks, 'during-staging-write')
       writeFileSync(descriptor, formatted, 'utf8')
       fsyncSync(descriptor)
     } finally {
       closeSync(descriptor)
     }
+    fault(options.hooks, 'before-publication')
+    assertRealDirectory(root, kindDirectory)
+    assertRealDirectory(root, stagingDirectory)
     try {
       linkSync(stagingPath, path)
+      published = true
+      fault(options.hooks, 'after-publication')
+      fsyncDirectory(kindDirectory)
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
         return fail('RECORD_EXISTS', `Record ${recordFile.id} already exists.`, { path: relativePath })
       }
       throw error
     }
+  } catch (error) {
+    operationFailed = true
+    throw error
   } finally {
-    rmSync(stagingPath, { force: true })
+    try {
+      fault(options.hooks, 'during-cleanup')
+      rmSync(stagingPath, { force: true })
+      fsyncDirectory(stagingDirectory)
+    } catch (error) {
+      if (!(operationFailed || published)) {
+        cleanupError = error
+      }
+    }
+  }
+  if (cleanupError !== undefined) {
+    throw cleanupError
   }
   if (options.hydrate !== false) {
     hydrateResolvedRepository(root, false)

--- a/src/records.ts
+++ b/src/records.ts
@@ -33,7 +33,12 @@ type RecordScan = {
   errors: ValidationIssue[]
 }
 
-type RecordWriteFault = 'after-publication' | 'before-publication' | 'during-cleanup' | 'during-staging-write'
+type RecordWriteFault =
+  | 'after-publication'
+  | 'before-publication'
+  | 'during-cleanup'
+  | 'during-publication-flush'
+  | 'during-staging-write'
 
 type RecordWriteHooks = {
   fault?: (point: RecordWriteFault) => void
@@ -447,13 +452,18 @@ export const addRecordResolved = (root: string, input: AddRecordInput, options: 
     try {
       linkSync(stagingPath, path)
       published = true
-      fault(options.hooks, 'after-publication')
-      fsyncDirectory(kindDirectory)
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
         return fail('RECORD_EXISTS', `Record ${recordFile.id} already exists.`, { path: relativePath })
       }
       throw error
+    }
+    try {
+      fault(options.hooks, 'after-publication')
+      fault(options.hooks, 'during-publication-flush')
+      fsyncDirectory(kindDirectory)
+    } catch {
+      // The canonical hard link is already visible; do not report a committed mutation as failed.
     }
   } catch (error) {
     operationFailed = true

--- a/test/records.test.ts
+++ b/test/records.test.ts
@@ -266,6 +266,44 @@ describe('canonical records', () => {
     assert.deepEqual(readdirSync(join(root, 'encephalon', '_staging')), [])
   })
 
+  test('does not misreport cache hydration failure after canonical publication', () => {
+    const root = createRoot()
+    const record = addRecordResolved(
+      root,
+      {
+        id: 'hydration-failure',
+        kind: 'decision',
+        payload: { summary: 'Published' },
+        source: 'agent',
+        subject: 'hydration.failure',
+      },
+      {
+        hooks: {
+          fault: point => {
+            if (point === 'during-hydration') {
+              throw new Error('Injected hydration failure')
+            }
+          },
+        },
+      },
+    )
+
+    assert.equal(record.id, 'hydration-failure')
+    assert.equal(existsSync(join(root, record.path)), true)
+    assertErrorCode(
+      () =>
+        api.addRecord({
+          id: record.id,
+          kind: 'decision',
+          payload: { summary: 'Retry' },
+          root,
+          source: 'agent',
+          subject: 'hydration.failure',
+        }),
+      'RECORD_EXISTS',
+    )
+  })
+
   test('validates supersession graphs and permits a multi-head resolver', () => {
     const root = createRoot()
     const first = api.addRecord({

--- a/test/records.test.ts
+++ b/test/records.test.ts
@@ -1,8 +1,19 @@
 import assert from 'node:assert/strict'
-import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  linkSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, describe, test } from 'node:test'
 import * as api from '../src/index.ts'
+import { addRecordResolved } from '../src/records.ts'
 import { discoverRepository } from '../src/repository.ts'
 import { createTestRepository, ensureParent, removeTestRepository } from '../test/helpers.ts'
 
@@ -40,6 +51,7 @@ describe('canonical records', () => {
     })
 
     assert.equal(record.path, 'encephalon/decision/550e8400-e29b-41d4-a716-446655440000.json')
+    assert.equal(existsSync(join(root, 'encephalon', '_artifacts', 'decision', record.id)), false)
     const filePath = join(root, record.path)
     assert.equal(existsSync(filePath), true)
     assert.equal(
@@ -111,7 +123,119 @@ describe('canonical records', () => {
     })
 
     assert.deepEqual(record.artifacts, [artifact])
+    assert.deepEqual(readdirSync(join(root, 'encephalon', '_artifacts', 'architecture', id)), ['diagram.svg'])
     assert.equal(api.validateRecords({ root }).valid, true)
+  })
+
+  test('rejects a symlinked internal staging directory before writing records', {
+    skip: process.platform === 'win32' ? 'Windows runners may not permit directory symlink creation.' : false,
+  }, () => {
+    const root = createRoot()
+    const outside = join(root, 'outside-staging')
+    mkdirSync(outside)
+    mkdirSync(join(root, 'encephalon'))
+    symlinkSync(outside, join(root, 'encephalon', '_staging'), 'dir')
+
+    assertErrorCode(
+      () =>
+        api.addRecord({
+          id: 'staging-symlink',
+          kind: 'decision',
+          payload: {},
+          root,
+          source: 'agent',
+          subject: 'staging.symlink',
+        }),
+      'VALIDATION_FAILED',
+    )
+    assert.deepEqual(readdirSync(outside), [])
+  })
+
+  test('rejects a replaced kind directory immediately before publication', () => {
+    const root = createRoot()
+
+    assertErrorCode(
+      () =>
+        addRecordResolved(
+          root,
+          {
+            id: 'kind-replaced',
+            kind: 'decision',
+            payload: {},
+            source: 'agent',
+            subject: 'kind.replaced',
+          },
+          {
+            hooks: {
+              fault: point => {
+                if (point === 'before-publication') {
+                  rmSync(join(root, 'encephalon', 'decision'), { force: true, recursive: true })
+                  writeFileSync(join(root, 'encephalon', 'decision'), 'not a directory')
+                }
+              },
+            },
+            hydrate: false,
+          },
+        ),
+      'VALIDATION_FAILED',
+    )
+    assert.equal(readFileSync(join(root, 'encephalon', 'decision'), 'utf8'), 'not a directory')
+  })
+
+  test('cleans orphaned internal staging aliases on the next mutation', () => {
+    const root = createRoot()
+    const first = api.addRecord({
+      id: 'orphan-source',
+      kind: 'decision',
+      payload: { summary: 'Committed' },
+      root,
+      source: 'agent',
+      subject: 'staging.orphan',
+    })
+    const stagingDirectory = join(root, 'encephalon', '_staging')
+    mkdirSync(stagingDirectory, { recursive: true })
+    linkSync(join(root, first.path), join(stagingDirectory, 'orphan.tmp'))
+
+    api.addRecord({
+      id: 'after-orphan',
+      kind: 'decision',
+      payload: { summary: 'Next' },
+      root,
+      source: 'agent',
+      subject: 'staging.next',
+    })
+
+    assert.deepEqual(readdirSync(stagingDirectory), [])
+    assert.equal(existsSync(join(root, first.path)), true)
+    assert.equal(existsSync(join(root, 'encephalon', 'decision', 'after-orphan.json')), true)
+  })
+
+  test('does not misreport cleanup failure after canonical publication', () => {
+    const root = createRoot()
+    const record = addRecordResolved(
+      root,
+      {
+        id: 'cleanup-failure',
+        kind: 'decision',
+        payload: { summary: 'Published' },
+        source: 'agent',
+        subject: 'cleanup.failure',
+      },
+      {
+        hooks: {
+          fault: point => {
+            if (point === 'during-cleanup') {
+              throw new Error('Injected cleanup failure')
+            }
+          },
+        },
+        hydrate: false,
+      },
+    )
+
+    assert.equal(record.id, 'cleanup-failure')
+    assert.equal(existsSync(join(root, record.path)), true)
+    assert.equal(readdirSync(join(root, 'encephalon', '_staging')).length, 1)
   })
 
   test('validates supersession graphs and permits a multi-head resolver', () => {

--- a/test/records.test.ts
+++ b/test/records.test.ts
@@ -238,6 +238,34 @@ describe('canonical records', () => {
     assert.equal(readdirSync(join(root, 'encephalon', '_staging')).length, 1)
   })
 
+  test('does not misreport directory flush failure after canonical publication', () => {
+    const root = createRoot()
+    const record = addRecordResolved(
+      root,
+      {
+        id: 'flush-failure',
+        kind: 'decision',
+        payload: { summary: 'Published' },
+        source: 'agent',
+        subject: 'flush.failure',
+      },
+      {
+        hooks: {
+          fault: point => {
+            if (point === 'during-publication-flush') {
+              throw new Error('Injected directory flush failure')
+            }
+          },
+        },
+        hydrate: false,
+      },
+    )
+
+    assert.equal(record.id, 'flush-failure')
+    assert.equal(existsSync(join(root, record.path)), true)
+    assert.deepEqual(readdirSync(join(root, 'encephalon', '_staging')), [])
+  })
+
   test('validates supersession graphs and permits a multi-head resolver', () => {
     const root = createRoot()
     const first = api.addRecord({


### PR DESCRIPTION
## Human summary

Moves record staging out of artifact folders and makes interrupted record publication recoverable, so orphaned staging aliases are cleaned without risking committed records.

## Summary

This PR fixes MAR-2510 by hardening canonical record creation:

- moves temporary record staging into the reserved internal `encephalon/_staging` namespace
- keeps record staging out of caller-managed `_artifacts/<kind>/<id>` directories
- creates canonical and staging directory chains one component at a time and verifies each component is a real non-symlink directory
- revalidates the kind and staging directories immediately before hard-link publication
- writes and flushes staged record bytes before publishing the canonical record
- keeps no-overwrite `linkSync` publication semantics and preserves `RECORD_EXISTS` for destination collisions
- treats successful hard-link publication as the commit point, so post-publication directory flush failures cannot make a committed mutation look failed
- flushes the canonical kind directory after publication where supported
- removes stale internal staging entries on the next record mutation without deleting committed canonical records
- suppresses cleanup, post-publication flush, and cache hydration failures after canonical publication so the committed record outcome is not misreported
- avoids creating empty artifact directories for records that have no artifacts
- saves the MAR-2510 review lessons in Encephalon workflow memory so future publication work tests both sides of the commit point, including derived cache hydration

The test coverage adds regression cases for symlinked internal staging ancestry, kind-directory replacement at the publication boundary, orphaned staging alias cleanup, cleanup failure after canonical publication, post-publication directory flush failure, cache hydration failure after canonical publication, destination collisions, and artifact-first creation with an existing legitimate artifact directory.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves record staging into a reserved internal namespace and makes canonical hard-link publication the mutation commit point.
- Builds and revalidates non-symlink canonical and staging directory chains.
- Cleans orphaned staging entries on later mutations while preserving committed records.
- Suppresses cleanup, directory-flush, and cache-hydration errors after publication.
- Adds regression coverage for staging recovery, publication-boundary replacement, collisions, and post-commit failures.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/records.ts | Moves staging into the reserved internal namespace, validates directory ancestry, establishes hard-link publication as the commit point, and suppresses subsequent derived-state failures. |
| test/records.test.ts | Adds focused regression coverage for symlink rejection, publication-boundary replacement, orphan cleanup, destination collisions, and failures after publication. |
| encephalon/workflow/a46c2d81-6579-4f27-a927-5dc07644cf38.json | Records the publication commit-point and derived-cache recovery lessons from this review cycle. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Validate input and canonical records] --> B[Clean orphaned internal staging entries]
  B --> C[Create and verify kind and staging directories]
  C --> D[Write and fsync staged record]
  D --> E[Revalidate publication directories]
  E --> F[Create canonical hard link]
  F --> G{Publication succeeded?}
  G -- No --> H[Report pre-commit failure]
  G -- Yes --> I[Committed record]
  I --> J[Best-effort kind-directory flush]
  J --> K[Best-effort staging cleanup]
  K --> L[Best-effort cache hydration]
  L --> M[Return committed record]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["\[MAR-2510\] Record hydration review learn..."](https://github.com/isaachinman/encephalon/commit/ed530499b112f0283604423ed504842b4a553e44) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51371798)</sub>

<!-- /greptile_comment -->