### PR TITLE
[MAR-2514] Repair generated baseline heads

### DIFF
--- a/encephalon/workflow/7dfe930e-528c-412a-ab16-29bda86aa378.json
+++ b/encephalon/workflow/7dfe930e-528c-412a-ab16-29bda86aa378.json
@@ -1,0 +1,20 @@
+{
+  "createdAt": "2026-08-08T09:04:43.199Z",
+  "id": "7dfe930e-528c-412a-ab16-29bda86aa378",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Use Pullfrog reviews patiently and avoid duplicate or model-flag triggers unless a run reaches a terminal failure.",
+    "lessons": [
+      "Trigger Pullfrog reviews with a plain @pullfrog comment unless the user gives a different exact trigger.",
+      "After Pullfrog starts, allow significant time for the OSS tool to run; do not cancel, retry, or trigger duplicates merely because the agent step is quiet for several minutes.",
+      "Treat provider/model availability messages as external review-tool state, not code feedback. Only change repository code for actionable review comments or project workflow learnings.",
+      "Before confirming readiness or pushing/merging PR work, use Encephalon directly in this repository to retrieve relevant workflow learnings."
+    ],
+    "verification": [
+      "Check PR comments, review threads, and status checks for terminal Pullfrog results before deciding whether another @pullfrog trigger is necessary."
+    ]
+  },
+  "searchText": "Pullfrog review trigger and wait policy",
+  "source": "agent",
+  "subject": "workflow.pullfrog-review-gate"
+}

--- a/src/init.ts
+++ b/src/init.ts
@@ -3,7 +3,7 @@ import { hydrateResolvedRepository } from './cache.ts'
 import { EncephalonError, fail, wrapIo } from './errors.ts'
 import { applyInstructionChanges, planInstructionChanges } from './instructions.ts'
 import { withOperationLock } from './lock.ts'
-import { addRecordResolved, readRecords } from './records.ts'
+import { addRecordResolved, readRecords, readRecordsAllowingGeneratedMultiHeads } from './records.ts'
 import { resolveRepository } from './repository.ts'
 import type { AddRecordInput, BrainRecord, InitEncephalonInput, InitEncephalonResult } from './types.ts'
 
