### PR TITLE
[MAR-2518] Make gather reads snapshot consistent

### DIFF
--- a/encephalon/workflow/6ce2324a-6396-49d5-a29b-14058e7e2b6f.json
+++ b/encephalon/workflow/6ce2324a-6396-49d5-a29b-14058e7e2b6f.json
@@ -1,0 +1,20 @@
+{
+  "createdAt": "2026-08-08T10:57:18.028Z",
+  "id": "6ce2324a-6396-49d5-a29b-14058e7e2b6f",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Pullfrog PR #15 found that gather cache tests should not patch DatabaseSync.prototype globally and snapshot coverage must exercise both show and compact search reads.",
+    "mistake": "Global SQLite prototype patches in tests can leak across node --test file concurrency, and show-only snapshot tests do not prove FTS gather reads share the same transaction snapshot.",
+    "guidance": [
+      "Use scoped Encephalon cache test hooks instead of mutating DatabaseSync.prototype.",
+      "When changing gather snapshot behaviour, include separate coverage for show reads and compact search/FTS reads.",
+      "Keep Pullfrog review fixes as individual commits and query Encephalon immediately before each commit."
+    ],
+    "verification": [
+      "Run node --test test/cache.test.ts after cache test-hook changes.",
+      "Run full lint, typecheck, test, validate, build, and package checks before pushing."
+    ]
+  },
+  "source": "agent",
+  "subject": "review.cache-gather-test-hooks"
+}

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -60,6 +60,8 @@ type CompactRow = {
   snippet: string
 }
 
+type SearchStatementInput = Pick<SearchRecordsInput, 'includeSuperseded' | 'kind' | 'limit'>
+
 class CacheSchemaMismatch extends Error {}
 
 let sqliteModule: SQLiteModule | undefined
@@ -647,21 +649,78 @@ const searchRows = (database: DatabaseSync, input: SearchRecordsInput) => {
     .all(...parameters) as Array<RecordRow & CompactRow>
 }
 
+const compactRecordFromRow = (row: CompactRow): CompactBrainRecord => ({
+  id: row.id,
+  kind: row.kind,
+  path: row.path,
+  rank: row.rank,
+  snippet: row.snippet,
+  subject: row.subject,
+  summary: row.summary,
+})
+
+const createCompactSearchReader = (database: DatabaseSync, input: SearchStatementInput) => {
+  const conditions = [
+    'record_search MATCH ?',
+    input.includeSuperseded === true ? undefined : 'records.active = 1',
+    input.kind === undefined ? undefined : 'records.kind = ?',
+  ].filter((value): value is string => value !== undefined)
+  const kindParameters = input.kind === undefined ? [] : [input.kind]
+  const limit = positiveLimit(input.limit)
+  const statement = database.prepare(`
+    SELECT
+      records.id,
+      records.kind,
+      records.subject,
+      records.path,
+      records.summary,
+      bm25(record_search) AS rank,
+      snippet(record_search, 1, '[', ']', '...', 16) AS snippet
+    FROM record_search
+    JOIN records ON records.id = record_search.id
+    WHERE ${conditions.join(' AND ')}
+    ORDER BY rank ASC, records.created_at DESC, records.id DESC
+    LIMIT ?
+  `)
+  return (query: string) => {
+    const match = literalMatchQuery(query)
+    if (match.length === 0) {
+      return []
+    }
+    return (statement.all(match, ...kindParameters, limit) as CompactRow[]).map(compactRecordFromRow)
+  }
+}
+
 export const searchRecords = (input: SearchRecordsInput): BrainRecord[] =>
   withPreparedDatabase(input, database => searchRows(database, input).map(parseRecordRow))
 
 export const searchCompactRecords = (input: SearchRecordsInput): CompactBrainRecord[] =>
