### PR TITLE
[MAR-2512] Quarantine instruction deletions

### DIFF
--- a/encephalon/workflow/2bf81475-1e33-4350-8229-e614d09fd073.json
+++ b/encephalon/workflow/2bf81475-1e33-4350-8229-e614d09fd073.json
@@ -1,0 +1,19 @@
+{
+  "createdAt": "2026-08-08T08:38:03.178Z",
+  "id": "2bf81475-1e33-4350-8229-e614d09fd073",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Use Encephalon itself as a required workflow gate before confirming or pushing PR work in this repository.",
+    "lessons": [
+      "Before confirming a PR is ready, pushing PR updates, or merging PR work in this repository, query Encephalon state directly for relevant workflow and review learnings.",
+      "If a relevant workflow rule is missing from Encephalon state, add it through Encephalon itself before proceeding so future agents can retrieve it without relying on conversation context.",
+      "Use the repository-local Encephalon CLI or API, not CreateState, for durable project learnings in this repo."
+    ],
+    "verification": [
+      "Run an Encephalon search or gather command before PR push/confirmation steps and cite the retrieved state in the working notes."
+    ]
+  },
+  "searchText": "Use Encephalon before PR confirmation and push",
+  "source": "agent",
+  "subject": "workflow.encephalon-pr-gate"
+}

--- a/encephalon/workflow/30c54e99-87db-4922-b01c-1af6a20d54c0.json
+++ b/encephalon/workflow/30c54e99-87db-4922-b01c-1af6a20d54c0.json
@@ -1,0 +1,20 @@
+{
+  "createdAt": "2026-08-08T08:33:42.663Z",
+  "id": "30c54e99-87db-4922-b01c-1af6a20d54c0",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Pullfrog PR #9 found that delete quarantine must be revalidated immediately before unlinking it.",
+    "lessons": [
+      "Verification before a fault-injection or callback boundary is not enough when the quarantined inode can still be mutated through an existing descriptor.",
+      "For quarantined instruction deletes, revalidate the quarantined inode identity and bytes immediately before the unlink commit point, after any hook or callback that could allow concurrent mutation.",
+      "If final revalidation fails, restore the changed quarantine to the public path when possible or leave the changed quarantine recoverable; do not silently discard descriptor writes."
+    ],
+    "verification": [
+      "Add POSIX descriptor-race tests that mutate the quarantined instruction file after delete verification and assert REPOSITORY_CHANGED with changed bytes still recoverable."
+    ]
+  },
+  "searchText": "Instruction delete final revalidation learning",
+  "source": "agent",
+  "subject": "review.github-pr-feedback",
+  "supersedes": ["bb3e1dcf-4d78-4740-9cde-2e1563b89d5f"]
+}

--- a/encephalon/workflow/a412b9a9-157d-4418-8c3d-e1f67bd1c097.json
+++ b/encephalon/workflow/a412b9a9-157d-4418-8c3d-e1f67bd1c097.json
@@ -1,0 +1,20 @@
+{
+  "createdAt": "2026-08-08T08:34:50.524Z",
+  "id": "a412b9a9-157d-4418-8c3d-e1f67bd1c097",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Pullfrog PR #9 found that instruction delete must not report post-unlink directory flush failures as failed mutations.",
+    "lessons": [
+      "For quarantined instruction deletes, successful unlink of the quarantine is the deletion commit point.",
+      "After the unlink commit point, directory fsync and other durability cleanup should be best-effort; do not throw an IO_ERROR that makes callers observe a failed mutation when retry would find the instruction file already absent.",
+      "Keep pre-commit unlink failures distinct from post-commit flush failures: pre-commit errors restore or preserve quarantine, post-commit errors do not roll back the committed delete."
+    ],
+    "verification": [
+      "Add regression coverage that injects a directory flush failure after quarantine unlink and asserts the delete call succeeds with no public path or stranded quarantine."
+    ]
+  },
+  "searchText": "Instruction delete commit point learning",
+  "source": "agent",
+  "subject": "review.github-pr-feedback",
+  "supersedes": ["30c54e99-87db-4922-b01c-1af6a20d54c0"]
+}