@@ -43,7 +43,8 @@ const baselineActions = (records: BrainRecord[], baseline: AddRecordInput[], ref
       }
       if (
         refresh &&
-        matching.some(record => canonicalPayload(record.payload) !== canonicalPayload(candidate.payload))
+        (matching.length > 1 ||
+          matching.some(record => canonicalPayload(record.payload) !== canonicalPayload(candidate.payload)))
       ) {
         return {
           ...result,
@@ -61,6 +62,18 @@ const baselineActions = (records: BrainRecord[], baseline: AddRecordInput[], ref
     { additions: [], conflicts: [] },
   )
 
+const readBaselineRecords = (root: string, baseline: AddRecordInput[], refresh: boolean) =>
+  refresh
+    ? readRecordsAllowingGeneratedMultiHeads(
+        { root },
+        baseline.map(candidate => ({
+          kind: candidate.kind,
+          source: 'encephalon:init',
+          subject: candidate.subject,
+        })),
+      )
+    : readRecords({ root })
+
 const initResolved = (input: InitEncephalonInput): InitEncephalonResult => {
   if (input.remove === true && input.refreshBaseline === true) {
     return fail('INVALID_ARGUMENT', 'init cannot refresh and remove managed instructions in the same operation.')
@@ -77,10 +90,15 @@ const initResolved = (input: InitEncephalonInput): InitEncephalonResult => {
     }))
   }
 
-  readRecords({ root })
+  readBaselineRecords(root, scanBaseline(root), input.refreshBaseline === true)
   return withOperationLock(root, () => {
     const instructionPlans = planInstructionChanges(root, false)
-    const actions = baselineActions(readRecords({ root }), scanBaseline(root), input.refreshBaseline === true)
+    const baseline = scanBaseline(root)
+    const actions = baselineActions(
+      readBaselineRecords(root, baseline, input.refreshBaseline === true),
+      baseline,
+      input.refreshBaseline === true,
+    )
     const recordsCreated = actions.additions.map(addition =>
       addRecordResolved(root, { ...addition, root }, { hydrate: false }),
     )

--- a/src/records.ts
+++ b/src/records.ts
@@ -68,6 +68,12 @@ type ValidateRecordsOptions = {
   hooks?: RecordReadHooks
 }
 
+type AllowedMultiHead = {
+  kind: string
+  source: string
+  subject: string
+}
+
 const STAGING_DIRECTORY = '_staging'
 const RESERVED_DIRECTORIES = new Set(['_artifacts', STAGING_DIRECTORY])
 const directoryFlag = constants.O_DIRECTORY ?? 0
@@ -499,6 +505,31 @@ const validateScanned = (root: string, scan: RecordScan): ValidateResult => {
   }
 }
 
+const allowedMultiHeadRecordIds = (records: BrainRecord[], allowed: AllowedMultiHead[]) => {
+  const allowedKeys = new Set(allowed.map(candidate => `${candidate.kind}\0${candidate.subject}\0${candidate.source}`))
+  const superseded = new Set(records.flatMap(record => record.supersedes ?? []))
+  return [
+    ...records
+      .filter(record => !superseded.has(record.id))
+      .reduce<Map<string, BrainRecord[]>>((groups, record) => {
+        const key = `${record.kind}\0${record.subject}`
+        groups.set(key, [...(groups.get(key) ?? []), record])
+        return groups
+      }, new Map())
+      .values(),
+  ].reduce<Set<string>>((ids, group) => {
+    const [first] = group
+    if (
+      first !== undefined &&
+      group.length > 1 &&
+      group.every(record => allowedKeys.has(`${record.kind}\0${record.subject}\0${record.source}`))
+    ) {
+      return new Set([...ids, ...group.map(record => record.id)])
+    }
+    return ids
+  }, new Set())
+}
+
 export const validateRecordsResolved = (root: string, options: ValidateRecordsOptions = {}): ValidateResult => {
   try {
     return validateScanned(root, scanCanonicalRecords(root, options))
@@ -524,6 +555,26 @@ export const readRecords = (input: RootInput = {}) => {
   }
   return fail('VALIDATION_FAILED', 'Canonical records are invalid.', {
     errors: result.errors.map(error => ({
+      code: error.code,
+      message: error.message,
+    })),
+  })
+}
+
+export const readRecordsAllowingGeneratedMultiHeads = (input: RootInput, allowed: AllowedMultiHead[]) => {
+  const root = resolveRepository(input)
+  const scan = scanCanonicalRecords(root)
+  const result = validateScanned(root, scan)
+  const allowedIds = allowedMultiHeadRecordIds(scan.records, allowed)
+  const blockingErrors = result.errors.filter(
+    error =>
+      !(error.code === 'MULTIPLE_ACTIVE_HEADS' && error.recordId !== undefined && allowedIds.has(error.recordId)),
+  )
+  if (blockingErrors.length === 0) {
+    return scan.records
+  }
+  return fail('VALIDATION_FAILED', 'Canonical records are invalid.', {
+    errors: blockingErrors.map(error => ({
       code: error.code,
       message: error.message,
     })),

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -19,6 +19,7 @@ import { dirname, join } from 'node:path'
 import { afterEach, describe, test } from 'node:test'
 import * as api from '../src/index.ts'
 import { applyInstructionChanges, planInstructionChanges } from '../src/instructions.ts'
+import type { BrainRecord, BrainRecordFile } from '../src/types.ts'
 import { createTestRepository, ensureParent, removeTestRepository } from '../test/helpers.ts'
 
 const roots: string[] = []
@@ -46,6 +47,44 @@ const createDeletePlan = (root: string) => {
   const [agentsPlan] = planInstructionChanges(root, true)
   assert.equal(agentsPlan?.action, 'delete')
   return agentsPlan
+}
+
+const recordsForSubject = (root: string, subject: string) =>
+  api.listRecords({ includeSuperseded: true, limit: 50, root }).filter(record => record.subject === subject)
+
+const activeRecordsForSubject = (root: string, subject: string) =>
+  api.listRecords({ limit: 50, root }).filter(record => record.subject === subject)
+
+const readRecordFile = (root: string, record: BrainRecord): BrainRecordFile =>
+  JSON.parse(readFileSync(join(root, record.path), 'utf8')) as BrainRecordFile
+
+const writeRecordFile = (root: string, record: BrainRecordFile) => {
+  const path = join(root, 'encephalon', record.kind, `${record.id}.json`)
+  ensureParent(path)
+  writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`)
+}
+
+const rawRecordFilesForSubject = (root: string, kind: string, subject: string) =>
+  readdirSync(join(root, 'encephalon', kind))
+    .filter(name => name.endsWith('.json'))
+    .map(name => JSON.parse(readFileSync(join(root, 'encephalon', kind, name), 'utf8')) as BrainRecordFile)
+    .filter(record => record.subject === subject)
+
+const cloneBaselineRecord = (
+  root: string,
+  subject: string,
+  id: string,
+  overrides: Partial<Pick<BrainRecordFile, 'payload' | 'source' | 'supersedes'>> = {},
+) => {
+  const [record] = recordsForSubject(root, subject)
+  assert.ok(record)
+  const cloned = {
+    ...readRecordFile(root, record),
+    id,
+    ...overrides,
+  }
+  writeRecordFile(root, cloned)
+  return { cloned, original: record }
 }
 
 afterEach(() => {
@@ -149,6 +188,149 @@ describe('initialisation', () => {
     assert.match(JSON.stringify(workflow[0]?.payload), /npm run lint/)
     assert.doesNotMatch(JSON.stringify(workflow[0]?.payload), /lint-private-body/)
     assert.equal(api.listRecords({ limit: 20, root }).length, 3)
+  })
+
+  test('refresh resolves equivalent generated baseline heads from branch merges', () => {
+    const root = createRoot()
+    api.initEncephalon({ root })
+    const subject = 'encephalon:init/repository-overview'
+    const { cloned, original } = cloneBaselineRecord(root, subject, 'parallel-overview')
+
+    const refreshed = api.initEncephalon({ refreshBaseline: true, root })
+
+    assert.equal(refreshed.recordsCreated.length, 1)
+    const [resolver] = refreshed.recordsCreated
+    assert.ok(resolver)
+    assert.equal(resolver.subject, subject)
+    assert.deepEqual(
+      resolver.supersedes,
+      [cloned.id, original.id].sort((first, second) => first.localeCompare(second)),
+    )
+    assert.equal(api.validateRecords({ root }).valid, true)
+    assert.equal(activeRecordsForSubject(root, subject).length, 1)
+    assert.equal(recordsForSubject(root, subject).length, 3)
+  })
+
+  test('refresh resolves differing generated baseline heads', () => {
+    const root = createRoot()
+    api.initEncephalon({ root })
+    const subject = 'encephalon:init/tooling-layout'
+    const { cloned, original } = cloneBaselineRecord(root, subject, 'parallel-tooling', {
+      payload: {
+        summary: 'Branch-specific generated tooling payload.',
+      },
+    })
+
+    const refreshed = api.initEncephalon({ refreshBaseline: true, root })
+
+    assert.equal(refreshed.recordsCreated.length, 1)
+    const [resolver] = refreshed.recordsCreated
+    assert.ok(resolver)
+    assert.equal(resolver.subject, subject)
+    assert.deepEqual(
+      resolver.supersedes,
+      [cloned.id, original.id].sort((first, second) => first.localeCompare(second)),
+    )
+    assert.equal(api.validateRecords({ root }).valid, true)
+    assert.equal(activeRecordsForSubject(root, subject).length, 1)
+  })
+
+  test('refresh returns a structured conflict for a single human-owned baseline head', () => {
+    const root = createRoot()
+    api.addRecord({
+      id: 'human-overview',
+      kind: 'context',
+      payload: { summary: 'Curated overview' },
+      root,
+      source: 'human',
+      subject: 'encephalon:init/repository-overview',
+    })
+
+    const refreshed = api.initEncephalon({ refreshBaseline: true, root })
+
+    assert.deepEqual(
+      refreshed.recordsCreated.map(record => record.subject).sort((first, second) => first.localeCompare(second)),
+      ['encephalon:init/commands-ci', 'encephalon:init/tooling-layout'],
+    )
+    assert.deepEqual(refreshed.skippedConflicts, [
+      {
+        activeRecordIds: ['human-overview'],
+        kind: 'context',
+        subject: 'encephalon:init/repository-overview',
+      },
+    ])
+  })
+
+  test('refresh rejects mixed generated and human baseline heads without repairing them', () => {
+    const root = createRoot()
+    api.initEncephalon({ root })
+    const subject = 'encephalon:init/repository-overview'
+    cloneBaselineRecord(root, subject, 'human-parallel-overview', { source: 'human' })
+    const before = rawRecordFilesForSubject(root, 'context', subject).length
+
+    assert.throws(
+      () => api.initEncephalon({ refreshBaseline: true, root }),
+      (error: unknown) => {
+        assert.equal((error as { code?: unknown }).code, 'VALIDATION_FAILED')
+        return true
+      },
+    )
+    assert.equal(rawRecordFilesForSubject(root, 'context', subject).length, before)
+  })
+
+  test('refresh rejects unrelated active-head conflicts while repairing no baseline subject', () => {
+    const root = createRoot()
+    api.initEncephalon({ root })
+    api.addRecord({
+      id: 'custom-head-one',
+      kind: 'decision',
+      payload: { summary: 'One' },
+      root,
+      source: 'human',
+      subject: 'custom.subject',
+    })
+    const [custom] = api
+      .listRecords({ includeSuperseded: true, limit: 50, root })
+      .filter(record => record.id === 'custom-head-one')
+    assert.ok(custom)
+    writeRecordFile(root, {
+      ...readRecordFile(root, custom),
+      id: 'custom-head-two',
+    })
+
+    assert.throws(
+      () => api.initEncephalon({ refreshBaseline: true, root }),
+      (error: unknown) => {
+        assert.equal((error as { code?: unknown }).code, 'VALIDATION_FAILED')
+        return true
+      },
+    )
+    assert.equal(api.validateRecords({ root }).valid, false)
+  })
+
+  test('refresh rejects malformed supersession graphs while repairing no baseline subject', () => {
+    const root = createRoot()
+    api.initEncephalon({ root })
+    const subject = 'encephalon:init/commands-ci'
+    cloneBaselineRecord(root, subject, 'parallel-commands')
+    writeRecordFile(root, {
+      createdAt: '2026-08-08T00:00:00.000Z',
+      id: 'missing-supersedes-target',
+      kind: 'decision',
+      payload: { summary: 'Broken graph' },
+      source: 'human',
+      subject: 'broken.graph',
+      supersedes: ['does-not-exist'],
+    })
+
+    assert.throws(
+      () => api.initEncephalon({ refreshBaseline: true, root }),
+      (error: unknown) => {
+        assert.equal((error as { code?: unknown }).code, 'VALIDATION_FAILED')
+        return true
+      },
+    )
+    assert.equal(rawRecordFilesForSubject(root, 'workflow', subject).length, 2)
   })
 
   test('skips a reserved subject owned by an agent-authored active record', () => {


### PR DESCRIPTION
## Human summary

Lets `init --refresh-baseline` repair duplicate generated baseline records after branch merges, while still rejecting unrelated record conflicts.

## Summary

This PR fixes MAR-2514 by making baseline refresh repair a narrowly scoped class of generated multi-head conflicts:

- adds an internal read path that tolerates `MULTIPLE_ACTIVE_HEADS` only for caller-allowed subjects when every active head is generated by `encephalon:init`
- keeps malformed records, missing supersession targets, cycles, cross-subject supersession, duplicate IDs, artifact failures, unrelated multi-heads, and mixed generated/human heads blocking refresh
- updates baseline refresh planning to append a resolver record when more than one eligible generated head exists, even if their generated payloads are equivalent
- preserves the existing no-op behaviour for a single unchanged generated baseline head
- keeps human-owned single baseline subjects as structured skipped conflicts while allowing other missing generated baseline records to initialise
- supersedes every eligible generated active head in deterministic ID order
- adds regression tests for equivalent generated branch-merge heads, differing generated heads, single human-owned reserved subjects, mixed generated/human heads, unrelated conflicts, and malformed supersession graphs

Local verification passed:

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run check:package`
- `node dist/cli.mjs validate`