### PR TITLE
[MAR-2511] Preserve instruction file bytes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@ node_modules/
 dist/
 *.tgz
 coverage/
-/encephalon/
+/encephalon/_staging/
 .DS_Store
 AGENTS.md

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ npm install --save-dev encephalon
 npx --no-install encephalon init
 ```
 
-`init` safely scans derived repository metadata, creates up to three baseline records, builds the local cache, and adds a reversible managed block to root `AGENTS.md` and `CLAUDE.md`. It never reads source bodies, instruction-file text, README content, environment files, registry configuration, Git history, Git remotes, or CI workflow contents.
+`init` safely scans derived repository metadata, creates up to three baseline records, builds the local cache, and adds a reversible managed block to root `AGENTS.md` and `CLAUDE.md`. It does not record source bodies, instruction-file text, README content, environment files, registry configuration, Git history, Git remotes, or CI workflow contents.
+
+Existing instruction files must be valid UTF-8, NUL-free, regular non-symlink files no larger than 1 MiB. Invalid files are rejected before either instruction file is changed.
 
 The result includes a `nextAction` asking an agent to read the installed skill and optionally enrich the baseline semantically.
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1043,6 +1043,7 @@ Before changing either file:
 
 - Read raw bytes when it exists.
 - Reject NUL-containing or invalid UTF-8 text.
+- Reject instruction files larger than 1 MiB before rewriting them.
 - Detect the file's existing line ending without normalising content.
 - Detect zero, one, or multiple marker pairs.
 - Reject duplicate, nested, reversed, or unmatched markers.

--- a/encephalon/workflow/1fbe2c64-d1b7-4517-b640-35db963bb6e3.json
+++ b/encephalon/workflow/1fbe2c64-d1b7-4517-b640-35db963bb6e3.json
@@ -1,0 +1,34 @@
+{
+  "createdAt": "2026-08-08T07:45:17.000Z",
+  "id": "1fbe2c64-d1b7-4517-b640-35db963bb6e3",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Prevent repeat PR review issues found in Encephalon review fixes.",
+    "lessons": [
+      "For managed instruction-file publication, do not rely on a preflight-only snapshot before replacing a user-owned file; capture and revalidate the current target at publication time so concurrent edits return REPOSITORY_CHANGED instead of being overwritten.",
+      "Preserve mutable filesystem metadata from the file captured at publication time, not from the earlier plan, because owners can change permissions without changing bytes.",
+      "After renaming a user-owned file to a backup path, treat that backup inode as still mutable through existing open descriptors; revalidate it before cleanup and leave it recoverable if the bytes changed.",
+      "When restoring a moved-aside backup after a failed publication, use create-if-absent publication instead of check-then-rename so recovery cannot overwrite a target recreated by another writer.",
+      "Do not apply a final permission snapshot after publication if the source inode can still be changed through old descriptors; report pre-final mode drift and leave post-final drift recoverable on the backup instead.",
+      "When adding repository workflow guidance, keep Git commit subjects and PR titles prefixed with the Linear ticket in square brackets, for example [MAR-1234] Describe the change.",
+      "For append-only canonical record publication, treat successful hard-link creation as the commit point. Any post-publication cleanup or directory fsync failure must be best-effort and must not make the caller observe a failed mutation that will collide with RECORD_EXISTS on retry.",
+      "Cache hydration is derived state after canonical record publication. If hydration fails after the record commit point, return the committed record and let the next read rebuild cache state instead of reporting the mutation as failed.",
+      "When adding a managed block to a user-owned file with a byte-size limit, validate the final bytes that Encephalon will publish, not only the original preflight bytes, so the tool cannot create a file it later refuses to read or remove.",
+      "When reporting size-limit validation failures, describe the bytes actually being rejected: distinguish an original file that exceeds the cap from a final managed output that cannot fit the appended block within the cap.",
+      "Treat actionable Pullfrog review-body nitpicks as comments to resolve, even when GitHub does not expose them as inline review threads."
+    ],
+    "verification": [
+      "Search Encephalon before adding durable workflow lessons.",
+      "Add regression tests for each review comment when possible.",
+      "Use one commit per review-comment fix so replies can point to the exact change.",
+      "For publication paths, add tests for failures both before and after the commit point so successful commits are not misreported as failures.",
+      "For managed file-size limits, test boundary inputs after Encephalon's own appended or removed bytes are included.",
+      "Assert user-facing validation wording when the distinction between source bytes and generated output bytes matters.",
+      "Before merging, scan both unresolved inline threads and latest review bodies for outstanding actionable feedback."
+    ]
+  },
+  "searchText": "PR review hardening lessons Pullfrog review body nitpicks managed file accept boundary exact size limit",
+  "source": "agent",
+  "subject": "review.github-pr-feedback",
+  "supersedes": ["9c13e80e-1a09-4d9f-94a6-fd248c5b1479"]
+}

--- a/encephalon/workflow/2ca67690-910d-4a50-9c40-c4d8cad56910.json
+++ b/encephalon/workflow/2ca67690-910d-4a50-9c40-c4d8cad56910.json
@@ -23,7 +23,5 @@
   "searchText": "PR review hardening lessons for Encephalon record and instruction publication",
   "source": "agent",
   "subject": "review.github-pr-feedback",
-  "supersedes": [
-    "77f71585-914f-4acf-8116-884c688abed5"
-  ]
+  "supersedes": ["77f71585-914f-4acf-8116-884c688abed5"]
 }

--- a/encephalon/workflow/7e9c78c8-df84-4ed6-8eb1-04bbd9a09a08.json
+++ b/encephalon/workflow/7e9c78c8-df84-4ed6-8eb1-04bbd9a09a08.json
@@ -1,0 +1,32 @@
+{
+  "createdAt": "2026-08-08T07:25:46.000Z",
+  "id": "7e9c78c8-df84-4ed6-8eb1-04bbd9a09a08",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Prevent repeat PR review issues found in Encephalon review fixes.",
+    "lessons": [
+      "For managed instruction-file publication, do not rely on a preflight-only snapshot before replacing a user-owned file; capture and revalidate the current target at publication time so concurrent edits return REPOSITORY_CHANGED instead of being overwritten.",
+      "Preserve mutable filesystem metadata from the file captured at publication time, not from the earlier plan, because owners can change permissions without changing bytes.",
+      "After renaming a user-owned file to a backup path, treat that backup inode as still mutable through existing open descriptors; revalidate it before cleanup and leave it recoverable if the bytes changed.",
+      "When restoring a moved-aside backup after a failed publication, use create-if-absent publication instead of check-then-rename so recovery cannot overwrite a target recreated by another writer.",
+      "Do not apply a final permission snapshot after publication if the source inode can still be changed through old descriptors; report pre-final mode drift and leave post-final drift recoverable on the backup instead.",
+      "When adding repository workflow guidance, keep Git commit subjects and PR titles prefixed with the Linear ticket in square brackets, for example [MAR-1234] Describe the change.",
+      "For append-only canonical record publication, treat successful hard-link creation as the commit point. Any post-publication cleanup or directory fsync failure must be best-effort and must not make the caller observe a failed mutation that will collide with RECORD_EXISTS on retry.",
+      "Cache hydration is derived state after canonical record publication. If hydration fails after the record commit point, return the committed record and let the next read rebuild cache state instead of reporting the mutation as failed.",
+      "When adding a managed block to a user-owned file with a byte-size limit, validate the final bytes that Encephalon will publish, not only the original preflight bytes, so the tool cannot create a file it later refuses to read or remove."
+    ],
+    "verification": [
+      "Search Encephalon before adding durable workflow lessons.",
+      "Add regression tests for each review comment when possible.",
+      "Use one commit per review-comment fix so replies can point to the exact change.",
+      "For publication paths, add tests for failures both before and after the commit point so successful commits are not misreported as failures.",
+      "For managed file-size limits, test boundary inputs after Encephalon's own appended or removed bytes are included."
+    ]
+  },
+  "searchText": "PR review hardening lessons for Encephalon record and instruction publication managed file final size limit",
+  "source": "agent",
+  "subject": "review.github-pr-feedback",
+  "supersedes": [
+    "a46c2d81-6579-4f27-a927-5dc07644cf38"
+  ]
+}

--- a/encephalon/workflow/7e9c78c8-df84-4ed6-8eb1-04bbd9a09a08.json
+++ b/encephalon/workflow/7e9c78c8-df84-4ed6-8eb1-04bbd9a09a08.json
@@ -26,7 +26,5 @@
   "searchText": "PR review hardening lessons for Encephalon record and instruction publication managed file final size limit",
   "source": "agent",
   "subject": "review.github-pr-feedback",
-  "supersedes": [
-    "a46c2d81-6579-4f27-a927-5dc07644cf38"
-  ]
+  "supersedes": ["a46c2d81-6579-4f27-a927-5dc07644cf38"]
 }

--- a/encephalon/workflow/9c13e80e-1a09-4d9f-94a6-fd248c5b1479.json
+++ b/encephalon/workflow/9c13e80e-1a09-4d9f-94a6-fd248c5b1479.json
@@ -28,7 +28,5 @@
   "searchText": "PR review hardening lessons for Encephalon record and instruction publication managed file final size limit validation wording",
   "source": "agent",
   "subject": "review.github-pr-feedback",
-  "supersedes": [
-    "7e9c78c8-df84-4ed6-8eb1-04bbd9a09a08"
-  ]
+  "supersedes": ["7e9c78c8-df84-4ed6-8eb1-04bbd9a09a08"]
 }

--- a/encephalon/workflow/9c13e80e-1a09-4d9f-94a6-fd248c5b1479.json
+++ b/encephalon/workflow/9c13e80e-1a09-4d9f-94a6-fd248c5b1479.json
@@ -1,0 +1,34 @@
+{
+  "createdAt": "2026-08-08T07:34:11.000Z",
+  "id": "9c13e80e-1a09-4d9f-94a6-fd248c5b1479",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Prevent repeat PR review issues found in Encephalon review fixes.",
+    "lessons": [
+      "For managed instruction-file publication, do not rely on a preflight-only snapshot before replacing a user-owned file; capture and revalidate the current target at publication time so concurrent edits return REPOSITORY_CHANGED instead of being overwritten.",
+      "Preserve mutable filesystem metadata from the file captured at publication time, not from the earlier plan, because owners can change permissions without changing bytes.",
+      "After renaming a user-owned file to a backup path, treat that backup inode as still mutable through existing open descriptors; revalidate it before cleanup and leave it recoverable if the bytes changed.",
+      "When restoring a moved-aside backup after a failed publication, use create-if-absent publication instead of check-then-rename so recovery cannot overwrite a target recreated by another writer.",
+      "Do not apply a final permission snapshot after publication if the source inode can still be changed through old descriptors; report pre-final mode drift and leave post-final drift recoverable on the backup instead.",
+      "When adding repository workflow guidance, keep Git commit subjects and PR titles prefixed with the Linear ticket in square brackets, for example [MAR-1234] Describe the change.",
+      "For append-only canonical record publication, treat successful hard-link creation as the commit point. Any post-publication cleanup or directory fsync failure must be best-effort and must not make the caller observe a failed mutation that will collide with RECORD_EXISTS on retry.",
+      "Cache hydration is derived state after canonical record publication. If hydration fails after the record commit point, return the committed record and let the next read rebuild cache state instead of reporting the mutation as failed.",
+      "When adding a managed block to a user-owned file with a byte-size limit, validate the final bytes that Encephalon will publish, not only the original preflight bytes, so the tool cannot create a file it later refuses to read or remove.",
+      "When reporting size-limit validation failures, describe the bytes actually being rejected: distinguish an original file that exceeds the cap from a final managed output that cannot fit the appended block within the cap."
+    ],
+    "verification": [
+      "Search Encephalon before adding durable workflow lessons.",
+      "Add regression tests for each review comment when possible.",
+      "Use one commit per review-comment fix so replies can point to the exact change.",
+      "For publication paths, add tests for failures both before and after the commit point so successful commits are not misreported as failures.",
+      "For managed file-size limits, test boundary inputs after Encephalon's own appended or removed bytes are included.",
+      "Assert user-facing validation wording when the distinction between source bytes and generated output bytes matters."
+    ]
+  },
+  "searchText": "PR review hardening lessons for Encephalon record and instruction publication managed file final size limit validation wording",
+  "source": "agent",
+  "subject": "review.github-pr-feedback",
+  "supersedes": [
+    "7e9c78c8-df84-4ed6-8eb1-04bbd9a09a08"
+  ]
+}

--- a/encephalon/workflow/a46c2d81-6579-4f27-a927-5dc07644cf38.json
+++ b/encephalon/workflow/a46c2d81-6579-4f27-a927-5dc07644cf38.json
@@ -24,7 +24,5 @@
   "searchText": "PR review hardening lessons for Encephalon record and instruction publication",
   "source": "agent",
   "subject": "review.github-pr-feedback",
-  "supersedes": [
-    "2ca67690-910d-4a50-9c40-c4d8cad56910"
-  ]
+  "supersedes": ["2ca67690-910d-4a50-9c40-c4d8cad56910"]
 }

--- a/encephalon/workflow/e744ddc1-2a30-4e13-9165-3f392b6c4e15.json
+++ b/encephalon/workflow/e744ddc1-2a30-4e13-9165-3f392b6c4e15.json
@@ -1,0 +1,19 @@
+{
+  "createdAt": "2026-08-08T07:37:20.000Z",
+  "id": "e744ddc1-2a30-4e13-9165-3f392b6c4e15",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Keep Encephalon dogfooding state visible to Git.",
+    "lessons": [
+      "Do not ignore the repository's root encephalon directory wholesale in projects that dogfood Encephalon; records and referenced artifacts are durable project memory and should be ordinary reviewable Git changes.",
+      "If local scratch state needs ignoring, ignore only the transient internal path, such as encephalon/_staging, so future memory records do not require git add -f."
+    ],
+    "verification": [
+      "After changing Encephalon state, run git status without force-add assumptions and confirm new records appear as ordinary untracked or staged files."
+    ]
+  },
+  "searchText": "Encephalon dogfooding gitignore state records visible git staging",
+  "source": "agent",
+  "subject": "workflow.gitignore-dogfooding",
+  "supersedes": []
+}

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -114,6 +114,13 @@ const readRegularFileBytes = (path: string, filename: (typeof FILENAMES)[number]
   }
 }
 
+const boundedInstructionBytes = (filename: (typeof FILENAMES)[number], bytes: Buffer) => {
+  if (bytes.length <= MAX_INSTRUCTION_FILE_BYTES) {
+    return bytes
+  }
+  return fail('VALIDATION_FAILED', `${filename} exceeds the 1 MiB instruction-file limit.`)
+}
+
 const blockFor = (metadata: BlockMetadata) => {
   const lineEnding = metadata.lineEnding === 'CRLF' ? '\r\n' : '\n'
   return [
@@ -219,10 +226,11 @@ const additionPlan = (root: string, filename: (typeof FILENAMES)[number]): FileP
     separatorBase64: Buffer.from(separator, 'utf8').toString('base64'),
   }
   const nextContent = `${content}${separator}${blockFor(metadata)}`
+  const nextBytes = boundedInstructionBytes(filename, Buffer.from(nextContent, 'utf8'))
   return {
     action: 'write',
     content: nextContent,
-    contentBytes: Buffer.from(nextContent, 'utf8'),
+    contentBytes: nextBytes,
     filename,
     originalBytes,
     originalContent: content,

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -14,6 +14,7 @@ import {
   writeSync,
 } from 'node:fs'
 import { basename, dirname, join, resolve } from 'node:path'
+import { TextDecoder } from 'node:util'
 import { EncephalonError, fail, wrapIo } from './errors.ts'
 
 const FILENAMES = ['AGENTS.md', 'CLAUDE.md'] as const
@@ -33,12 +34,18 @@ type FilePlan = {
   filename: (typeof FILENAMES)[number]
   action: 'delete' | 'none' | 'write'
   content?: string
+  contentBytes?: Buffer
+  originalBytes: Buffer
   originalContent: string
   originalFileExisted: boolean
 }
 
 const ALLOWED_SEPARATORS = new Set(['', '\n', '\n\n', '\r\n', '\r\n\r\n'])
 const MODE_BITS = 0o7777
+const MAX_INSTRUCTION_FILE_BYTES = 1024 * 1024
+const noFollowFlag = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0
+const directoryFlag = typeof constants.O_DIRECTORY === 'number' ? constants.O_DIRECTORY : 0
+const utf8Decoder = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true })
 
 const lstatIfExists = (path: string) => {
   try {
@@ -71,6 +78,41 @@ const decodeMetadata = (encoded: string): BlockMetadata => {
 }
 
 const lineEndingFor = (content: string) => (content.includes('\r\n') ? '\r\n' : '\n')
+
+const decodeInstructionBytes = (filename: (typeof FILENAMES)[number], bytes: Buffer) => {
+  if (bytes.includes(0)) {
+    return fail('VALIDATION_FAILED', `${filename} contains a NUL byte.`)
+  }
+  try {
+    return utf8Decoder.decode(bytes)
+  } catch {
+    return fail('VALIDATION_FAILED', `${filename} must contain valid UTF-8.`)
+  }
+}
+
+const readRegularFileBytes = (path: string, filename: (typeof FILENAMES)[number]) => {
+  let descriptor: number
+  try {
+    descriptor = openSync(path, constants.O_RDONLY | noFollowFlag)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ELOOP') {
+      return fail('VALIDATION_FAILED', `${filename} must remain a regular non-symlink file.`)
+    }
+    throw error
+  }
+  try {
+    const metadata = fstatSync(descriptor)
+    if (!metadata.isFile()) {
+      return fail('VALIDATION_FAILED', 'Managed instruction paths must remain regular files.')
+    }
+    if (metadata.size > MAX_INSTRUCTION_FILE_BYTES) {
+      return fail('VALIDATION_FAILED', `${filename} exceeds the 1 MiB instruction-file limit.`)
+    }
+    return readFileSync(descriptor)
+  } finally {
+    closeSync(descriptor)
+  }
+}
 
 const blockFor = (metadata: BlockMetadata) => {
   const lineEnding = metadata.lineEnding === 'CRLF' ? '\r\n' : '\n'
@@ -153,15 +195,14 @@ const additionPlan = (root: string, filename: (typeof FILENAMES)[number]): FileP
       return fail('VALIDATION_FAILED', `${filename} must be a regular non-symlink file.`)
     }
   }
-  const content = existed ? readFileSync(path, 'utf8') : ''
-  if (content.includes('\0')) {
-    return fail('VALIDATION_FAILED', `${filename} contains a NUL byte.`)
-  }
+  const originalBytes = existed ? readRegularFileBytes(path, filename) : Buffer.alloc(0)
+  const content = decodeInstructionBytes(filename, originalBytes)
   const installed = inspectBlock(content)
   if (installed !== undefined) {
     return {
       action: 'none',
       filename,
+      originalBytes,
       originalContent: content,
       originalFileExisted: existed,
     }
@@ -177,10 +218,13 @@ const additionPlan = (root: string, filename: (typeof FILENAMES)[number]): FileP
     originalFileExisted: existed,
     separatorBase64: Buffer.from(separator, 'utf8').toString('base64'),
   }
+  const nextContent = `${content}${separator}${blockFor(metadata)}`
   return {
     action: 'write',
-    content: `${content}${separator}${blockFor(metadata)}`,
+    content: nextContent,
+    contentBytes: Buffer.from(nextContent, 'utf8'),
     filename,
+    originalBytes,
     originalContent: content,
     originalFileExisted: existed,
   }
@@ -193,6 +237,7 @@ const removalPlan = (root: string, filename: (typeof FILENAMES)[number]): FilePl
     return {
       action: 'none',
       filename,
+      originalBytes: Buffer.alloc(0),
       originalContent: '',
       originalFileExisted: false,
     }
@@ -200,15 +245,14 @@ const removalPlan = (root: string, filename: (typeof FILENAMES)[number]): FilePl
   if (!fileMetadata.isFile() || fileMetadata.isSymbolicLink()) {
     return fail('VALIDATION_FAILED', `${filename} must be a regular non-symlink file.`)
   }
-  const content = readFileSync(path, 'utf8')
-  if (content.includes('\0')) {
-    return fail('VALIDATION_FAILED', `${filename} contains a NUL byte.`)
-  }
+  const originalBytes = readRegularFileBytes(path, filename)
+  const content = decodeInstructionBytes(filename, originalBytes)
   const installed = inspectBlock(content)
   if (installed === undefined) {
     return {
       action: 'none',
       filename,
+      originalBytes,
       originalContent: content,
       originalFileExisted: true,
     }
@@ -218,31 +262,20 @@ const removalPlan = (root: string, filename: (typeof FILENAMES)[number]): FilePl
     return {
       action: 'delete',
       filename,
+      originalBytes,
       originalContent: content,
       originalFileExisted: true,
     }
   }
+  const nextBytes = Buffer.from(contentWithoutBlock, 'utf8')
   return {
     action: 'write',
     content: contentWithoutBlock,
+    contentBytes: nextBytes,
     filename,
+    originalBytes,
     originalContent: content,
     originalFileExisted: true,
-  }
-}
-
-const noFollowFlag = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0
-const directoryFlag = typeof constants.O_DIRECTORY === 'number' ? constants.O_DIRECTORY : 0
-
-const readRegularFile = (path: string) => {
-  const descriptor = openSync(path, constants.O_RDONLY | noFollowFlag)
-  try {
-    if (!fstatSync(descriptor).isFile()) {
-      return fail('VALIDATION_FAILED', 'Managed instruction paths must remain regular files.')
-    }
-    return readFileSync(descriptor, 'utf8')
-  } finally {
-    closeSync(descriptor)
   }
 }
 
@@ -256,7 +289,7 @@ const assertPlanIsCurrent = (root: string, plan: FilePlan) => {
   if (metadata?.isSymbolicLink() === true || (metadata !== undefined && !metadata.isFile())) {
     return fail('VALIDATION_FAILED', `${plan.filename} must remain a regular non-symlink file.`)
   }
-  if (exists && readRegularFile(path) !== plan.originalContent) {
+  if (exists && !readRegularFileBytes(path, plan.filename).equals(plan.originalBytes)) {
     return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
   }
 }
@@ -352,7 +385,7 @@ const assertBackupUnchanged = (backupPath: string, plan: FilePlan) => {
   if (metadata === undefined || metadata.isSymbolicLink() || !metadata.isFile()) {
     return fail('VALIDATION_FAILED', `${plan.filename} must remain a regular non-symlink file.`)
   }
-  if (readRegularFile(backupPath) !== plan.originalContent) {
+  if (!readRegularFileBytes(backupPath, plan.filename).equals(plan.originalBytes)) {
     return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
   }
   return metadata
@@ -412,8 +445,7 @@ const cleanupTempFile = (tempPath: string, hooks: AtomicWriteHooks | undefined, 
 }
 
 const writePlan = (root: string, path: string, plan: FilePlan, hooks?: AtomicWriteHooks) => {
-  const content = plan.content ?? ''
-  const bytes = Buffer.from(content, 'utf8')
+  const bytes = plan.contentBytes ?? Buffer.alloc(0)
   const tempPath = tempPathFor(path)
   let descriptor: number | undefined
   let operationFailed = false

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -118,7 +118,10 @@ const boundedInstructionBytes = (filename: (typeof FILENAMES)[number], bytes: Bu
   if (bytes.length <= MAX_INSTRUCTION_FILE_BYTES) {
     return bytes
   }
-  return fail('VALIDATION_FAILED', `${filename} exceeds the 1 MiB instruction-file limit.`)
+  return fail(
+    'VALIDATION_FAILED',
+    `${filename} cannot fit the Encephalon managed block within the 1 MiB instruction-file limit.`,
+  )
 }
 
 const blockFor = (metadata: BlockMetadata) => {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -29,9 +29,12 @@ const createRoot = () => {
 
 const MAX_INSTRUCTION_FILE_BYTES = 1024 * 1024
 
-const assertErrorCode = (operation: () => unknown, code: string) => {
+const assertErrorCode = (operation: () => unknown, code: string, message?: RegExp) => {
   assert.throws(operation, (error: unknown) => {
     assert.equal((error as { code?: unknown }).code, code)
+    if (message) {
+      assert.match((error as Error).message, message)
+    }
     return true
   })
 }
@@ -254,7 +257,11 @@ describe('initialisation', () => {
     writeFileSync(agentsPath, originalAgents)
     writeFileSync(claudePath, originalClaude)
 
-    assertErrorCode(() => api.initEncephalon({ root }), 'VALIDATION_FAILED')
+    assertErrorCode(
+      () => api.initEncephalon({ root }),
+      'VALIDATION_FAILED',
+      /cannot fit the Encephalon managed block within the 1 MiB instruction-file limit/,
+    )
 
     assert.deepEqual(readFileSync(agentsPath), originalAgents)
     assert.deepEqual(readFileSync(claudePath), originalClaude)

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -245,15 +245,20 @@ describe('initialisation', () => {
     assert.equal(existsSync(join(root, 'encephalon')), false)
   })
 
-  test('accepts an instruction file exactly at the preflight size limit', () => {
+  test('rejects an instruction file that cannot fit the managed block without mutation', () => {
     const root = createRoot()
-    const path = join(root, 'AGENTS.md')
-    writeFileSync(path, Buffer.alloc(MAX_INSTRUCTION_FILE_BYTES, 0x61))
+    const agentsPath = join(root, 'AGENTS.md')
+    const claudePath = join(root, 'CLAUDE.md')
+    const originalAgents = Buffer.alloc(MAX_INSTRUCTION_FILE_BYTES, 0x61)
+    const originalClaude = Buffer.from('untouched')
+    writeFileSync(agentsPath, originalAgents)
+    writeFileSync(claudePath, originalClaude)
 
-    const [agentsPlan] = planInstructionChanges(root, false)
+    assertErrorCode(() => api.initEncephalon({ root }), 'VALIDATION_FAILED')
 
-    assert.equal(agentsPlan?.action, 'write')
-    assert.deepEqual(readFileSync(path), Buffer.alloc(MAX_INSTRUCTION_FILE_BYTES, 0x61))
+    assert.deepEqual(readFileSync(agentsPath), originalAgents)
+    assert.deepEqual(readFileSync(claudePath), originalClaude)
+    assert.equal(existsSync(join(root, 'encephalon')), false)
   })
 
   test('rejects an instruction file over the preflight size limit without mutation', () => {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -268,6 +268,27 @@ describe('initialisation', () => {
     assert.equal(existsSync(join(root, 'encephalon')), false)
   })
 
+  test('round-trips an instruction file whose managed bytes exactly reach the size limit', () => {
+    const root = createRoot()
+    const agentsPath = join(root, 'AGENTS.md')
+    writeFileSync(agentsPath, Buffer.from('a'))
+    const [samplePlan] = planInstructionChanges(root, false)
+    if (samplePlan?.action !== 'write' || samplePlan.contentBytes === undefined) {
+      assert.fail('Expected a write plan for a non-empty instruction file.')
+    }
+    const managedOverheadBytes = samplePlan.contentBytes.length - 1
+    const originalAgents = Buffer.alloc(MAX_INSTRUCTION_FILE_BYTES - managedOverheadBytes, 0x61)
+    writeFileSync(agentsPath, originalAgents)
+
+    api.initEncephalon({ root })
+
+    assert.equal(readFileSync(agentsPath).length, MAX_INSTRUCTION_FILE_BYTES)
+
+    api.initEncephalon({ remove: true, root })
+
+    assert.deepEqual(readFileSync(agentsPath), originalAgents)
+  })
+
   test('rejects an instruction file over the preflight size limit without mutation', () => {
     const root = createRoot()
     const agentsPath = join(root, 'AGENTS.md')

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -27,6 +27,15 @@ const createRoot = () => {
   return root
 }
 
+const MAX_INSTRUCTION_FILE_BYTES = 1024 * 1024
+
+const assertErrorCode = (operation: () => unknown, code: string) => {
+  assert.throws(operation, (error: unknown) => {
+    assert.equal((error as { code?: unknown }).code, code)
+    return true
+  })
+}
+
 afterEach(() => {
   roots.splice(0).forEach(removeTestRepository)
 })
@@ -195,6 +204,74 @@ describe('initialisation', () => {
     assert.equal(existsSync(join(root, 'encephalon')), false)
   })
 
+  const invalidUtf8Cases = [
+    ['overlong sequence', Buffer.from([0xc0, 0xaf])],
+    ['lone continuation byte', Buffer.from([0x80])],
+    ['truncated multibyte sequence', Buffer.from([0xe2, 0x82])],
+    ['malformed surrogate encoding', Buffer.from([0xed, 0xa0, 0x80])],
+  ] as const
+
+  for (const [name, bytes] of invalidUtf8Cases) {
+    test(`rejects instruction files containing invalid UTF-8: ${name}`, () => {
+      const root = createRoot()
+      const agentsPath = join(root, 'AGENTS.md')
+      const claudePath = join(root, 'CLAUDE.md')
+      const originalAgents = Buffer.concat([Buffer.from('# Guidance\n'), bytes, Buffer.from('\n')])
+      const originalClaude = Buffer.from('untouched')
+      writeFileSync(agentsPath, originalAgents)
+      writeFileSync(claudePath, originalClaude)
+
+      assertErrorCode(() => api.initEncephalon({ root }), 'VALIDATION_FAILED')
+
+      assert.deepEqual(readFileSync(agentsPath), originalAgents)
+      assert.deepEqual(readFileSync(claudePath), originalClaude)
+      assert.equal(existsSync(join(root, 'encephalon')), false)
+    })
+  }
+
+  test('rejects embedded NUL bytes without changing either instruction file', () => {
+    const root = createRoot()
+    const agentsPath = join(root, 'AGENTS.md')
+    const claudePath = join(root, 'CLAUDE.md')
+    const originalAgents = Buffer.from('before\0after')
+    const originalClaude = Buffer.from('untouched')
+    writeFileSync(agentsPath, originalAgents)
+    writeFileSync(claudePath, originalClaude)
+
+    assertErrorCode(() => api.initEncephalon({ root }), 'VALIDATION_FAILED')
+
+    assert.deepEqual(readFileSync(agentsPath), originalAgents)
+    assert.deepEqual(readFileSync(claudePath), originalClaude)
+    assert.equal(existsSync(join(root, 'encephalon')), false)
+  })
+
+  test('accepts an instruction file exactly at the preflight size limit', () => {
+    const root = createRoot()
+    const path = join(root, 'AGENTS.md')
+    writeFileSync(path, Buffer.alloc(MAX_INSTRUCTION_FILE_BYTES, 0x61))
+
+    const [agentsPlan] = planInstructionChanges(root, false)
+
+    assert.equal(agentsPlan?.action, 'write')
+    assert.deepEqual(readFileSync(path), Buffer.alloc(MAX_INSTRUCTION_FILE_BYTES, 0x61))
+  })
+
+  test('rejects an instruction file over the preflight size limit without mutation', () => {
+    const root = createRoot()
+    const agentsPath = join(root, 'AGENTS.md')
+    const claudePath = join(root, 'CLAUDE.md')
+    const originalAgents = Buffer.alloc(MAX_INSTRUCTION_FILE_BYTES + 1, 0x61)
+    const originalClaude = Buffer.from('untouched')
+    writeFileSync(agentsPath, originalAgents)
+    writeFileSync(claudePath, originalClaude)
+
+    assertErrorCode(() => api.initEncephalon({ root }), 'VALIDATION_FAILED')
+
+    assert.deepEqual(readFileSync(agentsPath), originalAgents)
+    assert.deepEqual(readFileSync(claudePath), originalClaude)
+    assert.equal(existsSync(join(root, 'encephalon')), false)
+  })
+
   test('rejects managed metadata containing a separator Encephalon never emits', () => {
     const root = createRoot()
     const separator = 'forged-separator'
@@ -240,6 +317,18 @@ describe('initialisation', () => {
 
     api.initEncephalon({ remove: true, root })
     assert.equal(readFileSync(path, 'utf8'), `${original}User addition.\r\n`)
+  })
+
+  test('round-trips mixed line endings and no-final-newline files byte-for-byte', () => {
+    const root = createRoot()
+    const path = join(root, 'AGENTS.md')
+    const original = Buffer.from('\uFEFF# Existing guidance\r\nKeep café\nNo final newline')
+    writeFileSync(path, original)
+
+    api.initEncephalon({ root })
+    api.initEncephalon({ remove: true, root })
+
+    assert.deepEqual(readFileSync(path), original)
   })
 
   test('atomically publishes instruction replacements and preserves the existing file mode', () => {


### PR DESCRIPTION
## Human summary

Rejects unsafe instruction files before Encephalon edits them and preserves every original byte outside the managed block, including BOMs and mixed line endings.

## Summary

This PR fixes MAR-2511 by making managed instruction-file preflight byte-preserving:

- reads existing `AGENTS.md` and `CLAUDE.md` files as raw bytes through verified no-follow descriptors
- rejects malformed UTF-8 with fatal decoding before either instruction file is changed
- rejects embedded NUL bytes with stable errors that do not echo file content
- adds a 1 MiB preflight size limit for existing instruction files
- stores original preflight bytes in instruction plans and compares current/backup state with `Buffer.equals`
- writes precomputed planned bytes rather than re-deriving bytes during publication
- preserves BOM bytes, LF, CRLF, mixed line endings, empty files, and no-final-newline content outside the managed span
- documents the managed instruction-file byte contract in the README and implementation plan

The tests cover overlong UTF-8, lone continuation bytes, truncated multibyte sequences, malformed surrogate encodings, embedded NULs, exact and over-limit file sizes, byte-for-byte add/remove round trips, and no-mutation behaviour for rejected inputs.