-  withPreparedDatabase(input, database =>
-    searchRows(database, input).map(row => ({
-      id: row.id,
-      kind: row.kind,
-      path: row.path,
-      rank: row.rank,
-      snippet: row.snippet,
-      subject: row.subject,
-      summary: row.summary,
-    })),
-  )
+  withPreparedDatabase(input, database => createCompactSearchReader(database, input)(input.query))
+
+const createShowReader = (database: DatabaseSync, includeSuperseded: boolean | undefined) => {
+  const activeClause = includeSuperseded === true ? '' : ' AND active = 1'
+  const statement = database.prepare(`SELECT record_json FROM records WHERE id = ?${activeClause}`)
+  return (id: string) => {
+    const row = statement.get(id) as RecordRow | undefined
+    return row === undefined ? null : parseRecordRow(row)
+  }
+}
+
+const readTransaction = <Result>(database: DatabaseSync, read: () => Result) => {
+  database.exec('BEGIN')
+  try {
+    const result = read()
+    database.exec('ROLLBACK')
+    return result
+  } catch (error) {
+    try {
+      database.exec('ROLLBACK')
+    } catch {
+      // The original read failure is more useful than a secondary rollback failure.
+    }
+    throw error
+  }
+}
 
 export const gatherRecords = (input: GatherInput): GatherResult => {
   const root = resolveRepository(input)
@@ -688,29 +747,20 @@ export const gatherRecords = (input: GatherInput): GatherResult => {
     }
     const database = openDatabase(root)
     try {
-      return {
-        hydrated,
-        records: shows.map(id => {
-          const activeClause = input.includeSuperseded === true ? '' : ' AND active = 1'
-          const row = database.prepare(`SELECT record_json FROM records WHERE id = ?${activeClause}`).get(id) as
-            | RecordRow
-            | undefined
-          return { id, record: row === undefined ? null : parseRecordRow(row) }
-        }),
-        searches: searches.map(query => ({
-          kind: input.kind ?? null,
-          query,
-          results: searchRows(database, { ...input, query }).map(row => ({
-            id: row.id,
-            kind: row.kind,
-            path: row.path,
-            rank: row.rank,
-            snippet: row.snippet,
-            subject: row.subject,
-            summary: row.summary,
+      return readTransaction(database, () => {
+        const showRecordForId = shows.length === 0 ? () => null : createShowReader(database, input.includeSuperseded)
+        const searchCompactRecordsForQuery =
+          searches.length === 0 ? () => [] : createCompactSearchReader(database, input)
+        return {
+          hydrated,
+          records: shows.map(id => ({ id, record: showRecordForId(id) })),
+          searches: searches.map(query => ({
+            kind: input.kind ?? null,
+            query,
+            results: searchCompactRecordsForQuery(query),
           })),
-        })),
-      }
+        }
+      })
     } finally {
       database.close()
     }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -82,6 +82,7 @@ type CompactRow = {
 type SearchStatementInput = Pick<SearchRecordsInput, 'includeSuperseded' | 'kind' | 'limit'>
 
 type CacheReadTestHooks = {
+  afterCompactSearchRead?: ((query: string) => void) | undefined
   afterShowRead?: ((id: string) => void) | undefined
   onCompactSearchPrepare?: ((source: string) => void) | undefined
   onShowPrepare?: ((source: string) => void) | undefined
@@ -938,7 +939,9 @@ const createCompactSearchReader = (database: DatabaseSync, input: SearchStatemen
     if (match.length === 0) {
       return []
     }
-    return (statement.all(match, ...kindParameters, limit) as CompactRow[]).map(compactRecordFromRow)
+    const records = (statement.all(match, ...kindParameters, limit) as CompactRow[]).map(compactRecordFromRow)
+    cacheReadTestHooks.afterCompactSearchRead?.(query)
+    return records
   }
 }
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -81,10 +81,18 @@ type CompactRow = {
 
 type SearchStatementInput = Pick<SearchRecordsInput, 'includeSuperseded' | 'kind' | 'limit'>
 
+type CacheReadTestHooks = {
+  afterShowRead?: ((id: string) => void) | undefined
+  onCompactSearchPrepare?: ((source: string) => void) | undefined
+  onShowPrepare?: ((source: string) => void) | undefined
+}
+
 class CacheSchemaMismatch extends Error {}
 
 let sqliteModule: SQLiteModule | undefined
 let sqliteFeaturesVerified = false
+
+export const cacheReadTestHooks: CacheReadTestHooks = {}
 
 const loadSQLite = () => {
   if (sqliteModule === undefined) {
@@ -908,7 +916,7 @@ const createCompactSearchReader = (database: DatabaseSync, input: SearchStatemen
   ].filter((value): value is string => value !== undefined)
   const kindParameters = input.kind === undefined ? [] : [input.kind]
   const limit = positiveLimit(input.limit)
-  const statement = database.prepare(`
+  const source = `
     SELECT
       records.id,
       records.kind,
@@ -922,7 +930,9 @@ const createCompactSearchReader = (database: DatabaseSync, input: SearchStatemen
     WHERE ${conditions.join(' AND ')}
     ORDER BY rank ASC, records.created_at DESC, records.id DESC
     LIMIT ?
-  `)
+  `
+  cacheReadTestHooks.onCompactSearchPrepare?.(source)
+  const statement = database.prepare(source)
   return (query: string) => {
     const match = literalMatchQuery(query)
     if (match.length === 0) {
@@ -940,9 +950,12 @@ export const searchCompactRecords = (input: SearchRecordsInput): CompactBrainRec
 
 const createShowReader = (database: DatabaseSync, includeSuperseded: boolean | undefined) => {
   const activeClause = includeSuperseded === true ? '' : ' AND active = 1'
-  const statement = database.prepare(`SELECT record_json FROM records WHERE id = ?${activeClause}`)
+  const source = `SELECT record_json FROM records WHERE id = ?${activeClause}`
+  cacheReadTestHooks.onShowPrepare?.(source)
+  const statement = database.prepare(source)
   return (id: string) => {
     const row = statement.get(id) as RecordRow | undefined
+    cacheReadTestHooks.afterShowRead?.(id)
     return row === undefined ? null : parseRecordRow(row)
   }
 }

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -252,6 +252,89 @@ describe('SQLite cache and reads', () => {
     }
   })
 
+  test('gather reads every search from one cache snapshot', () => {
+    const root = createRoot()
+    const addRecord = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>>('addRecord')
+    const firstId = 'search-snapshot-v1'
+    addRecord({
+      id: firstId,
+      kind: 'context',
+      payload: { summary: 'Search snapshot generation one' },
+      root,
+      searchText: 'snapshot searchable generation one',
+      source: 'agent',
+      subject: 'cache.search-snapshot',
+    })
+    const replacement = {
+      createdAt: '2026-08-08T00:00:01.000Z',
+      id: 'search-snapshot-v2',
+      kind: 'context',
+      path: 'encephalon/context/search-snapshot-v2.json',
+      payload: { summary: 'Search snapshot generation two' },
+      searchText: 'snapshot searchable generation two',
+      source: 'agent',
+      subject: 'cache.search-snapshot',
+      supersedes: [firstId],
+    }
+    let mutatedBetweenSearches = false
+
+    cacheReadTestHooks.afterCompactSearchRead = () => {
+      if (!mutatedBetweenSearches) {
+        mutatedBetweenSearches = true
+        const database = new DatabaseSync(cacheDatabasePath(root))
+        try {
+          database.exec('BEGIN IMMEDIATE')
+          database.prepare('UPDATE records SET active = 0 WHERE id = ?').run(firstId)
+          database
+            .prepare(`
+              INSERT INTO records(id, kind, subject, source, created_at, path, active, summary, record_json)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            `)
+            .run(
+              replacement.id,
+              replacement.kind,
+              replacement.subject,
+              replacement.source,
+              replacement.createdAt,
+              replacement.path,
+              1,
+              'Search snapshot generation two',
+              JSON.stringify(replacement),
+            )
+          database
+            .prepare('INSERT INTO record_search(id, text) VALUES (?, ?)')
+            .run(replacement.id, replacement.searchText)
+          database.exec('COMMIT')
+        } catch (error) {
+          try {
+            database.exec('ROLLBACK')
+          } catch {}
+          throw error
+        } finally {
+          database.close()
+        }
+      }
+    }
+
+    try {
+      const gatherRecords =
+        functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>>('gatherRecords')
+      const gathered = gatherRecords({
+        root,
+        searches: ['snapshot searchable', 'snapshot searchable'],
+      }) as {
+        searches: Array<{ results: Array<{ id: string }> }>
+      }
+      assert.equal(mutatedBetweenSearches, true)
+      assert.deepEqual(
+        gathered.searches.map(entry => entry.results.map(result => result.id)),
+        [[firstId], [firstId]],
+      )
+    } finally {
+      cacheReadTestHooks.afterCompactSearchRead = undefined
+    }
+  })
+
   test('gather preserves duplicate order while reusing show and search statements', () => {
     const root = createRoot()
     const addRecord = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>>('addRecord')

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -22,6 +22,12 @@ afterEach(() => {
 
 const functionFromApi = <T>(name: string) => (api as unknown as Record<string, T>)[name] as T
 
+const cacheDatabasePath = (root: string) => join(root, 'node_modules', '.cache', 'encephalon', 'brain.sqlite')
+
+type SQLitePrototype = {
+  prepare: (source: string) => unknown
+}
+
 describe('SQLite cache and reads', () => {
   test('prepares an empty repository before a cache directory exists', () => {
     const root = createRoot()
@@ -138,6 +144,179 @@ describe('SQLite cache and reads', () => {
       subject: 'no.summary',
     })
     assert.equal(searchCompactRecords({ query: 'searchable marker', root })[0]?.summary, null)
+  })
+
+  test('gather reads every item from one cache snapshot', () => {
+    const root = createRoot()
+    const addRecord = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>>('addRecord')
+    const firstId = 'snapshot-v1'
+    addRecord({
+      id: firstId,
+      kind: 'context',
+      payload: { summary: 'Snapshot generation one' },
+      root,
+      source: 'agent',
+      subject: 'cache.snapshot',
+    })
+    const replacement = {
+      createdAt: '2026-08-08T00:00:01.000Z',
+      id: 'snapshot-v2',
+      kind: 'context',
+      path: 'encephalon/context/snapshot-v2.json',
+      payload: { summary: 'Snapshot generation two' },
+      source: 'agent',
+      subject: 'cache.snapshot',
+      supersedes: [firstId],
+    }
+    const prototype = DatabaseSync.prototype as unknown as SQLitePrototype
+    const originalPrepare = prototype.prepare
+    let mutatedBetweenItems = false
+
+    prototype.prepare = function patchedPrepare(this: unknown, source: string) {
+      const statement = originalPrepare.call(this, source) as Record<PropertyKey, unknown>
+      if (source.includes('SELECT record_json FROM records WHERE id = ?')) {
+        return new Proxy(statement, {
+          get(target, property, receiver) {
+            const value = Reflect.get(target, property, receiver)
+            if (property !== 'get' || typeof value !== 'function') {
+              return value
+            }
+            return (...parameters: unknown[]) => {
+              const result = value.apply(target, parameters)
+              if (!mutatedBetweenItems) {
+                mutatedBetweenItems = true
+                const database = new DatabaseSync(cacheDatabasePath(root))
+                try {
+                  database.exec('BEGIN IMMEDIATE')
+                  database.prepare('UPDATE records SET active = 0 WHERE id = ?').run(firstId)
+                  database
+                    .prepare(`
+                      INSERT INTO records(id, kind, subject, source, created_at, path, active, summary, record_json)
+                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    `)
+                    .run(
+                      replacement.id,
+                      replacement.kind,
+                      replacement.subject,
+                      replacement.source,
+                      replacement.createdAt,
+                      replacement.path,
+                      1,
+                      'Snapshot generation two',
+                      JSON.stringify(replacement),
+                    )
+                  database
+                    .prepare('INSERT INTO record_search(id, text) VALUES (?, ?)')
+                    .run(replacement.id, 'Snapshot generation two')
+                  database.exec('COMMIT')
+                } catch (error) {
+                  try {
+                    database.exec('ROLLBACK')
+                  } catch {}
+                  throw error
+                } finally {
+                  database.close()
+                }
+              }
+              return result
+            }
+          },
+        })
+      }
+      return statement
+    }
+
+    try {
+      const gatherRecords =
+        functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>>('gatherRecords')
+      const gathered = gatherRecords({ root, shows: [firstId, firstId] }) as {
+        records: Array<{ id: string; record: { id: string } | null }>
+      }
+      assert.equal(mutatedBetweenItems, true)
+      assert.deepEqual(
+        gathered.records.map(entry => [entry.id, entry.record?.id ?? null]),
+        [
+          [firstId, firstId],
+          [firstId, firstId],
+        ],
+      )
+    } finally {
+      prototype.prepare = originalPrepare
+    }
+  })
+
+  test('gather preserves duplicate order while reusing show and search statements', () => {
+    const root = createRoot()
+    const addRecord = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>>('addRecord')
+    const first = addRecord({
+      id: 'reuse-v1',
+      kind: 'decision',
+      payload: { summary: 'First reusable decision' },
+      root,
+      source: 'agent',
+      subject: 'cache.reuse',
+    })
+    const second = addRecord({
+      id: 'reuse-v2',
+      kind: 'decision',
+      payload: { summary: 'Second reusable decision' },
+      root,
+      searchText: 'statement reuse marker',
+      source: 'agent',
+      subject: 'cache.reuse',
+      supersedes: [first.id],
+    })
+    const prototype = DatabaseSync.prototype as unknown as SQLitePrototype
+    const originalPrepare = prototype.prepare
+    let showPrepareCount = 0
+    let searchPrepareCount = 0
+    let compactSearchSelectedRecordJson = false
+
+    prototype.prepare = function patchedPrepare(this: unknown, source: string) {
+      if (source.includes('SELECT record_json FROM records WHERE id = ?')) {
+        showPrepareCount += 1
+      }
+      if (source.includes('FROM record_search') && source.includes('JOIN records')) {
+        searchPrepareCount += 1
+        compactSearchSelectedRecordJson ||= source.includes('records.record_json')
+      }
+      return originalPrepare.call(this, source)
+    }
+
+    try {
+      const gatherRecords =
+        functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>>('gatherRecords')
+      const gathered = gatherRecords({
+        root,
+        searches: ['statement reuse marker', 'statement reuse marker', '   '],
+        shows: [second.id, second.id, first.id],
+      }) as {
+        records: Array<{ id: string; record: { id: string } | null }>
+        searches: Array<{ query: string; results: Array<{ id: string }> }>
+      }
+      assert.deepEqual(
+        gathered.records.map(entry => [entry.id, entry.record?.id ?? null]),
+        [
+          [second.id, second.id],
+          [second.id, second.id],
+          [first.id, null],
+        ],
+      )
+      assert.deepEqual(
+        gathered.searches.map(entry => [entry.query, entry.results.map(result => result.id)]),
+        [
+          ['statement reuse marker', [second.id]],
+          ['statement reuse marker', [second.id]],
+          ['   ', []],
+        ],
+      )
+    } finally {
+      prototype.prepare = originalPrepare
+    }
+
+    assert.equal(showPrepareCount, 1)
+    assert.equal(searchPrepareCount, 1)
+    assert.equal(compactSearchSelectedRecordJson, false)
   })
 
   test('tracks record and referenced-artifact freshness', () => {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -5,6 +5,7 @@ import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, symli
 import { join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import { afterEach, describe, test } from 'node:test'
+import { cacheReadTestHooks } from '../src/cache.ts'
 import * as api from '../src/index.ts'
 import { createTestRepository, ensureParent, removeTestRepository } from '../test/helpers.ts'
 
@@ -50,10 +51,6 @@ const mutateCache = (root: string, mutation: (database: DatabaseSync) => void) =
   } finally {
     database.close()
   }
-}
-
-type SQLitePrototype = {
-  prepare: (source: string) => unknown
 }
 
 describe('SQLite cache and reads', () => {
@@ -196,62 +193,44 @@ describe('SQLite cache and reads', () => {
       subject: 'cache.snapshot',
       supersedes: [firstId],
     }
-    const prototype = DatabaseSync.prototype as unknown as SQLitePrototype
-    const originalPrepare = prototype.prepare
     let mutatedBetweenItems = false
 
-    prototype.prepare = function patchedPrepare(this: unknown, source: string) {
-      const statement = originalPrepare.call(this, source) as Record<PropertyKey, unknown>
-      if (source.includes('SELECT record_json FROM records WHERE id = ?')) {
-        return new Proxy(statement, {
-          get(target, property, receiver) {
-            const value = Reflect.get(target, property, receiver)
-            if (property !== 'get' || typeof value !== 'function') {
-              return value
-            }
-            return (...parameters: unknown[]) => {
-              const result = value.apply(target, parameters)
-              if (!mutatedBetweenItems) {
-                mutatedBetweenItems = true
-                const database = new DatabaseSync(cacheDatabasePath(root))
-                try {
-                  database.exec('BEGIN IMMEDIATE')
-                  database.prepare('UPDATE records SET active = 0 WHERE id = ?').run(firstId)
-                  database
-                    .prepare(`
-                      INSERT INTO records(id, kind, subject, source, created_at, path, active, summary, record_json)
-                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    `)
-                    .run(
-                      replacement.id,
-                      replacement.kind,
-                      replacement.subject,
-                      replacement.source,
-                      replacement.createdAt,
-                      replacement.path,
-                      1,
-                      'Snapshot generation two',
-                      JSON.stringify(replacement),
-                    )
-                  database
-                    .prepare('INSERT INTO record_search(id, text) VALUES (?, ?)')
-                    .run(replacement.id, 'Snapshot generation two')
-                  database.exec('COMMIT')
-                } catch (error) {
-                  try {
-                    database.exec('ROLLBACK')
-                  } catch {}
-                  throw error
-                } finally {
-                  database.close()
-                }
-              }
-              return result
-            }
-          },
-        })
+    cacheReadTestHooks.afterShowRead = () => {
+      if (!mutatedBetweenItems) {
+        mutatedBetweenItems = true
+        const database = new DatabaseSync(cacheDatabasePath(root))
+        try {
+          database.exec('BEGIN IMMEDIATE')
+          database.prepare('UPDATE records SET active = 0 WHERE id = ?').run(firstId)
+          database
+            .prepare(`
+              INSERT INTO records(id, kind, subject, source, created_at, path, active, summary, record_json)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            `)
+            .run(
+              replacement.id,
+              replacement.kind,
+              replacement.subject,
+              replacement.source,
+              replacement.createdAt,
+              replacement.path,
+              1,
+              'Snapshot generation two',
+              JSON.stringify(replacement),
+            )
+          database
+            .prepare('INSERT INTO record_search(id, text) VALUES (?, ?)')
+            .run(replacement.id, 'Snapshot generation two')
+          database.exec('COMMIT')
+        } catch (error) {
+          try {
+            database.exec('ROLLBACK')
+          } catch {}
+          throw error
+        } finally {
+          database.close()
+        }
       }
-      return statement
     }
 
     try {
@@ -269,7 +248,7 @@ describe('SQLite cache and reads', () => {
         ],
       )
     } finally {
-      prototype.prepare = originalPrepare
+      cacheReadTestHooks.afterShowRead = undefined
     }
   })
 
@@ -294,21 +273,16 @@ describe('SQLite cache and reads', () => {
       subject: 'cache.reuse',
       supersedes: [first.id],
     })
-    const prototype = DatabaseSync.prototype as unknown as SQLitePrototype
-    const originalPrepare = prototype.prepare
     let showPrepareCount = 0
     let searchPrepareCount = 0
     let compactSearchSelectedRecordJson = false
 
-    prototype.prepare = function patchedPrepare(this: unknown, source: string) {
-      if (source.includes('SELECT record_json FROM records WHERE id = ?')) {
-        showPrepareCount += 1
-      }
-      if (source.includes('bm25(record_search)')) {
-        searchPrepareCount += 1
-        compactSearchSelectedRecordJson ||= source.includes('records.record_json')
-      }
-      return originalPrepare.call(this, source)
+    cacheReadTestHooks.onShowPrepare = () => {
+      showPrepareCount += 1
+    }
+    cacheReadTestHooks.onCompactSearchPrepare = source => {
+      searchPrepareCount += 1
+      compactSearchSelectedRecordJson ||= source.includes('records.record_json')
     }
 
     try {
@@ -339,7 +313,8 @@ describe('SQLite cache and reads', () => {
         ],
       )
     } finally {
-      prototype.prepare = originalPrepare
+      cacheReadTestHooks.onShowPrepare = undefined
+      cacheReadTestHooks.onCompactSearchPrepare = undefined
     }
 
     assert.equal(showPrepareCount, 1)


### PR DESCRIPTION
## Human summary

Gathered cache results now come from one SQLite snapshot, so batched record and search lookups cannot mix old and new cache generations.

## Summary

- Wrap `gatherRecords()` item reads in one explicit SQLite read transaction after any requested hydration completes.
- Prepare the gather show statement once per call and reuse one compact search statement shape for repeated queries.
- Share compact row mapping with standalone compact search and avoid selecting unused full record JSON for compact results.
- Add regression coverage for cache mutation between gather items, duplicate ID/query ordering, and statement reuse.
