### PR TITLE
[MAR-2516] Rebuild malformed cache state

### DIFF
--- a/encephalon/workflow/07c99618-832a-45f7-ac57-c4cd8246e73a.json
+++ b/encephalon/workflow/07c99618-832a-45f7-ac57-c4cd8246e73a.json
@@ -1,0 +1,19 @@
+{
+  "createdAt": "2026-08-08T09:57:33.060Z",
+  "id": "07c99618-832a-45f7-ac57-c4cd8246e73a",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Check Encephalon before Git commands that may create commits automatically.",
+    "lessons": [
+      "The pre-commit Encephalon gate applies to any command that can create a commit object, including git merge without --no-commit and git commit --amend, not only direct git commit invocations.",
+      "Before merging main into a ticket branch, query Encephalon first or use a no-commit merge form so the lookup happens before the eventual commit.",
+      "After an accidental local auto-commit, do not push it as-is; perform an Encephalon lookup and amend the local commit before pushing if the subject or gate requirements were missed."
+    ],
+    "verification": [
+      "Before running git merge on a PR branch, confirm the Encephalon commit-gate lookup has already been recorded in working notes.",
+      "Inspect git log before pushing to verify every local commit subject starts with the Linear ticket."
+    ]
+  },
+  "source": "agent",
+  "subject": "workflow.git-auto-commit-gate"
+}

--- a/encephalon/workflow/c5573544-1d86-4e22-b996-4c37e5f78dc2.json
+++ b/encephalon/workflow/c5573544-1d86-4e22-b996-4c37e5f78dc2.json
@@ -1,0 +1,21 @@
+{
+  "createdAt": "2026-08-08T10:19:14.678Z",
+  "id": "c5573544-1d86-4e22-b996-4c37e5f78dc2",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Pullfrog PR #13 found that every disposable SQLite cache read surface, including gather, must re-check cache freshness and canonical consistency immediately before query execution.",
+    "lessons": [
+      "Treat SQLite cell types as untrusted even when table schema declares TEXT; validate type before byte-length checks, JSON parsing, or returning values.",
+      "When a cache table stores duplicated query/filter columns alongside canonical record_json, validate those columns against the parsed canonical record before trusting filters, ordering, active-state reads, or gather results.",
+      "Prepare or hydrate is not a sufficient read gate by itself: a recoverable cache corruption can be observed after prepare and before the read query, so each cache-backed read surface should use the same freshness/consistency gate immediately before querying.",
+      "When adding a shared read gate, include all public cache reads in the audit: list, show, search, compact search, and gather."
+    ],
+    "verification": [
+      "Before resolving Pullfrog cache threads, inspect all public read surfaces for post-prepare consistency checks, not just the paths covered by helper APIs.",
+      "Dogfood Encephalon search before commits to catch cache regressions caused by the branch itself."
+    ]
+  },
+  "source": "agent",
+  "subject": "review.cache-disposable-state",
+  "supersedes": ["f1a1a9f6-77d5-40cc-922d-9e86fbcffdc5"]
+}

--- a/encephalon/workflow/f1a1a9f6-77d5-40cc-922d-9e86fbcffdc5.json
+++ b/encephalon/workflow/f1a1a9f6-77d5-40cc-922d-9e86fbcffdc5.json
@@ -1,0 +1,20 @@
+{
+  "createdAt": "2026-08-08T10:09:54.763Z",
+  "id": "f1a1a9f6-77d5-40cc-922d-9e86fbcffdc5",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Pullfrog PR #13 found that disposable SQLite cache validation must cover cell types and duplicated query columns, not only record_json shape.",
+    "lessons": [
+      "Treat SQLite cell types as untrusted even when table schema declares TEXT; validate type before byte-length checks, JSON parsing, or returning values.",
+      "When a cache table stores duplicated query/filter columns alongside canonical record_json, validate those columns against the parsed canonical record before trusting filters, ordering, or active-state reads.",
+      "Recoverable cache corruption can be observed after prepare and before the read query; read paths should re-check freshness/consistency or normalize validation failures into cache rebuilds.",
+      "Review-body feedback can identify actionable gaps even when GitHub cannot anchor an inline comment to the current diff."
+    ],
+    "verification": [
+      "Add regression tests for non-text SQLite cells and for cache columns that disagree with validated record_json.",
+      "Before resolving Pullfrog threads, inspect both unresolved review threads and the latest review body for dropped or unanchored comments."
+    ]
+  },
+  "source": "agent",
+  "subject": "review.cache-disposable-state"
+}

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -63,13 +63,13 @@ type RecordRow = {
 }
 
 type CompactRow = {
-  id: string
-  kind: string
-  subject: string
-  path: string
-  summary: string | null
-  rank: number
-  snippet: string
+  id: unknown
+  kind: unknown
+  subject: unknown
+  path: unknown
+  summary: unknown
+  rank: unknown
+  snippet: unknown
 }
 
 class CacheSchemaMismatch extends Error {}
