### PR TITLE
[MAR-2519] Make SQLite gate the lock authority

### DIFF
--- a/encephalon/workflow/1f3d2e98-59b3-4ff3-ab64-15bcc785a5fa.json
+++ b/encephalon/workflow/1f3d2e98-59b3-4ff3-ab64-15bcc785a5fa.json
@@ -1,0 +1,19 @@
+{
+  "createdAt": "2026-08-08T11:20:18.683Z",
+  "id": "1f3d2e98-59b3-4ff3-ab64-15bcc785a5fa",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Pullfrog PR #16 found non-SQLite recovery markers must be reclaimable because process death does not clean filesystem marker directories.",
+    "mistake": "A mkdir-based operation-lock.recovery marker can permanently block all later callers if the recoverer dies before its finally cleanup, even though SQLite locks themselves are released by the OS.",
+    "guidance": [
+      "When adding filesystem marker locks around SQLite recovery, write owner metadata with pid, token, and acquiredAt.",
+      "Peers must reclaim dead-owner or stale recovery markers before timing out with CACHE_BUSY.",
+      "Prefer rename-aside reclamation over direct deletion of marker paths to keep races benign."
+    ],
+    "verification": [
+      "Add a regression test with a dead recovery-marker owner before considering marker-lock recovery complete."
+    ]
+  },
+  "source": "agent",
+  "subject": "review.lock-recovery-marker-reclaim"
+}

--- a/encephalon/workflow/b043f1e4-73a1-4ceb-b3e1-9b0ae96aa272.json
+++ b/encephalon/workflow/b043f1e4-73a1-4ceb-b3e1-9b0ae96aa272.json
@@ -1,0 +1,22 @@
+{
+  "createdAt": "2026-08-08T11:13:19.643Z",
+  "id": "b043f1e4-73a1-4ceb-b3e1-9b0ae96aa272",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Pullfrog PR #16 found corrupt SQLite operation-gate recovery must not unlink or rename a live replacement gate, and tests must prove multi-process exclusivity.",
+    "mistake": "Recovering a malformed operation-lock.sqlite by deleting the path can let one process hold a transaction on an unlinked inode while another process creates and locks a new inode at the same path.",
+    "guidance": [
+      "Serialise corrupt gate recovery with an atomic recovery marker before replacing gate files.",
+      "Make normal gate openers wait while recovery is active so no contender creates a new gate during quarantine.",
+      "Use rename-aside quarantine for corrupt gate files rather than direct unlinking of the live path.",
+      "Cover corrupt-gate recovery with at least two child-process contenders that assert exclusive critical-section entry.",
+      "Keep stale live-PID tests focused on stale owner metadata; do not mock Date.now unless the implementation still depends on clock polling."
+    ],
+    "verification": [
+      "Run node --test test/cache.test.ts after lock recovery changes.",
+      "Check Pullfrog review threads for both production race and test coverage comments before resolving them."
+    ]
+  },
+  "source": "agent",
+  "subject": "review.lock-corrupt-gate-recovery"
+}

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -5,6 +5,7 @@ import { DatabaseSync } from 'node:sqlite'
 import { EncephalonError, fail, wrapIo } from './errors.ts'
 
 const LOCK_WAIT_MILLISECONDS = 60_000