--- a/encephalon/workflow/bb3e1dcf-4d78-4740-9cde-2e1563b89d5f.json
+++ b/encephalon/workflow/bb3e1dcf-4d78-4740-9cde-2e1563b89d5f.json
@@ -1,0 +1,27 @@
+{
+  "createdAt": "2026-08-08T08:32:36.870Z",
+  "id": "bb3e1dcf-4d78-4740-9cde-2e1563b89d5f",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Consolidated PR review hardening lessons for Encephalon instruction and record publication, including Pullfrog PR #9 restore-race feedback.",
+    "lessons": [
+      "For managed instruction-file publication, do not rely on a preflight-only snapshot before replacing a user-owned file; capture and revalidate the current target at publication time so concurrent edits return REPOSITORY_CHANGED instead of being overwritten.",
+      "After renaming a user-owned file to a backup or quarantine path, treat that inode as still mutable through existing open descriptors; revalidate it before cleanup and leave changed bytes recoverable if validation fails.",
+      "When restoring a moved-aside backup or quarantined delete before the commit point, use create-if-absent publication for regular files instead of check-then-rename so recovery cannot overwrite a target recreated by another writer.",
+      "Validate the live public instruction path immediately before quarantining it; otherwise a directory, symlink, or different inode created after preflight can be moved aside and become impossible to restore safely.",
+      "For append-only canonical record publication, treat successful hard-link creation as the commit point. Post-publication cleanup, hydration, or directory fsync failures must not make callers observe a failed mutation that will collide on retry."
+    ],
+    "verification": [
+      "Add regression tests for each review comment when possible.",
+      "Use one commit per review-comment fix so replies can point to the exact change.",
+      "For deletion quarantine paths, test failures before unlink and races inside restore windows to prove replacements are preserved and quarantines remain recoverable."
+    ]
+  },
+  "searchText": "Consolidated PR review hardening lessons with quarantined delete restore races",
+  "source": "agent",
+  "subject": "review.github-pr-feedback",
+  "supersedes": [
+    "1fbe2c64-d1b7-4517-b640-35db963bb6e3",
+    "e49b75d4-bfea-470e-9f5b-ce645b483940"
+  ]
+}

--- a/encephalon/workflow/e49b75d4-bfea-470e-9f5b-ce645b483940.json
+++ b/encephalon/workflow/e49b75d4-bfea-470e-9f5b-ce645b483940.json
@@ -1,0 +1,32 @@
+{
+  "createdAt": "2026-08-08T02:04:28.950Z",
+  "id": "e49b75d4-bfea-470e-9f5b-ce645b483940",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Prevent repeat PR review issues found on MAR-2509, MAR-2510, and MAR-2512.",
+    "lessons": [
+      "For managed instruction-file publication, do not rely on a preflight-only snapshot before replacing a user-owned file; capture and revalidate the current target at publication time so concurrent edits return REPOSITORY_CHANGED instead of being overwritten.",
+      "Preserve mutable filesystem metadata from the file captured at publication time, not from the earlier plan, because owners can change permissions without changing bytes.",
+      "After renaming a user-owned file to a backup path, treat that backup inode as still mutable through existing open descriptors; revalidate it before cleanup and leave it recoverable if the bytes changed.",
+      "When restoring a moved-aside backup after a failed publication, use create-if-absent publication instead of check-then-rename so recovery cannot overwrite a target recreated by another writer.",
+      "Do not apply a final permission snapshot after publication if the source inode can still be changed through old descriptors; report pre-final mode drift and leave post-final drift recoverable on the backup instead.",
+      "When adding repository workflow guidance, keep Git commit subjects and PR titles prefixed with the Linear ticket in square brackets, for example [MAR-1234] Describe the change.",
+      "For append-only canonical record publication, treat successful hard-link creation as the commit point. Any post-publication cleanup or directory fsync failure must be best-effort and must not make the caller observe a failed mutation that will collide with RECORD_EXISTS on retry.",
+      "Cache hydration is derived state after canonical record publication. If hydration fails after the record commit point, return the committed record and let the next read rebuild cache state instead of reporting the mutation as failed.",
+      "For instruction-file deletion quarantine, the rename to a quarantine path is not the commit point. If any failure occurs before the quarantined file is unlinked while the public path is absent, restore the quarantine path or leave it visibly recoverable, and test failures after verification but before final unlink."
+    ],
+    "verification": [
+      "Search Encephalon before adding durable workflow lessons.",
+      "Add regression tests for each review comment when possible.",
+      "Use one commit per review-comment fix so replies can point to the exact change.",
+      "For publication paths, add tests for failures both before and after the commit point so successful commits are not misreported as failures.",
+      "For deletion quarantine paths, inject failures after quarantine and after verification to prove user-visible paths are restored until deletion has actually committed."
+    ]
+  },
+  "searchText": "PR review hardening lessons for Encephalon record and instruction publication",
+  "source": "agent",
+  "subject": "review.github-pr-feedback",
+  "supersedes": [
+    "a46c2d81-6579-4f27-a927-5dc07644cf38"
+  ]
+}