@@ -412,6 +412,40 @@ const assertCacheScope = (root: string, metadata: Metadata | undefined) => {
 }
 
 const assertCacheContentConsistent = (database: DatabaseSync, metadata: Metadata) => {
+  const recordRows = database
+    .prepare('SELECT id, kind, subject, source, created_at, path, active, summary, record_json FROM records')
+    .all() as Array<
+    RecordRow & {
+      active?: unknown
+      created_at?: unknown
+      id?: unknown
+      kind?: unknown
+      path?: unknown
+      source?: unknown
+      subject?: unknown
+      summary?: unknown
+    }
+  >
+  if (recordRows.length !== metadata.recordsIndexed || recordRows.length > MAX_CACHE_RECORDS) {
+    throw new CacheSchemaMismatch('The cache record table does not match its metadata.')
+  }
+  const records = recordRows.map(row => ({ record: parseCachedRecord(row.record_json), row }))
+  const superseded = new Set(records.flatMap(({ record }) => record.supersedes ?? []))
+  for (const { record, row } of records) {
+    const active = superseded.has(record.id) ? 0 : 1
+    if (
+      row.id !== record.id ||
+      row.kind !== record.kind ||
+      row.subject !== record.subject ||
+      row.source !== record.source ||
+      row.created_at !== record.createdAt ||
+      row.path !== record.path ||
+      row.active !== active ||
+      row.summary !== summaryForRecord(record)
+    ) {
+      throw new CacheSchemaMismatch('The cache record table does not match its canonical JSON.')
+    }
+  }
   const counts = database
     .prepare(
       `SELECT
@@ -682,6 +716,10 @@ const withPreparedDatabase = <Result>(input: RootInput, read: (database: Databas
   const readOpenDatabase = () => {
     const database = openDatabase(root)
     try {
+      const metadata = readMetadata(database)
+      if (!metadataIsFresh(root, database, metadata)) {
+        throw new CacheSchemaMismatch('The cache is stale before read.')
+      }
       return read(database)
     } finally {
       database.close()
@@ -785,6 +823,20 @@ const searchRows = (database: DatabaseSync, input: SearchRecordsInput) => {
     .all(...parameters) as Array<RecordRow & CompactRow>
 }
 
+const compactRank = (value: unknown) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+  throw new CacheSchemaMismatch('Cached search rank must be a finite number.')
+}
+
+const compactSnippet = (value: unknown) => {
+  if (typeof value === 'string') {
+    return value
+  }
+  throw new CacheSchemaMismatch('Cached search snippet must be text.')
+}
+
 export const searchRecords = (input: SearchRecordsInput): BrainRecord[] =>
   withPreparedDatabase(input, database => searchRows(database, input).map(parseRecordRow))
 
@@ -796,8 +848,8 @@ export const searchCompactRecords = (input: SearchRecordsInput): CompactBrainRec
         id: record.id,
         kind: record.kind,
         path: record.path,
-        rank: row.rank,
-        snippet: row.snippet,
+        rank: compactRank(row.rank),
+        snippet: compactSnippet(row.snippet),
         subject: record.subject,
         summary: summaryForRecord(record),
       }
@@ -827,8 +879,8 @@ const readGatherFromDatabase = (root: string, input: GatherInput, hydrated: Hydr
             id: record.id,
             kind: record.kind,
             path: record.path,
-            rank: row.rank,
-            snippet: row.snippet,
+            rank: compactRank(row.rank),
+            snippet: compactSnippet(row.snippet),
             subject: record.subject,
             summary: summaryForRecord(record),
           }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -711,23 +711,24 @@ const positiveLimit = (value: unknown, fallback = 20) => {
   return fail('INVALID_ARGUMENT', 'limit must be an integer between 1 and 1000.', { field: 'limit' })
 }
 
+const readFreshDatabase = <Result>(root: string, read: (database: DatabaseSync) => Result) => {
+  const database = openDatabase(root)
+  try {
+    const metadata = readMetadata(database)
+    if (!metadataIsFresh(root, database, metadata)) {
+      throw new CacheSchemaMismatch('The cache is stale before read.')
+    }
+    return read(database)
+  } finally {
+    database.close()
+  }
+}
+
 const withPreparedDatabase = <Result>(input: RootInput, read: (database: DatabaseSync) => Result) => {
   const root = resolveRepository(input)
-  const readOpenDatabase = () => {
-    const database = openDatabase(root)
-    try {
-      const metadata = readMetadata(database)
-      if (!metadataIsFresh(root, database, metadata)) {
-        throw new CacheSchemaMismatch('The cache is stale before read.')
-      }
-      return read(database)
-    } finally {
-      database.close()
-    }
-  }
   try {
     prepareResolved(root)
-    return readOpenDatabase()
+    return readFreshDatabase(root, read)
   } catch (error) {
     if (error instanceof EncephalonError) {
       throw error
@@ -735,7 +736,7 @@ const withPreparedDatabase = <Result>(input: RootInput, read: (database: Databas
     if (isRecoverableCacheFailure(error)) {
       withOperationLock(root, () => rebuildCache(root))
       try {
-        return readOpenDatabase()
+        return readFreshDatabase(root, read)
       } catch (retryError) {
         if (retryError instanceof EncephalonError) {
           throw retryError
@@ -856,39 +857,38 @@ export const searchCompactRecords = (input: SearchRecordsInput): CompactBrainRec
     }),
   )
 
-const readGatherFromDatabase = (root: string, input: GatherInput, hydrated: HydrateResult | null): GatherResult => {
-  const database = openDatabase(root)
-  try {
-    const searches = input.searches ?? []
-    const shows = input.shows ?? []
-    return {
-      hydrated,
-      records: shows.map(id => {
-        const activeClause = input.includeSuperseded === true ? '' : ' AND active = 1'
-        const row = database.prepare(`SELECT record_json FROM records WHERE id = ?${activeClause}`).get(id) as
-          | RecordRow
-          | undefined
-        return { id, record: row === undefined ? null : parseRecordRow(row) }
+const readGatherFromDatabase = (
+  database: DatabaseSync,
+  input: GatherInput,
+  hydrated: HydrateResult | null,
+): GatherResult => {
+  const searches = input.searches ?? []
+  const shows = input.shows ?? []
+  return {
+    hydrated,
+    records: shows.map(id => {
+      const activeClause = input.includeSuperseded === true ? '' : ' AND active = 1'
+      const row = database.prepare(`SELECT record_json FROM records WHERE id = ?${activeClause}`).get(id) as
+        | RecordRow
+        | undefined
+      return { id, record: row === undefined ? null : parseRecordRow(row) }
+    }),
+    searches: searches.map(query => ({
+      kind: input.kind ?? null,
+      query,
+      results: searchRows(database, { ...input, query }).map(row => {
+        const record = parseRecordRow(row)
+        return {
+          id: record.id,
+          kind: record.kind,
+          path: record.path,
+          rank: compactRank(row.rank),
+          snippet: compactSnippet(row.snippet),
+          subject: record.subject,
+          summary: summaryForRecord(record),
+        }
       }),
-      searches: searches.map(query => ({
-        kind: input.kind ?? null,
-        query,
-        results: searchRows(database, { ...input, query }).map(row => {
-          const record = parseRecordRow(row)
-          return {
-            id: record.id,
-            kind: record.kind,
-            path: record.path,
-            rank: compactRank(row.rank),
-            snippet: compactSnippet(row.snippet),
-            subject: record.subject,
-            summary: summaryForRecord(record),
-          }
-        }),
-      })),
-    }
-  } finally {
-    database.close()
+    })),
   }
 }
 
@@ -915,7 +915,7 @@ export const gatherRecords = (input: GatherInput): GatherResult => {
         field: 'shows',
       })
     }
-    return readGatherFromDatabase(root, input, hydrated)
+    return readFreshDatabase(root, database => readGatherFromDatabase(database, input, hydrated))
   } catch (error) {
     if (error instanceof EncephalonError) {
       throw error
@@ -923,10 +923,12 @@ export const gatherRecords = (input: GatherInput): GatherResult => {
     if (isRecoverableCacheFailure(error)) {
       const recovered = withOperationLock(root, () => rebuildCache(root))
       try {
-        return readGatherFromDatabase(
-          root,
-          input,
-          input.hydrate === true ? { recordsIndexed: recovered.recordsIndexed } : null,
+        return readFreshDatabase(root, database =>
+          readGatherFromDatabase(
+            database,
+            input,
+            input.hydrate === true ? { recordsIndexed: recovered.recordsIndexed } : null,
+          ),
         )
       } catch (retryError) {
         if (retryError instanceof EncephalonError) {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -59,7 +59,7 @@ type ManifestEntry = {
 }
 
 type RecordRow = {
-  record_json: string
+  record_json: unknown
 }
 
 type CompactRow = {
@@ -281,13 +281,16 @@ const repositoryManifest = (root: string, artifactPaths: string[]) => {
 
 const byteLength = (value: string) => Buffer.byteLength(value, 'utf8')
 
-const assertCacheValueSize = (value: string, maximum: number) => {
+function assertCacheValueSize(value: unknown, maximum: number): asserts value is string {
+  if (typeof value !== 'string') {
+    throw new CacheSchemaMismatch('Cached values must be text.')
+  }
   if (byteLength(value) > maximum) {
     throw new CacheSchemaMismatch('A cached value exceeds its size limit.')
   }
 }
 
-const parseCacheJson = (value: string, maximum: number) => {
+const parseCacheJson = (value: unknown, maximum: number) => {
   assertCacheValueSize(value, maximum)
   try {
     return JSON.parse(value) as unknown
@@ -311,7 +314,7 @@ const validateCachedArtifactPath = (value: unknown) => {
   }
 }
 
-const parseCachedRecord = (value: string): BrainRecord => {
+const parseCachedRecord = (value: unknown): BrainRecord => {
   const parsed = parseCacheJson(value, MAX_CACHE_RECORD_BYTES)
   if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new CacheSchemaMismatch('Cached record JSON must be an object.')
@@ -329,6 +332,16 @@ const parseCachedRecord = (value: string): BrainRecord => {
     // Normalise every cached-row validation failure into disposable cache corruption.
   }
   throw new CacheSchemaMismatch('Cached record JSON does not match the canonical record schema.')
+}
+
+const summaryForRecord = (record: BrainRecord) => {
+  if (record.payload !== null && !Array.isArray(record.payload) && typeof record.payload === 'object') {
+    const { summary } = record.payload
+    if (typeof summary === 'string' && summary.trim().length > 0) {
+      return summary.trim()
+    }
+  }
+  return null
 }
 
 const readMetadata = (database: DatabaseSync): Metadata | undefined => {
@@ -442,16 +455,6 @@ const metadataIsFresh = (
     assertCacheContentConsistent(database, metadata)
   }
   return fresh
-}
-
-const summaryForRecord = (record: BrainRecord) => {
-  if (record.payload !== null && !Array.isArray(record.payload) && typeof record.payload === 'object') {
-    const { summary } = record.payload
-    if (typeof summary === 'string' && summary.trim().length > 0) {
-      return summary.trim()
-    }
-  }
-  return null
 }
 
 const searchDocumentForRecord = (record: BrainRecord) =>

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -5,8 +5,9 @@ import { resolve } from 'node:path'
 import type { DatabaseSync } from 'node:sqlite'
 import { EncephalonError, fail, failWithCause, wrapIo } from './errors.ts'
 import { cacheDirectory, withOperationLock } from './lock.ts'
-import { readRecords } from './records.ts'
+import { canonicalRecordPath, readRecords } from './records.ts'
 import { resolveRepository } from './repository.ts'
+import { MAX_RECORD_BYTES, parseRecordFile, validateArtifactPath } from './schema.ts'
 import type {
   BrainRecord,
   CompactBrainRecord,
@@ -24,6 +25,17 @@ const PACKAGE_VERSION = '0.1.0'
 const SCHEMA_VERSION = '1'
 const MAX_REPOSITORY_CHANGE_RETRIES = 3
 const DATABASE_FILENAME = 'brain.sqlite'
+const MAX_CACHE_METADATA_BYTES = 1024 * 1024
+const MAX_CACHE_RECORD_BYTES = MAX_RECORD_BYTES + 4096
+const MAX_CACHE_RECORDS = 100_000
+const METADATA_KEYS = [
+  'artifactPaths',
+  'manifest',
+  'packageVersion',
+  'recordsIndexed',
+  'repositoryRealpath',
+  'schemaVersion',
+] as const
 
 type SQLiteModule = {
   DatabaseSync: new (path: string) => DatabaseSync
@@ -112,7 +124,7 @@ const assertTableColumns = (database: DatabaseSync, table: string, expected: str
 
 const removeCorruptCache = (root: string) => {
   const path = databasePath(root)
-  for (const candidate of [path, `${path}-wal`, `${path}-shm`]) {
+  for (const candidate of [path, `${path}-wal`, `${path}-shm`, `${path}-journal`]) {
     rmSync(candidate, { force: true })
   }
 }
@@ -267,40 +279,105 @@ const repositoryManifest = (root: string, artifactPaths: string[]) => {
   return createHash('sha256').update(JSON.stringify(entries)).digest('hex')
 }
 
+const byteLength = (value: string) => Buffer.byteLength(value, 'utf8')
+
+const assertCacheValueSize = (value: string, maximum: number) => {
+  if (byteLength(value) > maximum) {
+    throw new CacheSchemaMismatch('A cached value exceeds its size limit.')
+  }
+}
+
+const parseCacheJson = (value: string, maximum: number) => {
+  assertCacheValueSize(value, maximum)
+  try {
+    return JSON.parse(value) as unknown
+  } catch (error) {
+    throw new CacheSchemaMismatch('The cache contains malformed JSON.', { cause: error })
+  }
+}
+
+const validateCachedArtifactPath = (value: unknown) => {
+  if (typeof value !== 'string') {
+    throw new CacheSchemaMismatch('Cached artifact metadata must contain strings.')
+  }
+  const [, kind, id] = value.split('/')
+  if (kind === undefined || id === undefined) {
+    throw new CacheSchemaMismatch('Cached artifact metadata contains an invalid path.')
+  }
+  try {
+    return validateArtifactPath(value, kind, id)
+  } catch (error) {
+    throw new CacheSchemaMismatch('Cached artifact metadata contains an invalid path.', { cause: error })
+  }
+}
+
+const parseCachedRecord = (value: string): BrainRecord => {
+  const parsed = parseCacheJson(value, MAX_CACHE_RECORD_BYTES)
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new CacheSchemaMismatch('Cached record JSON must be an object.')
+  }
+  const { path, ...recordFile } = parsed as Record<string, unknown>
+  if (typeof path !== 'string') {
+    throw new CacheSchemaMismatch('Cached record JSON must include a runtime path.')
+  }
+  try {
+    const record = parseRecordFile(recordFile)
+    if (path === canonicalRecordPath(record)) {
+      return { ...record, path }
+    }
+  } catch {
+    // Normalise every cached-row validation failure into disposable cache corruption.
+  }
+  throw new CacheSchemaMismatch('Cached record JSON does not match the canonical record schema.')
+}
+
 const readMetadata = (database: DatabaseSync): Metadata | undefined => {
   const rows = database.prepare('SELECT key, value FROM metadata').all() as Array<{
-    key: string
-    value: string
+    key?: unknown
+    value?: unknown
   }>
-  const values = new Map(rows.map(row => [row.key, row.value]))
+  if (rows.length === 0) {
+    return
+  }
+  const values = new Map<string, string>()
+  for (const row of rows) {
+    if (
+      typeof row.key !== 'string' ||
+      typeof row.value !== 'string' ||
+      !(METADATA_KEYS as readonly string[]).includes(row.key)
+    ) {
+      throw new CacheSchemaMismatch('The cache metadata contains invalid keys or values.')
+    }
+    assertCacheValueSize(row.value, MAX_CACHE_METADATA_BYTES)
+    values.set(row.key, row.value)
+  }
+  if (values.size !== METADATA_KEYS.length || METADATA_KEYS.some(key => values.get(key) === undefined)) {
+    throw new CacheSchemaMismatch('The cache metadata key set is incomplete.')
+  }
   const artifactPathsValue = values.get('artifactPaths')
   const recordsIndexedValue = values.get('recordsIndexed')
+  if (artifactPathsValue === undefined || recordsIndexedValue === undefined) {
+    throw new CacheSchemaMismatch('The cache metadata key set is incomplete.')
+  }
+  const artifactPaths = parseCacheJson(artifactPathsValue, MAX_CACHE_METADATA_BYTES)
+  const recordsIndexed = Number(recordsIndexedValue)
   if (
-    values.get('schemaVersion') !== undefined &&
-    values.get('packageVersion') !== undefined &&
-    values.get('repositoryRealpath') !== undefined &&
-    values.get('manifest') !== undefined &&
-    artifactPathsValue !== undefined &&
-    recordsIndexedValue !== undefined
+    !Array.isArray(artifactPaths) ||
+    artifactPaths.length > MAX_CACHE_RECORDS ||
+    !Number.isSafeInteger(recordsIndexed) ||
+    recordsIndexed < 0 ||
+    recordsIndexed > MAX_CACHE_RECORDS
   ) {
-    try {
-      const artifactPaths = JSON.parse(artifactPathsValue) as unknown
-      const recordsIndexed = Number(recordsIndexedValue)
-      if (
-        Array.isArray(artifactPaths) &&
-        artifactPaths.every(path => typeof path === 'string') &&
-        Number.isInteger(recordsIndexed)
-      ) {
-        return {
-          artifactPaths,
-          manifest: values.get('manifest') ?? '',
-          packageVersion: values.get('packageVersion') ?? '',
-          recordsIndexed,
-          repositoryRealpath: values.get('repositoryRealpath') ?? '',
-          schemaVersion: values.get('schemaVersion') ?? '',
-        }
-      }
-    } catch {}
+    throw new CacheSchemaMismatch('The cache metadata contains invalid values.')
+  }
+  const validatedArtifactPaths = artifactPaths.map(validateCachedArtifactPath)
+  return {
+    artifactPaths: validatedArtifactPaths,
+    manifest: values.get('manifest') ?? '',
+    packageVersion: values.get('packageVersion') ?? '',
+    recordsIndexed,
+    repositoryRealpath: values.get('repositoryRealpath') ?? '',
+    schemaVersion: values.get('schemaVersion') ?? '',
   }
 }
 
@@ -321,14 +398,50 @@ const assertCacheScope = (root: string, metadata: Metadata | undefined) => {
   }
 }
 
-const metadataIsFresh = (root: string, metadata: Metadata | undefined): metadata is Metadata => {
+const assertCacheContentConsistent = (database: DatabaseSync, metadata: Metadata) => {
+  const counts = database
+    .prepare(
+      `SELECT
+        (SELECT COUNT(*) FROM records) AS records,
+        (SELECT COUNT(*) FROM record_search) AS searchRows,
+        (SELECT COUNT(DISTINCT id) FROM record_search) AS distinctSearchRows,
+        (SELECT COUNT(*) FROM records LEFT JOIN record_search ON records.id = record_search.id WHERE record_search.id IS NULL) AS missingSearchRows,
+        (SELECT COUNT(*) FROM record_search LEFT JOIN records ON records.id = record_search.id WHERE records.id IS NULL) AS orphanSearchRows
+      `,
+    )
+    .get() as {
+    distinctSearchRows?: unknown
+    missingSearchRows?: unknown
+    orphanSearchRows?: unknown
+    records?: unknown
+    searchRows?: unknown
+  }
+  if (
+    counts.records !== metadata.recordsIndexed ||
+    counts.searchRows !== metadata.recordsIndexed ||
+    counts.distinctSearchRows !== metadata.recordsIndexed ||
+    counts.missingSearchRows !== 0 ||
+    counts.orphanSearchRows !== 0
+  ) {
+    throw new CacheSchemaMismatch('The cache record and search tables are inconsistent.')
+  }
+}
+
+const metadataIsFresh = (
+  root: string,
+  database: DatabaseSync,
+  metadata: Metadata | undefined,
+): metadata is Metadata => {
   assertCacheScope(root, metadata)
-  return (
+  const fresh =
     metadata !== undefined &&
     metadata.schemaVersion === SCHEMA_VERSION &&
     metadata.packageVersion === PACKAGE_VERSION &&
     metadata.manifest === repositoryManifest(root, metadata.artifactPaths)
-  )
+  if (fresh) {
+    assertCacheContentConsistent(database, metadata)
+  }
+  return fresh
 }
 
 const summaryForRecord = (record: BrainRecord) => {
@@ -406,7 +519,15 @@ const rebuildCache = (root: string): PrepareResult => {
       database = openDatabase(root)
     }
     try {
-      assertCacheScope(root, readMetadata(database))
+      let existingMetadata: Metadata | undefined
+      try {
+        existingMetadata = readMetadata(database)
+      } catch (error) {
+        if (!(error instanceof CacheSchemaMismatch)) {
+          throw error
+        }
+      }
+      assertCacheScope(root, existingMetadata)
       database.exec('BEGIN IMMEDIATE')
       try {
         database.exec('DELETE FROM record_search; DELETE FROM records; DELETE FROM metadata;')
@@ -467,7 +588,7 @@ const prepareResolvedWithoutCorruptionRecovery = (root: string): PrepareResult =
         const recheck = openDatabase(root)
         try {
           const metadata = readMetadata(recheck)
-          if (metadataIsFresh(root, metadata)) {
+          if (metadataIsFresh(root, recheck, metadata)) {
             return {
               hydrated: false,
               recordsIndexed: metadata.recordsIndexed,
@@ -483,7 +604,7 @@ const prepareResolvedWithoutCorruptionRecovery = (root: string): PrepareResult =
   const database = openDatabase(root)
   try {
     const metadata = readMetadata(database)
-    if (metadataIsFresh(root, metadata)) {
+    if (metadataIsFresh(root, database, metadata)) {
       return { hydrated: false, recordsIndexed: metadata.recordsIndexed }
     }
   } finally {
@@ -493,7 +614,7 @@ const prepareResolvedWithoutCorruptionRecovery = (root: string): PrepareResult =
     const recheck = openDatabase(root)
     try {
       const metadata = readMetadata(recheck)
-      if (metadataIsFresh(root, metadata)) {
+      if (metadataIsFresh(root, recheck, metadata)) {
         return {
           hydrated: false,
           recordsIndexed: metadata.recordsIndexed,
@@ -555,23 +676,37 @@ const positiveLimit = (value: unknown, fallback = 20) => {
 
 const withPreparedDatabase = <Result>(input: RootInput, read: (database: DatabaseSync) => Result) => {
   const root = resolveRepository(input)
-  try {
-    prepareResolved(root)
+  const readOpenDatabase = () => {
     const database = openDatabase(root)
     try {
       return read(database)
     } finally {
       database.close()
     }
+  }
+  try {
+    prepareResolved(root)
+    return readOpenDatabase()
   } catch (error) {
     if (error instanceof EncephalonError) {
       throw error
+    }
+    if (isRecoverableCacheFailure(error)) {
+      withOperationLock(root, () => rebuildCache(root))
+      try {
+        return readOpenDatabase()
+      } catch (retryError) {
+        if (retryError instanceof EncephalonError) {
+          throw retryError
+        }
+        return wrapIo('Unable to read the Encephalon cache.', retryError)
+      }
     }
     return wrapIo('Unable to read the Encephalon cache.', error)
   }
 }
 
-const parseRecordRow = (row: RecordRow) => JSON.parse(row.record_json) as BrainRecord
+const parseRecordRow = (row: RecordRow) => parseCachedRecord(row.record_json)
 
 export const listRecords = (input: ListRecordsInput = {}): BrainRecord[] =>
   withPreparedDatabase(input, database => {
@@ -652,16 +787,55 @@ export const searchRecords = (input: SearchRecordsInput): BrainRecord[] =>
 
 export const searchCompactRecords = (input: SearchRecordsInput): CompactBrainRecord[] =>
   withPreparedDatabase(input, database =>
-    searchRows(database, input).map(row => ({
-      id: row.id,
-      kind: row.kind,
-      path: row.path,
-      rank: row.rank,
-      snippet: row.snippet,
-      subject: row.subject,
-      summary: row.summary,
-    })),
+    searchRows(database, input).map(row => {
+      const record = parseRecordRow(row)
+      return {
+        id: record.id,
+        kind: record.kind,
+        path: record.path,
+        rank: row.rank,
+        snippet: row.snippet,
+        subject: record.subject,
+        summary: summaryForRecord(record),
+      }
+    }),
   )
+
+const readGatherFromDatabase = (root: string, input: GatherInput, hydrated: HydrateResult | null): GatherResult => {
+  const database = openDatabase(root)
+  try {
+    const searches = input.searches ?? []
+    const shows = input.shows ?? []
+    return {
+      hydrated,
+      records: shows.map(id => {
+        const activeClause = input.includeSuperseded === true ? '' : ' AND active = 1'
+        const row = database.prepare(`SELECT record_json FROM records WHERE id = ?${activeClause}`).get(id) as
+          | RecordRow
+          | undefined
+        return { id, record: row === undefined ? null : parseRecordRow(row) }
+      }),
+      searches: searches.map(query => ({
+        kind: input.kind ?? null,
+        query,
+        results: searchRows(database, { ...input, query }).map(row => {
+          const record = parseRecordRow(row)
+          return {
+            id: record.id,
+            kind: record.kind,
+            path: record.path,
+            rank: row.rank,
+            snippet: row.snippet,
+            subject: record.subject,
+            summary: summaryForRecord(record),
+          }
+        }),
+      })),
+    }
+  } finally {
+    database.close()
+  }
+}
 
 export const gatherRecords = (input: GatherInput): GatherResult => {
   const root = resolveRepository(input)
@@ -686,37 +860,25 @@ export const gatherRecords = (input: GatherInput): GatherResult => {
         field: 'shows',
       })
     }
-    const database = openDatabase(root)
-    try {
-      return {
-        hydrated,
-        records: shows.map(id => {
-          const activeClause = input.includeSuperseded === true ? '' : ' AND active = 1'
-          const row = database.prepare(`SELECT record_json FROM records WHERE id = ?${activeClause}`).get(id) as
-            | RecordRow
-            | undefined
-          return { id, record: row === undefined ? null : parseRecordRow(row) }
-        }),
-        searches: searches.map(query => ({
-          kind: input.kind ?? null,
-          query,
-          results: searchRows(database, { ...input, query }).map(row => ({
-            id: row.id,
-            kind: row.kind,
-            path: row.path,
-            rank: row.rank,
-            snippet: row.snippet,
-            subject: row.subject,
-            summary: row.summary,
-          })),
-        })),
-      }
-    } finally {
-      database.close()
-    }
+    return readGatherFromDatabase(root, input, hydrated)
   } catch (error) {
     if (error instanceof EncephalonError) {
       throw error
+    }
+    if (isRecoverableCacheFailure(error)) {
+      const recovered = withOperationLock(root, () => rebuildCache(root))
+      try {
+        return readGatherFromDatabase(
+          root,
+          input,
+          input.hydrate === true ? { recordsIndexed: recovered.recordsIndexed } : null,
+        )
+      } catch (retryError) {
+        if (retryError instanceof EncephalonError) {
+          throw retryError
+        }
+        return wrapIo('Unable to gather Encephalon records.', retryError)
+      }
     }
     return wrapIo('Unable to gather Encephalon records.', error)
   }

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -327,6 +327,21 @@ describe('SQLite cache and reads', () => {
     })
   }
 
+  test('rebuilds non-text cached record JSON before reading it', () => {
+    const root = createRoot()
+    const record = addCacheRecord(root)
+    mutateCache(root, database => {
+      database.prepare('UPDATE records SET record_json = ? WHERE id = ?').run(42, String(record.id))
+    })
+
+    assert.deepEqual(
+      functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>[]>('listRecords')({ root }).map(
+        entry => entry.id,
+      ),
+      [record.id],
+    )
+  })
+
   test('rebuilds cached records with invalid shapes and runtime paths', () => {
     const invalidRecordJson = (record: Record<string, unknown>) => [
       JSON.stringify({ ...record, unexpected: true }),

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -365,6 +365,38 @@ describe('SQLite cache and reads', () => {
     }
   })
 
+  test('rebuilds cached record columns that disagree with validated JSON', () => {
+    const root = createRoot()
+    const oldRecord = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>>('addRecord')({
+      id: 'old-cache-record',
+      kind: 'context',
+      payload: { summary: 'Old cache record' },
+      root,
+      source: 'agent',
+      subject: 'cache.validation',
+    })
+    const newRecord = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>>('addRecord')({
+      id: 'new-cache-record',
+      kind: 'context',
+      payload: { summary: 'New cache record' },
+      root,
+      source: 'agent',
+      subject: 'cache.validation',
+      supersedes: [oldRecord.id],
+    })
+    mutateCache(root, database => {
+      database.prepare('UPDATE records SET kind = ? WHERE id = ?').run('decision', String(newRecord.id))
+      database.prepare('UPDATE records SET active = 1 WHERE id = ?').run(String(oldRecord.id))
+    })
+
+    const listRecords = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>[]>('listRecords')
+    assert.deepEqual(listRecords({ kind: 'decision', root }), [])
+    assert.deepEqual(
+      listRecords({ root }).map(record => record.id),
+      [newRecord.id],
+    )
+  })
+
   test('rebuilds invalid cache metadata instead of trusting it', () => {
     const metadataCases = [
       ['artifactPaths', JSON.stringify(['../outside'])],

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -22,6 +22,28 @@ afterEach(() => {
 
 const functionFromApi = <T>(name: string) => (api as unknown as Record<string, T>)[name] as T
 
+const cacheDatabasePath = (root: string) => join(root, 'node_modules', '.cache', 'encephalon', 'brain.sqlite')
+
+const addCacheRecord = (root: string) =>
+  functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>>('addRecord')({
+    id: 'cache-record',
+    kind: 'context',
+    payload: { detail: 'cache corruption marker', summary: 'Cache record' },
+    root,
+    searchText: 'recoverable cache row',
+    source: 'agent',
+    subject: 'cache.validation',
+  })
+
+const mutateCache = (root: string, mutation: (database: DatabaseSync) => void) => {
+  const database = new DatabaseSync(cacheDatabasePath(root))
+  try {
+    mutation(database)
+  } finally {
+    database.close()
+  }
+}
+
 describe('SQLite cache and reads', () => {
   test('prepares an empty repository before a cache directory exists', () => {
     const root = createRoot()
@@ -210,17 +232,173 @@ describe('SQLite cache and reads', () => {
 
   test('rebuilds a disposable cache with an incompatible table schema', () => {
     const root = createRoot()
-    const cachePath = join(root, 'node_modules', '.cache', 'encephalon', 'brain.sqlite')
+    const path = join(root, 'node_modules', '.cache', 'encephalon', 'brain.sqlite')
     mkdirSync(join(root, 'node_modules', '.cache', 'encephalon'), {
       recursive: true,
     })
-    const database = new DatabaseSync(cachePath)
+    const database = new DatabaseSync(path)
     database.exec('CREATE TABLE metadata (wrong_column TEXT)')
     database.close()
 
     const prepare = functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')
     assert.deepEqual(prepare({ root }), { hydrated: true, recordsIndexed: 0 })
     assert.deepEqual(prepare({ root }), { hydrated: false, recordsIndexed: 0 })
+  })
+
+  const readRecoveryCases = [
+    {
+      name: 'list',
+      read: (root: string, record: Record<string, unknown>) => {
+        const result = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>[]>('listRecords')({
+          root,
+        })
+        assert.deepEqual(
+          result.map(entry => entry.id),
+          [record.id],
+        )
+      },
+    },
+    {
+      name: 'show',
+      read: (root: string, record: Record<string, unknown>) => {
+        const result = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown> | null>(
+          'showRecord',
+        )({
+          id: record.id,
+          root,
+        })
+        assert.equal(result?.id, record.id)
+      },
+    },
+    {
+      name: 'full search',
+      read: (root: string, record: Record<string, unknown>) => {
+        const result = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>[]>('searchRecords')({
+          query: 'recoverable cache row',
+          root,
+        })
+        assert.deepEqual(
+          result.map(entry => entry.id),
+          [record.id],
+        )
+      },
+    },
+    {
+      name: 'compact search',
+      read: (root: string, record: Record<string, unknown>) => {
+        const result = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>[]>(
+          'searchCompactRecords',
+        )({
+          query: 'recoverable cache row',
+          root,
+        })
+        assert.deepEqual(
+          result.map(entry => entry.id),
+          [record.id],
+        )
+      },
+    },
+    {
+      name: 'gather',
+      read: (root: string, record: Record<string, unknown>) => {
+        const result = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>>('gatherRecords')({
+          root,
+          searches: ['recoverable cache row'],
+          shows: [record.id],
+        }) as {
+          records: Array<{ record: { id: unknown } | null }>
+          searches: Array<{ results: Array<{ id: unknown }> }>
+        }
+        assert.equal(result.records[0]?.record?.id, record.id)
+        assert.equal(result.searches[0]?.results[0]?.id, record.id)
+      },
+    },
+  ] as const
+
+  for (const { name, read } of readRecoveryCases) {
+    test(`rebuilds invalid cached row JSON during ${name}`, () => {
+      const root = createRoot()
+      const record = addCacheRecord(root)
+      mutateCache(root, database => {
+        database.prepare('UPDATE records SET record_json = ? WHERE id = ?').run('{not-json', String(record.id))
+      })
+
+      read(root, record)
+    })
+  }
+
+  test('rebuilds cached records with invalid shapes and runtime paths', () => {
+    const invalidRecordJson = (record: Record<string, unknown>) => [
+      JSON.stringify({ ...record, unexpected: true }),
+      JSON.stringify({ ...record, path: '/tmp/elsewhere.json' }),
+      JSON.stringify({ ...record, path: '../elsewhere.json' }),
+    ]
+
+    for (const recordJson of invalidRecordJson(addCacheRecord(createRoot()))) {
+      const root = roots.at(-1)
+      assert.ok(root)
+      mutateCache(root, database => {
+        database.prepare('UPDATE records SET record_json = ?').run(recordJson)
+      })
+      const records = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>[]>('listRecords')({
+        root,
+      })
+      assert.deepEqual(
+        records.map(record => record.id),
+        ['cache-record'],
+      )
+    }
+  })
+
+  test('rebuilds invalid cache metadata instead of trusting it', () => {
+    const metadataCases = [
+      ['artifactPaths', JSON.stringify(['../outside'])],
+      ['recordsIndexed', '-1'],
+      ['recordsIndexed', String(Number.MAX_SAFE_INTEGER + 1)],
+      ['artifactPaths', JSON.stringify(['x'.repeat(1024 * 1024 + 1)])],
+    ] as const
+
+    for (const [key, value] of metadataCases) {
+      const root = createRoot()
+      addCacheRecord(root)
+      mutateCache(root, database => {
+        database.prepare('UPDATE metadata SET value = ? WHERE key = ?').run(value, key)
+      })
+      assert.deepEqual(functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }), {
+        hydrated: true,
+        recordsIndexed: 1,
+      })
+    }
+
+    const root = createRoot()
+    addCacheRecord(root)
+    mutateCache(root, database => {
+      database.prepare('INSERT INTO metadata(key, value) VALUES (?, ?)').run('unexpected', 'value')
+    })
+    assert.deepEqual(functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }), {
+      hydrated: true,
+      recordsIndexed: 1,
+    })
+  })
+
+  test('rebuilds missing and duplicate FTS rows', () => {
+    for (const duplicate of [false, true]) {
+      const root = createRoot()
+      const record = addCacheRecord(root)
+      mutateCache(root, database => {
+        if (duplicate) {
+          database
+            .prepare('INSERT INTO record_search(id, text) VALUES (?, ?)')
+            .run(String(record.id), 'duplicate search row')
+        } else {
+          database.prepare('DELETE FROM record_search WHERE id = ?').run(String(record.id))
+        }
+      })
+      assert.deepEqual(functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }), {
+        hydrated: true,
+        recordsIndexed: 1,
+      })
+    }
   })
 
   test('recovers an ownerless or malformed operation lock', () => {


### PR DESCRIPTION
## Human summary

Treats the SQLite cache as disposable: malformed cached metadata, rows, or search state are rebuilt from canonical JSON instead of being returned.

## Summary

This PR fixes MAR-2516 by hardening disposable SQLite cache reads and freshness checks:

- validates cache metadata keys, value types, size limits, artifact paths, and `recordsIndexed` bounds
- validates `recordsIndexed` against stored record rows and FTS rows
- detects missing, duplicate, and orphaned FTS rows before treating metadata as fresh
- validates cached `record_json` through the canonical record schema plus runtime path checks
- rejects cached records with unknown fields, malformed JSON, invalid paths, or oversized serialized rows
- derives compact search record fields from validated cached records rather than trusting parallel cache columns
- removes SQLite WAL, SHM, and rollback-journal files when discarding corrupt cache state
- rebuilds once under the operation lock when list, show, full search, compact search, or gather first observe recoverable cache corruption
- preserves `CACHE_SCOPE_MISMATCH` for valid caches bound to a different repository realpath
- adds regression coverage for invalid rows, invalid cached record shapes and paths, unsafe metadata, invalid counts, oversized metadata, missing/duplicate FTS rows, and all public read surfaces

Local verification passed:

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run check:package`
- `node dist/cli.mjs validate`