+const RECOVERY_POLL_MILLISECONDS = 50
 
 type LockOwner = {
   token: string
@@ -67,6 +68,7 @@ export const withOperationLock = <Result>(
   const directory = cacheDirectory(root)
   const lockPath = resolve(directory, 'operation.lock')
   const gatePath = resolve(directory, 'operation-lock.sqlite')
+  const gateRecoveryPath = resolve(directory, 'operation-lock.recovery')
   const token = randomUUID()
   const candidatePath = resolve(directory, `operation.lock.${token}`)
   const startedAt = Date.now()
@@ -75,13 +77,45 @@ export const withOperationLock = <Result>(
 
   const remainingMilliseconds = () => Math.max(0, LOCK_WAIT_MILLISECONDS - (Date.now() - startedAt))
 
-  const removeGate = () => {
-    for (const candidate of [gatePath, `${gatePath}-wal`, `${gatePath}-shm`, `${gatePath}-journal`]) {
-      rmSync(candidate, { force: true })
+  const wait = (milliseconds: number) => {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds)
+  }
+
+  const missingPath = (error: unknown) => (error as NodeJS.ErrnoException).code === 'ENOENT'
+
+  const quarantineGateCandidate = (path: string) => {
+    const quarantinePath = `${path}.corrupt-${token}`
+    try {
+      renameSync(path, quarantinePath)
+      rmSync(quarantinePath, { force: true })
+    } catch (error) {
+      if (!missingPath(error)) {
+        throw error
+      }
     }
   }
 
-  const beginGateTransaction = () => {
+  const waitForGateRecovery = () => {
+    while (existsSync(gateRecoveryPath)) {
+      if (remainingMilliseconds() === 0) {
+        return fail('CACHE_BUSY', 'Timed out waiting for the Encephalon operation lock.', {
+          timeoutMilliseconds: LOCK_WAIT_MILLISECONDS,
+        })
+      }
+      wait(Math.min(RECOVERY_POLL_MILLISECONDS, remainingMilliseconds()))
+    }
+  }
+
+  const quarantineCorruptGate = () => {
+    for (const candidate of [`${gatePath}-wal`, `${gatePath}-shm`, `${gatePath}-journal`, gatePath]) {
+      quarantineGateCandidate(candidate)
+    }
+  }
+
+  const beginGateTransaction = (recoveryLockHeld = false) => {
+    if (!recoveryLockHeld) {
+      waitForGateRecovery()
+    }
     gate = new DatabaseSync(gatePath, { timeout: remainingMilliseconds() })
     try {
       gate.exec('BEGIN IMMEDIATE')
@@ -90,6 +124,45 @@ export const withOperationLock = <Result>(
       gate.close()
       gate = undefined
       throw error
+    }
+  }
+
+  const recoverCorruptGate = () => {
+    let recoveryLockHeld = false
+    while (!recoveryLockHeld) {
+      try {
+        mkdirSync(gateRecoveryPath)
+        recoveryLockHeld = true
+      } catch (error) {
+        const existingRecovery = (error as NodeJS.ErrnoException).code === 'EEXIST'
+        if (!existingRecovery) {
+          throw error
+        }
+        if (remainingMilliseconds() === 0) {
+          return fail('CACHE_BUSY', 'Timed out waiting for the Encephalon operation lock.', {
+            timeoutMilliseconds: LOCK_WAIT_MILLISECONDS,
+          })
+        }
+        wait(Math.min(RECOVERY_POLL_MILLISECONDS, remainingMilliseconds()))
+      }
+    }
+    try {
+      try {
+        beginGateTransaction(true)
+      } catch (error) {
+        if (sqliteBusy(error)) {
+          return fail('CACHE_BUSY', 'Timed out waiting for the Encephalon operation lock.', {
+            timeoutMilliseconds: LOCK_WAIT_MILLISECONDS,
+          })
+        }
+        if (!sqliteCorrupt(error)) {
+          throw error
+        }
+        quarantineCorruptGate()
+        beginGateTransaction(true)
+      }
+    } finally {
+      rmSync(gateRecoveryPath, { force: true, recursive: true })
     }
   }
 
@@ -118,17 +191,7 @@ export const withOperationLock = <Result>(
       if (!sqliteCorrupt(error)) {
         throw error
       }
-      removeGate()
-      try {
-        beginGateTransaction()
-      } catch (retryError) {
-        if (sqliteBusy(retryError)) {
-          return fail('CACHE_BUSY', 'Timed out waiting for the Encephalon operation lock.', {
-            timeoutMilliseconds: LOCK_WAIT_MILLISECONDS,
-          })
-        }
-        throw retryError
-      }
+      recoverCorruptGate()
     }
 
     // The SQLite transaction is the authoritative operation lock. A valid owner

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -5,7 +5,6 @@ import { DatabaseSync } from 'node:sqlite'
 import { EncephalonError, fail, wrapIo } from './errors.ts'
 
 const LOCK_WAIT_MILLISECONDS = 60_000
-const POLL_MILLISECONDS = 50
 
 type LockOwner = {
   token: string
@@ -15,19 +14,6 @@ type LockOwner = {
 
 type LockTestHooks = {
   afterStaleObservation?: () => void
-}
-
-const sleep = (milliseconds: number) => {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds)
-}
-
-const processExists = (pid: number) => {
-  try {
-    process.kill(pid, 0)
-    return true
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code === 'EPERM'
-  }
 }
 
 const readOwner = (path: string): LockOwner | undefined => {
@@ -61,6 +47,16 @@ const sqliteBusy = (error: unknown) => {
   )
 }
 
+const sqliteCorrupt = (error: unknown) => {
+  const candidate = error as { errcode?: unknown; message?: unknown }
+  return (
+    candidate.errcode === 11 ||
+    candidate.errcode === 26 ||
+    (typeof candidate.message === 'string' &&
+      /database disk image is malformed|file is not a database|malformed database schema/i.test(candidate.message))
+  )
+}
+
 export const cacheDirectory = (root: string) => resolve(root, 'node_modules', '.cache', 'encephalon')
 
 export const withOperationLock = <Result>(
@@ -77,6 +73,26 @@ export const withOperationLock = <Result>(
   let gate: DatabaseSync | undefined
   let gateTransaction = false
 
+  const remainingMilliseconds = () => Math.max(0, LOCK_WAIT_MILLISECONDS - (Date.now() - startedAt))
+
+  const removeGate = () => {
+    for (const candidate of [gatePath, `${gatePath}-wal`, `${gatePath}-shm`, `${gatePath}-journal`]) {
+      rmSync(candidate, { force: true })
+    }
+  }
+
+  const beginGateTransaction = () => {
+    gate = new DatabaseSync(gatePath, { timeout: remainingMilliseconds() })
+    try {
+      gate.exec('BEGIN IMMEDIATE')
+      gateTransaction = true
+    } catch (error) {
+      gate.close()
+      gate = undefined
+      throw error
+    }
+  }
+
   try {
     mkdirSync(directory, { recursive: true })
     mkdirSync(candidatePath)
@@ -87,43 +103,49 @@ export const withOperationLock = <Result>(
     }
     writeFileSync(resolve(candidatePath, 'owner.json'), `${JSON.stringify(candidateOwner)}\n`, { flag: 'wx' })
 
-    const observedOwner = existsSync(lockPath) ? readOwner(lockPath) : undefined
-    if (existsSync(lockPath) && (observedOwner === undefined || !processExists(observedOwner.pid))) {
+    if (existsSync(lockPath)) {
       testHooks.afterStaleObservation?.()
     }
 
-    const remaining = Math.max(0, LOCK_WAIT_MILLISECONDS - (Date.now() - startedAt))
-    gate = new DatabaseSync(gatePath, { timeout: remaining })
     try {
-      gate.exec('BEGIN IMMEDIATE')
-      gateTransaction = true
+      beginGateTransaction()
     } catch (error) {
       if (sqliteBusy(error)) {
         return fail('CACHE_BUSY', 'Timed out waiting for the Encephalon operation lock.', {
           timeoutMilliseconds: LOCK_WAIT_MILLISECONDS,
         })
       }
-      throw error
+      if (!sqliteCorrupt(error)) {
+        throw error
+      }
+      removeGate()
+      try {
+        beginGateTransaction()
+      } catch (retryError) {
+        if (sqliteBusy(retryError)) {
+          return fail('CACHE_BUSY', 'Timed out waiting for the Encephalon operation lock.', {
+            timeoutMilliseconds: LOCK_WAIT_MILLISECONDS,
+          })
+        }
+        throw retryError
+      }
     }
 
-    while (existsSync(lockPath)) {
-      const owner = readOwner(lockPath)
-      if (owner === undefined || !processExists(owner.pid)) {
-        rmSync(lockPath, { force: true, recursive: true })
-      } else if (Date.now() - startedAt <= LOCK_WAIT_MILLISECONDS) {
-        sleep(POLL_MILLISECONDS)
-      } else {
-        return fail('CACHE_BUSY', 'Timed out waiting for the Encephalon operation lock.', {
-          timeoutMilliseconds: LOCK_WAIT_MILLISECONDS,
-        })
-      }
+    // The SQLite transaction is the authoritative operation lock. A valid owner
+    // must still hold that gate, so any directory metadata seen here is orphaned.
+    if (existsSync(lockPath)) {
+      rmSync(lockPath, { force: true, recursive: true })
     }
 
     renameSync(candidatePath, lockPath)
     try {
       return operation()
     } finally {
-      releaseOwnedLock(lockPath, token)
+      try {
+        releaseOwnedLock(lockPath, token)
+      } catch {
+        // The SQLite gate is authoritative; stale metadata is removed by the next holder.
+      }
     }
   } catch (error) {
     if (error instanceof EncephalonError) {
@@ -139,6 +161,10 @@ export const withOperationLock = <Result>(
       }
     }
     gate?.close()
-    rmSync(candidatePath, { force: true, recursive: true })
+    try {
+      rmSync(candidatePath, { force: true, recursive: true })
+    } catch {
+      // Candidate cleanup must not mask the operation outcome.
+    }
   }
 }

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -1,11 +1,12 @@
 import { randomUUID } from 'node:crypto'
-import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import { EncephalonError, fail, wrapIo } from './errors.ts'
 
 const LOCK_WAIT_MILLISECONDS = 60_000
 const RECOVERY_POLL_MILLISECONDS = 50
+const RECOVERY_STALE_MILLISECONDS = 5000
 
 type LockOwner = {
   token: string
@@ -35,6 +36,15 @@ const releaseOwnedLock = (path: string, token: string) => {
   const owner = readOwner(path)
   if (owner?.token === token) {
     rmSync(path, { force: true, recursive: true })
+  }
+}
+
+const processIsRunning = (pid: number) => {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM'
   }
 }
 
@@ -83,6 +93,35 @@ export const withOperationLock = <Result>(
 
   const missingPath = (error: unknown) => (error as NodeJS.ErrnoException).code === 'ENOENT'
 
+  const recoveryMarkerIsStale = () => {
+    const owner = readOwner(gateRecoveryPath)
+    if (owner !== undefined) {
+      const acquiredAt = Date.parse(owner.acquiredAt)
+      const age = Number.isFinite(acquiredAt) ? Date.now() - acquiredAt : RECOVERY_STALE_MILLISECONDS + 1
+      return !processIsRunning(owner.pid) || age > RECOVERY_STALE_MILLISECONDS
+    }
+    try {
+      return Date.now() - statSync(gateRecoveryPath).mtimeMs > RECOVERY_STALE_MILLISECONDS
+    } catch (error) {
+      if (missingPath(error)) {
+        return false
+      }
+      throw error
+    }
+  }
+
+  const reclaimRecoveryMarker = () => {
+    const quarantinePath = `${gateRecoveryPath}.stale-${token}`
+    try {
+      renameSync(gateRecoveryPath, quarantinePath)
+      rmSync(quarantinePath, { force: true, recursive: true })
+    } catch (error) {
+      if (!missingPath(error)) {
+        throw error
+      }
+    }
+  }
+
   const quarantineGateCandidate = (path: string) => {
     const quarantinePath = `${path}.corrupt-${token}`
     try {
@@ -101,6 +140,9 @@ export const withOperationLock = <Result>(
         return fail('CACHE_BUSY', 'Timed out waiting for the Encephalon operation lock.', {
           timeoutMilliseconds: LOCK_WAIT_MILLISECONDS,
         })
+      }
+      if (recoveryMarkerIsStale()) {
+        reclaimRecoveryMarker()
       }
       wait(Math.min(RECOVERY_POLL_MILLISECONDS, remainingMilliseconds()))
     }
@@ -132,6 +174,15 @@ export const withOperationLock = <Result>(
     while (!recoveryLockHeld) {
       try {
         mkdirSync(gateRecoveryPath)
+        writeFileSync(
+          resolve(gateRecoveryPath, 'owner.json'),
+          `${JSON.stringify({
+            acquiredAt: new Date().toISOString(),
+            pid: process.pid,
+            token,
+          })}\n`,
+          { flag: 'wx' },
+        )
         recoveryLockHeld = true
       } catch (error) {
         const existingRecovery = (error as NodeJS.ErrnoException).code === 'EEXIST'
@@ -142,6 +193,9 @@ export const withOperationLock = <Result>(
           return fail('CACHE_BUSY', 'Timed out waiting for the Encephalon operation lock.', {
             timeoutMilliseconds: LOCK_WAIT_MILLISECONDS,
           })
+        }
+        if (recoveryMarkerIsStale()) {
+          reclaimRecoveryMarker()
         }
         wait(Math.min(RECOVERY_POLL_MILLISECONDS, remainingMilliseconds()))
       }

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -849,6 +849,30 @@ describe('SQLite cache and reads', () => {
     )
   })
 
+  test('reclaims an abandoned operation gate recovery marker', () => {
+    const root = createRoot()
+    const recoveryPath = join(root, 'node_modules', '.cache', 'encephalon', 'operation-lock.recovery')
+    const deadProcess = spawnSync(process.execPath, ['-e', ''])
+    const deadPid = deadProcess.pid
+    assert.equal(deadProcess.status, 0)
+    assert.ok(deadPid !== undefined)
+    mkdirSync(recoveryPath, { recursive: true })
+    writeFileSync(
+      join(recoveryPath, 'owner.json'),
+      `${JSON.stringify({
+        acquiredAt: new Date().toISOString(),
+        pid: deadPid,
+        token: 'dead-recovery-owner',
+      })}\n`,
+    )
+
+    assert.equal(
+      withOperationLock(root, () => 'entered'),
+      'entered',
+    )
+    assert.equal(existsSync(recoveryPath), false)
+  })
+
   test('serialises two contenders recovering the same malformed operation gate', async () => {
     const root = createRoot()
     const cachePath = join(root, 'node_modules', '.cache', 'encephalon')

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -830,22 +830,10 @@ describe('SQLite cache and reads', () => {
         token: 'stale-live-pid-owner',
       })}\n`,
     )
-    const startedAt = Date.now()
-    const originalNow = Date.now
-    let nowCalls = 0
-    Date.now = () => {
-      const elapsed = nowCalls > 2 ? 60_001 : 0
-      nowCalls += 1
-      return startedAt + elapsed
-    }
-    try {
-      assert.equal(
-        withOperationLock(root, () => 'entered'),
-        'entered',
-      )
-    } finally {
-      Date.now = originalNow
-    }
+    assert.equal(
+      withOperationLock(root, () => 'entered'),
+      'entered',
+    )
     assert.equal(existsSync(lockPath), false)
   })
 

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import { afterEach, describe, test } from 'node:test'
 import * as api from '../src/index.ts'
+import { withOperationLock } from '../src/lock.ts'
 import { createTestRepository, ensureParent, removeTestRepository } from '../test/helpers.ts'
 
 const roots: string[] = []
@@ -230,6 +231,49 @@ describe('SQLite cache and reads', () => {
     writeFileSync(join(lockPath, 'owner.json'), 'not-json')
     const prepare = functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')
     assert.deepEqual(prepare({ root }), { hydrated: true, recordsIndexed: 0 })
+  })
+
+  test('ignores stale owner metadata with a reused live PID after acquiring the gate', () => {
+    const root = createRoot()
+    const lockPath = join(root, 'node_modules', '.cache', 'encephalon', 'operation.lock')
+    mkdirSync(lockPath, { recursive: true })
+    writeFileSync(
+      join(lockPath, 'owner.json'),
+      `${JSON.stringify({
+        acquiredAt: '2026-08-06T10:00:00.000Z',
+        pid: process.pid,
+        token: 'stale-live-pid-owner',
+      })}\n`,
+    )
+    const startedAt = Date.now()
+    const originalNow = Date.now
+    let nowCalls = 0
+    Date.now = () => {
+      const elapsed = nowCalls > 2 ? 60_001 : 0
+      nowCalls += 1
+      return startedAt + elapsed
+    }
+    try {
+      assert.equal(
+        withOperationLock(root, () => 'entered'),
+        'entered',
+      )
+    } finally {
+      Date.now = originalNow
+    }
+    assert.equal(existsSync(lockPath), false)
+  })
+
+  test('recovers a malformed disposable operation gate database', () => {
+    const root = createRoot()
+    const cachePath = join(root, 'node_modules', '.cache', 'encephalon')
+    mkdirSync(cachePath, { recursive: true })
+    writeFileSync(join(cachePath, 'operation-lock.sqlite'), 'not a sqlite database')
+
+    assert.equal(
+      withOperationLock(root, () => 'entered'),
+      'entered',
+    )
   })
 
   test('serialises two contenders that both observed the same stale lock', async () => {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -861,6 +861,47 @@ describe('SQLite cache and reads', () => {
     )
   })
 
+  test('serialises two contenders recovering the same malformed operation gate', async () => {
+    const root = createRoot()
+    const cachePath = join(root, 'node_modules', '.cache', 'encephalon')
+    const gatePath = join(cachePath, 'operation-lock.sqlite')
+    const releasePath = join(root, 'release-corrupt-gate-contenders')
+    const activePath = join(root, 'active-corrupt-gate-contender')
+    const firstReady = join(root, 'first-corrupt-gate-ready')
+    const secondReady = join(root, 'second-corrupt-gate-ready')
+    const firstEntered = join(root, 'first-corrupt-gate-entered')
+    const secondEntered = join(root, 'second-corrupt-gate-entered')
+    mkdirSync(cachePath, { recursive: true })
+    writeFileSync(gatePath, 'not a sqlite database')
+
+    const fixture = join(import.meta.dirname, 'fixtures', 'contend-for-corrupt-gate.ts')
+    const first = spawn(process.execPath, [fixture, root, firstReady, releasePath, activePath, firstEntered, '300'], {
+      stdio: 'inherit',
+    })
+    const second = spawn(
+      process.execPath,
+      [fixture, root, secondReady, releasePath, activePath, secondEntered, '300'],
+      {
+        stdio: 'inherit',
+      },
+    )
+
+    waitForPath(firstReady, first)
+    waitForPath(secondReady, second)
+    writeFileSync(releasePath, 'release')
+
+    if (first.exitCode === null) {
+      await once(first, 'exit')
+    }
+    if (second.exitCode === null) {
+      await once(second, 'exit')
+    }
+    assert.equal(first.exitCode, 0)
+    assert.equal(second.exitCode, 0)
+    assert.equal(existsSync(firstEntered), true)
+    assert.equal(existsSync(secondEntered), true)
+  })
+
   test('serialises two contenders that both observed the same stale lock', async () => {
     const root = createRoot()
     const cachePath = join(root, 'node_modules', '.cache', 'encephalon')

--- a/test/fixtures/contend-for-corrupt-gate.ts
+++ b/test/fixtures/contend-for-corrupt-gate.ts
@@ -1,0 +1,36 @@
+import { closeSync, existsSync, openSync, rmSync, writeFileSync } from 'node:fs'
+import { withOperationLock } from '../../src/lock.ts'
+
+const [root, readyPath, releasePath, activePath, enteredPath, holdText] = process.argv.slice(2)
+
+if (
+  root === undefined ||
+  readyPath === undefined ||
+  releasePath === undefined ||
+  activePath === undefined ||
+  enteredPath === undefined ||
+  holdText === undefined
+) {
+  throw new Error('Expected repository, synchronisation, and result paths.')
+}
+
+const holdMilliseconds = Number(holdText)
+const wait = (milliseconds: number) => {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds)
+}
+
+writeFileSync(readyPath, 'ready')
+while (!existsSync(releasePath)) {
+  wait(10)
+}
+
+withOperationLock(root, () => {
+  const descriptor = openSync(activePath, 'wx')
+  try {
+    writeFileSync(enteredPath, 'entered')
+    wait(holdMilliseconds)
+  } finally {
+    closeSync(descriptor)
+    rmSync(activePath, { force: true })
+  }
+})


### PR DESCRIPTION
## Human summary

Operation locking now trusts the SQLite gate instead of stale PID metadata, avoiding false lockouts when a process ID has been reused.

## Summary

- Make the SQLite `BEGIN IMMEDIATE` gate the documented authority for operation serialization.
- Treat any `operation.lock` directory seen after acquiring the SQLite gate as orphaned metadata.
- Recover malformed disposable gate databases by removing gate files and retrying acquisition.
- Make directory-lock release and candidate cleanup best-effort so cleanup failures do not mask operation outcomes.
- Add regression tests for reused live-PID owner metadata and malformed gate database recovery.