--- a/encephalon/workflow/e49b75d4-bfea-470e-9f5b-ce645b483940.json
+++ b/encephalon/workflow/e49b75d4-bfea-470e-9f5b-ce645b483940.json
@@ -26,7 +26,5 @@
   "searchText": "PR review hardening lessons for Encephalon record and instruction publication",
   "source": "agent",
   "subject": "review.github-pr-feedback",
-  "supersedes": [
-    "a46c2d81-6579-4f27-a927-5dc07644cf38"
-  ]
+  "supersedes": ["a46c2d81-6579-4f27-a927-5dc07644cf38"]
 }

--- a/encephalon/workflow/e744ddc1-2a30-4e13-9165-3f392b6c4e15.json
+++ b/encephalon/workflow/e744ddc1-2a30-4e13-9165-3f392b6c4e15.json
@@ -14,6 +14,5 @@
   },
   "searchText": "Encephalon dogfooding gitignore state records visible git staging",
   "source": "agent",
-  "subject": "workflow.gitignore-dogfooding",
-  "supersedes": []
+  "subject": "workflow.gitignore-dogfooding"
 }

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -463,6 +463,7 @@ const deletePlan = (path: string, plan: FilePlan, hooks: AtomicWriteHooks | unde
     fault(hooks, 'after-delete-quarantine')
     assertQuarantinedDeleteTarget(quarantinePath, plan)
     fault(hooks, 'after-delete-verification')
+    assertQuarantinedDeleteTarget(quarantinePath, plan)
     rmSync(quarantinePath, { force: true })
     fsyncDirectory(dirname(path))
   } catch (error) {

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -333,6 +333,7 @@ type AtomicWriteFault =
   | 'after-final-backup-validation'
   | 'after-plan-validation'
   | 'before-deletion'
+  | 'during-quarantine-restore'
   | 'before-temp-create'
   | 'during-backup-restore'
   | 'during-file-flush'
@@ -426,10 +427,12 @@ const assertBackupUnchanged = (backupPath: string, plan: FilePlan) => {
   return metadata
 }
 
-const restoreQuarantinedFile = (path: string, quarantinePath: string) => {
+const restoreQuarantinedFile = (path: string, quarantinePath: string, hooks: AtomicWriteHooks | undefined) => {
   try {
     if (lstatIfExists(path) === undefined && lstatIfExists(quarantinePath) !== undefined) {
-      renameSync(quarantinePath, path)
+      fault(hooks, 'during-quarantine-restore')
+      linkSync(quarantinePath, path)
+      rmSync(quarantinePath, { force: true })
     }
   } catch {
     // Keep the quarantined file in place so the inspected bytes remain recoverable.
@@ -454,6 +457,7 @@ const deletePlan = (path: string, plan: FilePlan, hooks: AtomicWriteHooks | unde
   let quarantined = false
   try {
     fault(hooks, 'before-deletion')
+    assertQuarantinedDeleteTarget(path, plan)
     renameSync(path, quarantinePath)
     quarantined = true
     fault(hooks, 'after-delete-quarantine')
@@ -463,7 +467,7 @@ const deletePlan = (path: string, plan: FilePlan, hooks: AtomicWriteHooks | unde
     fsyncDirectory(dirname(path))
   } catch (error) {
     if (quarantined) {
-      restoreQuarantinedFile(path, quarantinePath)
+      restoreQuarantinedFile(path, quarantinePath, hooks)
     }
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -333,6 +333,7 @@ type AtomicWriteFault =
   | 'after-final-backup-validation'
   | 'after-plan-validation'
   | 'before-deletion'
+  | 'during-delete-flush'
   | 'during-quarantine-restore'
   | 'before-temp-create'
   | 'during-backup-restore'
@@ -465,7 +466,12 @@ const deletePlan = (path: string, plan: FilePlan, hooks: AtomicWriteHooks | unde
     fault(hooks, 'after-delete-verification')
     assertQuarantinedDeleteTarget(quarantinePath, plan)
     rmSync(quarantinePath, { force: true })
-    fsyncDirectory(dirname(path))
+    try {
+      fault(hooks, 'during-delete-flush')
+      fsyncDirectory(dirname(path))
+    } catch {
+      // The quarantine unlink is the deletion commit point; do not report a committed deletion as failed.
+    }
   } catch (error) {
     if (quarantined) {
       restoreQuarantinedFile(path, quarantinePath, hooks)

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import type { Stats } from 'node:fs'
 import {
   chmodSync,
   closeSync,
@@ -38,6 +39,12 @@ type FilePlan = {
   originalBytes: Buffer
   originalContent: string
   originalFileExisted: boolean
+  originalIdentity?: FileIdentity
+}
+
+type FileIdentity = {
+  dev: number
+  ino: number
 }
 
 const ALLOWED_SEPARATORS = new Set(['', '\n', '\n\n', '\r\n', '\r\n\r\n'])
@@ -46,6 +53,14 @@ const MAX_INSTRUCTION_FILE_BYTES = 1024 * 1024
 const noFollowFlag = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0
 const directoryFlag = typeof constants.O_DIRECTORY === 'number' ? constants.O_DIRECTORY : 0
 const utf8Decoder = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true })
+
+const identityFor = (metadata: Stats): FileIdentity => ({
+  dev: metadata.dev,
+  ino: metadata.ino,
+})
+
+const sameIdentity = (left: FileIdentity | undefined, right: FileIdentity) =>
+  left !== undefined && left.dev === right.dev && left.ino === right.ino
 
 const lstatIfExists = (path: string) => {
   try {
@@ -215,6 +230,7 @@ const additionPlan = (root: string, filename: (typeof FILENAMES)[number]): FileP
       originalBytes,
       originalContent: content,
       originalFileExisted: existed,
+      ...(existingMetadata === undefined ? {} : { originalIdentity: identityFor(existingMetadata) }),
     }
   }
   const lineEnding = lineEndingFor(content)
@@ -236,6 +252,7 @@ const additionPlan = (root: string, filename: (typeof FILENAMES)[number]): FileP
     contentBytes: nextBytes,
     filename,
     originalBytes,
+    ...(existingMetadata === undefined ? {} : { originalIdentity: identityFor(existingMetadata) }),
     originalContent: content,
     originalFileExisted: existed,
   }
@@ -266,6 +283,7 @@ const removalPlan = (root: string, filename: (typeof FILENAMES)[number]): FilePl
       originalBytes,
       originalContent: content,
       originalFileExisted: true,
+      originalIdentity: identityFor(fileMetadata),
     }
   }
   const contentWithoutBlock = `${content.slice(0, installed.start - installed.separator.length)}${content.slice(installed.end)}`
@@ -276,6 +294,7 @@ const removalPlan = (root: string, filename: (typeof FILENAMES)[number]): FilePl
       originalBytes,
       originalContent: content,
       originalFileExisted: true,
+      originalIdentity: identityFor(fileMetadata),
     }
   }
   const nextBytes = Buffer.from(contentWithoutBlock, 'utf8')
@@ -287,6 +306,7 @@ const removalPlan = (root: string, filename: (typeof FILENAMES)[number]): FilePl
     originalBytes,
     originalContent: content,
     originalFileExisted: true,
+    originalIdentity: identityFor(fileMetadata),
   }
 }
 
@@ -308,7 +328,11 @@ const assertPlanIsCurrent = (root: string, plan: FilePlan) => {
 type AtomicWriteFault =
   | 'after-publication'
   | 'after-backup-validation'
+  | 'after-delete-quarantine'
+  | 'after-delete-verification'
   | 'after-final-backup-validation'
+  | 'after-plan-validation'
+  | 'before-deletion'
   | 'before-temp-create'
   | 'during-backup-restore'
   | 'during-file-flush'
@@ -400,6 +424,54 @@ const assertBackupUnchanged = (backupPath: string, plan: FilePlan) => {
     return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
   }
   return metadata
+}
+
+const restoreQuarantinedFile = (path: string, quarantinePath: string) => {
+  try {
+    if (lstatIfExists(path) === undefined && lstatIfExists(quarantinePath) !== undefined) {
+      renameSync(quarantinePath, path)
+    }
+  } catch {
+    // Keep the quarantined file in place so the inspected bytes remain recoverable.
+  }
+}
+
+const assertQuarantinedDeleteTarget = (quarantinePath: string, plan: FilePlan) => {
+  const metadata = lstatIfExists(quarantinePath)
+  if (metadata === undefined || metadata.isSymbolicLink() || !metadata.isFile()) {
+    return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
+  }
+  if (!sameIdentity(plan.originalIdentity, identityFor(metadata))) {
+    return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
+  }
+  if (!readRegularFileBytes(quarantinePath, plan.filename).equals(plan.originalBytes)) {
+    return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
+  }
+}
+
+const deletePlan = (path: string, plan: FilePlan, hooks: AtomicWriteHooks | undefined) => {
+  const quarantinePath = tempPathFor(path, 'delete')
+  let quarantined = false
+  let verified = false
+  try {
+    fault(hooks, 'before-deletion')
+    renameSync(path, quarantinePath)
+    quarantined = true
+    fault(hooks, 'after-delete-quarantine')
+    assertQuarantinedDeleteTarget(quarantinePath, plan)
+    verified = true
+    fault(hooks, 'after-delete-verification')
+    rmSync(quarantinePath, { force: true })
+    fsyncDirectory(dirname(path))
+  } catch (error) {
+    if (quarantined && !verified) {
+      restoreQuarantinedFile(path, quarantinePath)
+    }
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
+    }
+    throw error
+  }
 }
 
 const publishTempFile = (path: string, tempPath: string, plan: FilePlan, hooks: AtomicWriteHooks | undefined) => {
@@ -502,10 +574,11 @@ export const applyInstructionChanges = (root: string, plans: FilePlan[], hooks?:
         assertPlanIsCurrent(root, plan)
       }
     }
+    fault(hooks, 'after-plan-validation')
     for (const plan of plans) {
       const path = resolve(root, plan.filename)
       if (plan.action === 'delete') {
-        rmSync(path)
+        deletePlan(path, plan, hooks)
       }
       if (plan.action === 'write') {
         writePlan(root, path, plan, hooks)

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -452,19 +452,17 @@ const assertQuarantinedDeleteTarget = (quarantinePath: string, plan: FilePlan) =
 const deletePlan = (path: string, plan: FilePlan, hooks: AtomicWriteHooks | undefined) => {
   const quarantinePath = tempPathFor(path, 'delete')
   let quarantined = false
-  let verified = false
   try {
     fault(hooks, 'before-deletion')
     renameSync(path, quarantinePath)
     quarantined = true
     fault(hooks, 'after-delete-quarantine')
     assertQuarantinedDeleteTarget(quarantinePath, plan)
-    verified = true
     fault(hooks, 'after-delete-verification')
     rmSync(quarantinePath, { force: true })
     fsyncDirectory(dirname(path))
   } catch (error) {
-    if (quarantined && !verified) {
+    if (quarantined) {
       restoreQuarantinedFile(path, quarantinePath)
     }
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -573,6 +573,31 @@ describe('initialisation', () => {
     assert.equal(readFileSync(path, 'utf8'), replacement)
   })
 
+  test('restores the quarantined instruction file when final unlink fails', () => {
+    const root = createRoot()
+    const path = join(root, 'AGENTS.md')
+    const agentsPlan = createDeletePlan(root)
+    const original = readFileSync(path, 'utf8')
+
+    assertErrorCode(
+      () =>
+        applyInstructionChanges(root, [agentsPlan], {
+          fault: point => {
+            if (point === 'after-delete-verification') {
+              throw new Error('Injected final unlink failure')
+            }
+          },
+        }),
+      'IO_ERROR',
+    )
+
+    assert.equal(readFileSync(path, 'utf8'), original)
+    assert.deepEqual(
+      readdirSync(root).filter(filename => filename.includes('.AGENTS.md.') && filename.endsWith('.delete')),
+      [],
+    )
+  })
+
   test('keeps old-descriptor writes recoverable after backup validation', {
     skip: process.platform === 'win32' ? 'Windows does not allow this POSIX descriptor race.' : false,
   }, () => {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -598,6 +598,39 @@ describe('initialisation', () => {
     )
   })
 
+  test('keeps old-descriptor writes recoverable after delete verification', {
+    skip: process.platform === 'win32' ? 'Windows does not allow this POSIX descriptor race.' : false,
+  }, () => {
+    const root = createRoot()
+    const path = join(root, 'AGENTS.md')
+    const agentsPlan = createDeletePlan(root)
+    const changed = '# Descriptor delete edit\n'
+    const descriptor = openSync(path, 'r+')
+
+    try {
+      assertErrorCode(
+        () =>
+          applyInstructionChanges(root, [agentsPlan], {
+            fault: point => {
+              if (point === 'after-delete-verification') {
+                ftruncateSync(descriptor, 0)
+                writeSync(descriptor, changed, 0, 'utf8')
+              }
+            },
+          }),
+        'REPOSITORY_CHANGED',
+      )
+    } finally {
+      closeSync(descriptor)
+    }
+
+    assert.equal(readFileSync(path, 'utf8'), changed)
+    assert.deepEqual(
+      readdirSync(root).filter(filename => filename.includes('.AGENTS.md.') && filename.endsWith('.delete')),
+      [],
+    )
+  })
+
   test('keeps old-descriptor writes recoverable after backup validation', {
     skip: process.platform === 'win32' ? 'Windows does not allow this POSIX descriptor race.' : false,
   }, () => {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -668,6 +668,36 @@ describe('initialisation', () => {
     assert.equal(readFileSync(join(root, backupName), 'utf8'), original)
   })
 
+  test('does not overwrite files created while restoring a quarantined delete', () => {
+    const root = createRoot()
+    const path = join(root, 'AGENTS.md')
+    const agentsPlan = createDeletePlan(root)
+    const original = readFileSync(path, 'utf8')
+    const replacement = '# Concurrent delete restore guidance\n'
+
+    assertErrorCode(
+      () =>
+        applyInstructionChanges(root, [agentsPlan], {
+          fault: point => {
+            if (point === 'after-delete-verification') {
+              throw new Error('Injected deletion failure')
+            }
+            if (point === 'during-quarantine-restore') {
+              writeFileSync(path, replacement)
+            }
+          },
+        }),
+      'IO_ERROR',
+    )
+
+    const [quarantineName] = readdirSync(root).filter(
+      name => name.startsWith('.AGENTS.md.') && name.endsWith('.delete'),
+    )
+    assert.ok(quarantineName)
+    assert.equal(readFileSync(path, 'utf8'), replacement)
+    assert.equal(readFileSync(join(root, quarantineName), 'utf8'), original)
+  })
+
   test('reports old-descriptor mode changes after backup validation', {
     skip: process.platform === 'win32' ? 'Windows does not expose POSIX mode changes consistently.' : false,
   }, () => {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -5,15 +5,17 @@ import {
   existsSync,
   fchmodSync,
   ftruncateSync,
+  mkdirSync,
   openSync,
   readdirSync,
   readFileSync,
+  rmSync,
   statSync,
   symlinkSync,
   writeFileSync,
   writeSync,
 } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { afterEach, describe, test } from 'node:test'
 import * as api from '../src/index.ts'
 import { applyInstructionChanges, planInstructionChanges } from '../src/instructions.ts'
@@ -37,6 +39,13 @@ const assertErrorCode = (operation: () => unknown, code: string, message?: RegEx
     }
     return true
   })
+}
+
+const createDeletePlan = (root: string) => {
+  api.initEncephalon({ root })
+  const [agentsPlan] = planInstructionChanges(root, true)
+  assert.equal(agentsPlan?.action, 'delete')
+  return agentsPlan
 }
 
 afterEach(() => {
@@ -445,6 +454,123 @@ describe('initialisation', () => {
       },
     )
     assert.equal(readFileSync(path, 'utf8'), changed)
+  })
+
+  test('does not delete an instruction file replaced after global plan validation', () => {
+    const root = createRoot()
+    const path = join(root, 'AGENTS.md')
+    const agentsPlan = createDeletePlan(root)
+    const replacement = '# Replacement guidance\n'
+
+    assertErrorCode(
+      () =>
+        applyInstructionChanges(root, [agentsPlan], {
+          fault: point => {
+            if (point === 'after-plan-validation') {
+              writeFileSync(path, replacement)
+            }
+          },
+        }),
+      'REPOSITORY_CHANGED',
+    )
+    assert.equal(readFileSync(path, 'utf8'), replacement)
+  })
+
+  const preDeletionReplacementCases = [
+    {
+      assertReplacement: (path: string, replacement: string) => assert.equal(readFileSync(path, 'utf8'), replacement),
+      name: 'regular file',
+      replace: (path: string, replacement: string) => writeFileSync(path, replacement),
+      skip: false,
+    },
+    {
+      assertReplacement: (path: string, replacement: string) => assert.equal(readFileSync(path, 'utf8'), replacement),
+      name: 'different file containing identical bytes',
+      replace: (path: string, replacement: string) => {
+        rmSync(path)
+        writeFileSync(path, replacement)
+      },
+      skip: false,
+    },
+    {
+      assertReplacement: (path: string, replacement: string) => assert.equal(readFileSync(path, 'utf8'), replacement),
+      name: 'symlink',
+      replace: (path: string, replacement: string) => {
+        const target = join(dirname(path), 'replacement-target.md')
+        rmSync(path)
+        writeFileSync(target, replacement)
+        symlinkSync(target, path)
+      },
+      skip: process.platform === 'win32',
+    },
+    {
+      assertReplacement: (path: string) => assert.equal(statSync(path).isDirectory(), true),
+      name: 'directory',
+      replace: (path: string) => {
+        rmSync(path)
+        mkdirSync(path)
+      },
+      skip: false,
+    },
+  ] as const
+
+  for (const replacementCase of preDeletionReplacementCases) {
+    test(`does not delete a ${replacementCase.name} replacement immediately before deletion`, {
+      skip: replacementCase.skip ? 'Windows runners may not permit file symlink creation.' : false,
+    }, () => {
+      const root = createRoot()
+      const path = join(root, 'AGENTS.md')
+      const agentsPlan = createDeletePlan(root)
+      const replacement =
+        replacementCase.name === 'regular file' ? '# Replacement guidance\n' : readFileSync(path, 'utf8')
+
+      assertErrorCode(
+        () =>
+          applyInstructionChanges(root, [agentsPlan], {
+            fault: point => {
+              if (point === 'before-deletion') {
+                replacementCase.replace(path, replacement)
+              }
+            },
+          }),
+        'REPOSITORY_CHANGED',
+      )
+      replacementCase.assertReplacement(path, replacement)
+    })
+  }
+
+  test('does not delete a replacement created after deletion quarantine', () => {
+    const root = createRoot()
+    const path = join(root, 'AGENTS.md')
+    const agentsPlan = createDeletePlan(root)
+    const replacement = '# Replacement after quarantine\n'
+
+    applyInstructionChanges(root, [agentsPlan], {
+      fault: point => {
+        if (point === 'after-delete-quarantine') {
+          writeFileSync(path, replacement)
+        }
+      },
+    })
+
+    assert.equal(readFileSync(path, 'utf8'), replacement)
+  })
+
+  test('does not delete a replacement created after deletion verification', () => {
+    const root = createRoot()
+    const path = join(root, 'AGENTS.md')
+    const agentsPlan = createDeletePlan(root)
+    const replacement = '# Replacement after verification\n'
+
+    applyInstructionChanges(root, [agentsPlan], {
+      fault: point => {
+        if (point === 'after-delete-verification') {
+          writeFileSync(path, replacement)
+        }
+      },
+    })
+
+    assert.equal(readFileSync(path, 'utf8'), replacement)
   })
 
   test('keeps old-descriptor writes recoverable after backup validation', {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -631,6 +631,26 @@ describe('initialisation', () => {
     )
   })
 
+  test('does not misreport directory flush failure after committed delete', () => {
+    const root = createRoot()
+    const path = join(root, 'AGENTS.md')
+    const agentsPlan = createDeletePlan(root)
+
+    applyInstructionChanges(root, [agentsPlan], {
+      fault: point => {
+        if (point === 'during-delete-flush') {
+          throw new Error('Injected delete flush failure')
+        }
+      },
+    })
+
+    assert.equal(existsSync(path), false)
+    assert.deepEqual(
+      readdirSync(root).filter(filename => filename.includes('.AGENTS.md.') && filename.endsWith('.delete')),
+      [],
+    )
+  })
+
   test('keeps old-descriptor writes recoverable after backup validation', {
     skip: process.platform === 'win32' ? 'Windows does not allow this POSIX descriptor race.' : false,
   }, () => {


### PR DESCRIPTION
## Human summary

Makes `init --remove` delete only the exact instruction file it inspected, so concurrent replacements are left intact instead of being removed accidentally.

## Summary

This PR fixes MAR-2512 by making managed instruction-file deletion race-safe:

- records the device/inode identity of preflighted instruction files
- adds a quarantine-and-verify deletion path for `delete` plans
- renames the delete candidate to a same-directory quarantine path before unlinking it
- verifies the quarantined file still matches the preflight identity and bytes
- restores an unverified quarantined replacement when verification fails
- restores quarantined files when a post-verification unlink failure would otherwise leave the public path absent
- removes the bare `rmSync(path)` deletion after detached validation
- adds deterministic deletion fault hooks for validation, quarantine, verification, and final unlink windows
- preserves replacement files created before deletion, after quarantine, or after verification
- saves the MAR-2512 review lesson in Encephalon workflow memory so future deletion-quarantine fixes test the final unlink window

The tests cover regular-file replacement, symlink replacement, directory replacement, a different file with identical bytes, replacement after global validation, replacement immediately before deletion, replacement after quarantine, replacement after verification, and restoration after a final unlink failure.