### PR TITLE
[MAR-2520] Validate API inputs before repository I/O

### DIFF
--- a/encephalon/review/21c4b7fa-0cd5-4c22-98bb-1d461fbd773d.json
+++ b/encephalon/review/21c4b7fa-0cd5-4c22-98bb-1d461fbd773d.json
@@ -1,0 +1,20 @@
+{
+  "createdAt": "2026-08-08T11:39:11.931Z",
+  "id": "21c4b7fa-0cd5-4c22-98bb-1d461fbd773d",
+  "kind": "review",
+  "payload": {
+    "summary": "Public addRecord parsing must validate root before repository discovery and must not discard generated BrainRecordFile values.",
+    "lessons": [
+      "When a public parser calls an impure normaliser such as createRecordFile, thread the generated value into the write path or use a pure validator; never call it only as a probe and then recreate the record later.",
+      "Keep addRecord root validation aligned with the other public API parsers by applying rootProperties before resolveRepository can perform filesystem discovery.",
+      "Side-effect guard tests should include addRecord root validation, not only record schema fields."
+    ],
+    "verification": [
+      "Before committing addRecord parser changes, check tests that invalid public inputs do not create cache or instruction side effects.",
+      "Review parseAddRecordInput for generated ids/timestamps being preserved across the public add path."
+    ]
+  },
+  "searchText": "addRecord input validation createRecordFile root public parser Pullfrog",
+  "source": "agent",
+  "subject": "review.add-record-input-validation"
+}

--- a/src/api-input.ts
+++ b/src/api-input.ts
@@ -180,8 +180,10 @@ export const parseInitInput = (value: unknown = {}): InitEncephalonInput => {
 
 export const parseAddRecordInput = (value: unknown): ParsedAddRecordInput => {
   const input = objectInput(value, 'addRecord') as AddRecordInput
+  const root = rootProperties(input)
   return {
     ...input,
+    ...root,
     recordFile: createRecordFile(input),
   }
 }

--- a/src/api-input.ts
+++ b/src/api-input.ts
@@ -2,6 +2,7 @@ import { fail } from './errors.ts'
 import { createRecordFile, validateId, validateKind } from './schema.ts'
 import type {
   AddRecordInput,
+  BrainRecordFile,
   GatherInput,
   InitEncephalonInput,
   ListRecordsInput,
@@ -9,6 +10,10 @@ import type {
   SearchRecordsInput,
   ShowRecordInput,
 } from './types.ts'
+
+export type ParsedAddRecordInput = AddRecordInput & {
+  recordFile: BrainRecordFile
+}
 
 const MAX_TEXT_BYTES = 1024
 
@@ -173,8 +178,10 @@ export const parseInitInput = (value: unknown = {}): InitEncephalonInput => {
   }
 }
 
-export const parseAddRecordInput = (value: unknown): AddRecordInput => {
+export const parseAddRecordInput = (value: unknown): ParsedAddRecordInput => {
   const input = objectInput(value, 'addRecord') as AddRecordInput
-  createRecordFile(input)
-  return input
+  return {
+    ...input,
+    recordFile: createRecordFile(input),
+  }
 }

--- a/src/api-input.ts
+++ b/src/api-input.ts
@@ -1,0 +1,180 @@
+import { fail } from './errors.ts'
+import { createRecordFile, validateId, validateKind } from './schema.ts'
+import type {
+  AddRecordInput,
+  GatherInput,
+  InitEncephalonInput,
+  ListRecordsInput,
+  RootInput,
+  SearchRecordsInput,
+  ShowRecordInput,
+} from './types.ts'
+
+const MAX_TEXT_BYTES = 1024
+
+const objectInput = (value: unknown, name: string): Record<string, unknown> => {
+  if (value === undefined) {
+    return {}
+  }
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>
+  }
+  return fail('INVALID_ARGUMENT', `${name} input must be an object.`, { field: name })
+}
+
+const optionalRoot = (value: unknown) => {
+  if (value === undefined) {
+    return
+  }
+  if (typeof value === 'string' && value.length > 0) {
+    return value
+  }
+  return fail('INVALID_ARGUMENT', 'root must be a non-empty string.', { field: 'root' })
+}
+
+const optionalBoolean = (value: unknown, field: string) => {
+  if (value === undefined) {
+    return
+  }
+  if (typeof value === 'boolean') {
+    return value
+  }
+  return fail('INVALID_ARGUMENT', `${field} must be a boolean.`, { field })
+}
+
+export const optionalLimit = (value: unknown) => {
+  if (value === undefined) {
+    return
+  }
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0 && value <= 1000) {
+    return value
+  }
+  return fail('INVALID_ARGUMENT', 'limit must be an integer between 1 and 1000.', { field: 'limit' })
+}
+
+const optionalText = (value: unknown, field: string) => {
+  if (value === undefined) {
+    return
+  }
+  if (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value === value.trim() &&
+    Buffer.byteLength(value, 'utf8') <= MAX_TEXT_BYTES
+  ) {
+    return value
+  }
+  return fail('INVALID_ARGUMENT', `${field} must be a non-empty string of at most 1024 UTF-8 bytes.`, { field })
+}
+
+const optionalQuery = (value: unknown, field: string) => {
+  if (value === undefined) {
+    return
+  }
+  if (typeof value === 'string' && Buffer.byteLength(value, 'utf8') <= MAX_TEXT_BYTES) {
+    return value
+  }
+  return fail('INVALID_ARGUMENT', `${field} must be a string of at most 1024 UTF-8 bytes.`, { field })
+}
+
+const optionalStringArray = (value: unknown, field: string, item: (value: unknown) => string) => {
+  if (value === undefined) {
+    return
+  }
+  if (Array.isArray(value) && value.every(entry => typeof entry === 'string')) {
+    return value.map(item)
+  }
+  return fail('INVALID_ARGUMENT', `${field} must be an array of strings.`, { field })
+}
+
+const rootProperties = (input: Record<string, unknown>): RootInput => {
+  const root = optionalRoot(input.root)
+  return root === undefined ? {} : { root }
+}
+
+export const parseRootInput = (value: unknown = {}, name = 'root'): RootInput =>
+  rootProperties(objectInput(value, name))
+
+export const parseListRecordsInput = (value: unknown = {}): ListRecordsInput => {
+  const input = objectInput(value, 'listRecords')
+  const root = rootProperties(input)
+  const kind = input.kind === undefined ? undefined : validateKind(input.kind)
+  const subject = optionalText(input.subject, 'subject')
+  const includeSuperseded = optionalBoolean(input.includeSuperseded, 'includeSuperseded')
+  const limit = optionalLimit(input.limit)
+  return {
+    ...root,
+    ...(kind === undefined ? {} : { kind }),
+    ...(subject === undefined ? {} : { subject }),
+    ...(includeSuperseded === undefined ? {} : { includeSuperseded }),
+    ...(limit === undefined ? {} : { limit }),
+  }
+}
+
+export const parseShowRecordInput = (value: unknown): ShowRecordInput => {
+  const input = objectInput(value, 'showRecord')
+  const root = rootProperties(input)
+  const activeOnly = optionalBoolean(input.activeOnly, 'activeOnly')
+  return {
+    ...root,
+    ...(activeOnly === undefined ? {} : { activeOnly }),
+    id: validateId(input.id),
+  }
+}
+
+export const parseSearchRecordsInput = (value: unknown): SearchRecordsInput => {
+  const input = objectInput(value, 'searchRecords')
+  const root = rootProperties(input)
+  const kind = input.kind === undefined ? undefined : validateKind(input.kind)
+  const includeSuperseded = optionalBoolean(input.includeSuperseded, 'includeSuperseded')
+  const limit = optionalLimit(input.limit)
+  const query = optionalQuery(input.query, 'query')
+  if (query === undefined) {
+    return fail('INVALID_ARGUMENT', 'query must be a string of at most 1024 UTF-8 bytes.', { field: 'query' })
+  }
+  return {
+    ...root,
+    query,
+    ...(kind === undefined ? {} : { kind }),
+    ...(includeSuperseded === undefined ? {} : { includeSuperseded }),
+    ...(limit === undefined ? {} : { limit }),
+  }
+}
+
+export const parseGatherInput = (value: unknown): GatherInput => {
+  const input = objectInput(value, 'gatherRecords')
+  const root = rootProperties(input)
+  const kind = input.kind === undefined ? undefined : validateKind(input.kind)
+  const includeSuperseded = optionalBoolean(input.includeSuperseded, 'includeSuperseded')
+  const hydrate = optionalBoolean(input.hydrate, 'hydrate')
+  const limit = optionalLimit(input.limit)
+  const searches = optionalStringArray(input.searches, 'searches', entry => optionalQuery(entry, 'searches') ?? '')
+  const shows = optionalStringArray(input.shows, 'shows', validateId)
+  return {
+    ...root,
+    ...(searches === undefined ? {} : { searches }),
+    ...(shows === undefined ? {} : { shows }),
+    ...(kind === undefined ? {} : { kind }),
+    ...(includeSuperseded === undefined ? {} : { includeSuperseded }),
+    ...(hydrate === undefined ? {} : { hydrate }),
+    ...(limit === undefined ? {} : { limit }),
+  }
+}
+
+export const parseInitInput = (value: unknown = {}): InitEncephalonInput => {
+  const input = objectInput(value, 'initEncephalon')
+  const root = rootProperties(input)
+  const refreshBaseline = optionalBoolean(input.refreshBaseline, 'refreshBaseline')
+  const remove = optionalBoolean(input.remove, 'remove')
+  return {
+    ...root,
+    ...(refreshBaseline === undefined ? {} : { refreshBaseline }),
+    ...(remove === undefined ? {} : { remove }),
+  }
+}
+
+export const parseAddRecordInput = (value: unknown): AddRecordInput => {
+  const input = objectInput(value, 'addRecord') as AddRecordInput
+  createRecordFile(input)
+  return input
+}

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -3,6 +3,13 @@ import { existsSync, lstatSync, readdirSync, realpathSync, rmSync, statSync } fr
 import { createRequire } from 'node:module'
 import { resolve } from 'node:path'
 import type { DatabaseSync } from 'node:sqlite'
+import {
+  parseGatherInput,
+  parseListRecordsInput,
+  parseRootInput,
+  parseSearchRecordsInput,
+  parseShowRecordInput,
+} from './api-input.ts'
 import { EncephalonError, fail, failWithCause, wrapIo } from './errors.ts'
 import { cacheDirectory, withOperationLock } from './lock.ts'
 import { readRecords } from './records.ts'
@@ -521,7 +528,7 @@ export const hydrateResolvedRepository = (root: string, lock = true): PrepareRes
   lock ? withOperationLock(root, () => rebuildCache(root)) : rebuildCache(root)
 
 export const prepare = (input: RootInput = {}): PrepareResult => {
-  const root = resolveRepository(input)
+  const root = resolveRepository(parseRootInput(input, 'prepare'))
   try {
     return prepareResolved(root)
   } catch (error) {
@@ -533,7 +540,7 @@ export const prepare = (input: RootInput = {}): PrepareResult => {
 }
 
 export const hydrate = (input: RootInput = {}): HydrateResult => {
-  const root = resolveRepository(input)
+  const root = resolveRepository(parseRootInput(input, 'hydrate'))
   try {
     const result = hydrateResolvedRepository(root)
     return { recordsIndexed: result.recordsIndexed }
@@ -573,17 +580,18 @@ const withPreparedDatabase = <Result>(input: RootInput, read: (database: Databas
 
 const parseRecordRow = (row: RecordRow) => JSON.parse(row.record_json) as BrainRecord
 
-export const listRecords = (input: ListRecordsInput = {}): BrainRecord[] =>
-  withPreparedDatabase(input, database => {
+export const listRecords = (input: ListRecordsInput = {}): BrainRecord[] => {
+  const parsed = parseListRecordsInput(input)
+  return withPreparedDatabase(parsed, database => {
     const conditions = [
-      input.includeSuperseded === true ? undefined : 'active = 1',
-      input.kind === undefined ? undefined : 'kind = ?',
-      input.subject === undefined ? undefined : 'subject = ?',
+      parsed.includeSuperseded === true ? undefined : 'active = 1',
+      parsed.kind === undefined ? undefined : 'kind = ?',
+      parsed.subject === undefined ? undefined : 'subject = ?',
     ].filter((value): value is string => value !== undefined)
     const parameters = [
-      ...(input.kind === undefined ? [] : [input.kind]),
-      ...(input.subject === undefined ? [] : [input.subject]),
-      positiveLimit(input.limit),
+      ...(parsed.kind === undefined ? [] : [parsed.kind]),
+      ...(parsed.subject === undefined ? [] : [parsed.subject]),
+      positiveLimit(parsed.limit),
     ]
     const where = conditions.length === 0 ? '' : `WHERE ${conditions.join(' AND ')}`
     const rows = database
@@ -591,20 +599,18 @@ export const listRecords = (input: ListRecordsInput = {}): BrainRecord[] =>
       .all(...parameters) as RecordRow[]
     return rows.map(parseRecordRow)
   })
+}
 
-export const showRecord = (input: ShowRecordInput): BrainRecord | null =>
-  withPreparedDatabase(input, database => {
-    if (typeof input.id !== 'string' || input.id.length === 0) {
-      return fail('INVALID_ARGUMENT', 'id must be a non-empty string.', {
-        field: 'id',
-      })
-    }
-    const activeClause = input.activeOnly === true ? ' AND active = 1' : ''
-    const row = database.prepare(`SELECT record_json FROM records WHERE id = ?${activeClause}`).get(input.id) as
+export const showRecord = (input: ShowRecordInput): BrainRecord | null => {
+  const parsed = parseShowRecordInput(input)
+  return withPreparedDatabase(parsed, database => {
+    const activeClause = parsed.activeOnly === true ? ' AND active = 1' : ''
+    const row = database.prepare(`SELECT record_json FROM records WHERE id = ?${activeClause}`).get(parsed.id) as
       | RecordRow
       | undefined
     return row === undefined ? null : parseRecordRow(row)
   })
+}
 
 const literalMatchQuery = (query: unknown) => {
   if (typeof query !== 'string') {
@@ -647,12 +653,15 @@ const searchRows = (database: DatabaseSync, input: SearchRecordsInput) => {
     .all(...parameters) as Array<RecordRow & CompactRow>
 }
 
-export const searchRecords = (input: SearchRecordsInput): BrainRecord[] =>
-  withPreparedDatabase(input, database => searchRows(database, input).map(parseRecordRow))
+export const searchRecords = (input: SearchRecordsInput): BrainRecord[] => {
+  const parsed = parseSearchRecordsInput(input)
+  return withPreparedDatabase(parsed, database => searchRows(database, parsed).map(parseRecordRow))
+}
 
-export const searchCompactRecords = (input: SearchRecordsInput): CompactBrainRecord[] =>
-  withPreparedDatabase(input, database =>
-    searchRows(database, input).map(row => ({
+export const searchCompactRecords = (input: SearchRecordsInput): CompactBrainRecord[] => {
+  const parsed = parseSearchRecordsInput(input)
+  return withPreparedDatabase(parsed, database =>
+    searchRows(database, parsed).map(row => ({
       id: row.id,
       kind: row.kind,
       path: row.path,
@@ -662,45 +671,37 @@ export const searchCompactRecords = (input: SearchRecordsInput): CompactBrainRec
       summary: row.summary,
     })),
   )
+}
 
 export const gatherRecords = (input: GatherInput): GatherResult => {
-  const root = resolveRepository(input)
+  const parsed = parseGatherInput(input)
+  const root = resolveRepository(parsed)
   try {
     let hydrated: HydrateResult | null = null
-    if (input.hydrate === true) {
+    if (parsed.hydrate === true) {
       hydrated = {
         recordsIndexed: hydrateResolvedRepository(root).recordsIndexed,
       }
     } else {
       prepareResolved(root)
     }
-    const searches = input.searches ?? []
-    const shows = input.shows ?? []
-    if (!(Array.isArray(searches) && searches.every(query => typeof query === 'string'))) {
-      return fail('INVALID_ARGUMENT', 'searches must be an array of strings.', {
-        field: 'searches',
-      })
-    }
-    if (!(Array.isArray(shows) && shows.every(id => typeof id === 'string'))) {
-      return fail('INVALID_ARGUMENT', 'shows must be an array of strings.', {
-        field: 'shows',
-      })
-    }
+    const searches = parsed.searches ?? []
+    const shows = parsed.shows ?? []
     const database = openDatabase(root)
     try {
       return {
         hydrated,
         records: shows.map(id => {
-          const activeClause = input.includeSuperseded === true ? '' : ' AND active = 1'
+          const activeClause = parsed.includeSuperseded === true ? '' : ' AND active = 1'
           const row = database.prepare(`SELECT record_json FROM records WHERE id = ?${activeClause}`).get(id) as
             | RecordRow
             | undefined
           return { id, record: row === undefined ? null : parseRecordRow(row) }
         }),
         searches: searches.map(query => ({
-          kind: input.kind ?? null,
+          kind: parsed.kind ?? null,
           query,
-          results: searchRows(database, { ...input, query }).map(row => ({
+          results: searchRows(database, { ...parsed, query }).map(row => ({
             id: row.id,
             kind: row.kind,
             path: row.path,

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,3 +1,4 @@
+import { parseInitInput } from './api-input.ts'
 import { canonicalPayload, scanBaseline } from './baseline.ts'
 import { hydrateResolvedRepository } from './cache.ts'
 import { EncephalonError, fail, wrapIo } from './errors.ts'
@@ -97,7 +98,7 @@ const initResolved = (input: InitEncephalonInput): InitEncephalonResult => {
 
 export const initEncephalon = (input: InitEncephalonInput = {}): InitEncephalonResult => {
   try {
-    return initResolved(input)
+    return initResolved(parseInitInput(input))
   } catch (error) {
     if (error instanceof EncephalonError) {
       throw error

--- a/src/records.ts
+++ b/src/records.ts
@@ -14,6 +14,7 @@ import {
   writeFileSync,
 } from 'node:fs'
 import { basename, join, relative, resolve } from 'node:path'
+import { parseAddRecordInput, parseRootInput } from './api-input.ts'
 import { hydrateResolvedRepository } from './cache.ts'
 import { EncephalonError, fail, wrapIo } from './errors.ts'
 import { withOperationLock } from './lock.ts'
@@ -366,7 +367,7 @@ const validateScanned = (root: string, scan: RecordScan): ValidateResult => {
 }
 
 export const validateRecords = (input: RootInput = {}): ValidateResult => {
-  const root = resolveRepository(input)
+  const root = resolveRepository(parseRootInput(input, 'validateRecords'))
   try {
     return validateScanned(root, scanCanonicalRecords(root))
   } catch (error) {
@@ -495,9 +496,10 @@ export const addRecordResolved = (root: string, input: AddRecordInput, options: 
 }
 
 export const addRecord = (input: AddRecordInput): BrainRecord => {
-  const root = resolveRepository(input)
+  const parsed = parseAddRecordInput(input)
+  const root = resolveRepository(parsed)
   try {
-    return withOperationLock(root, () => addRecordResolved(root, input))
+    return withOperationLock(root, () => addRecordResolved(root, parsed))
   } catch (error) {
     if (error instanceof EncephalonError) {
       throw error

--- a/src/records.ts
+++ b/src/records.ts
@@ -582,8 +582,7 @@ export const readRecordsAllowingGeneratedMultiHeads = (input: RootInput, allowed
   })
 }
 
-export const addRecordResolved = (root: string, input: AddRecordInput, options: AddRecordOptions = {}): BrainRecord => {
-  const recordFile = createRecordFile(input)
+const addRecordFileResolved = (root: string, recordFile: BrainRecordFile, options: AddRecordOptions = {}): BrainRecord => {
   const relativePath = `encephalon/${recordFile.kind}/${recordFile.id}.json`
   const path = resolve(root, ...relativePath.split('/'))
   if (existsSync(path)) {
@@ -684,11 +683,14 @@ export const addRecordResolved = (root: string, input: AddRecordInput, options: 
   return candidate
 }
 
+export const addRecordResolved = (root: string, input: AddRecordInput, options: AddRecordOptions = {}): BrainRecord =>
+  addRecordFileResolved(root, createRecordFile(input), options)
+
 export const addRecord = (input: AddRecordInput): BrainRecord => {
   const parsed = parseAddRecordInput(input)
   const root = resolveRepository(parsed)
   try {
-    return withOperationLock(root, () => addRecordResolved(root, parsed))
+    return withOperationLock(root, () => addRecordFileResolved(root, parsed.recordFile))
   } catch (error) {
     if (error instanceof EncephalonError) {
       throw error

--- a/src/records.ts
+++ b/src/records.ts
@@ -582,7 +582,11 @@ export const readRecordsAllowingGeneratedMultiHeads = (input: RootInput, allowed
   })
 }
 
-const addRecordFileResolved = (root: string, recordFile: BrainRecordFile, options: AddRecordOptions = {}): BrainRecord => {
+const addRecordFileResolved = (
+  root: string,
+  recordFile: BrainRecordFile,
+  options: AddRecordOptions = {},
+): BrainRecord => {
   const relativePath = `encephalon/${recordFile.kind}/${recordFile.id}.json`
   const path = resolve(root, ...relativePath.split('/'))
   if (existsSync(path)) {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -23,6 +23,112 @@ afterEach(() => {
 const functionFromApi = <T>(name: string) => (api as unknown as Record<string, T>)[name] as T
 
 describe('SQLite cache and reads', () => {
+  test('rejects invalid public API inputs before repository side effects', () => {
+    const cases: [string, (root: string) => void][] = [
+      [
+        'list includeSuperseded',
+        root => {
+          functionFromApi<(input: Record<string, unknown>) => unknown>('listRecords')({
+            includeSuperseded: 'yes',
+            root,
+          })
+        },
+      ],
+      [
+        'list limit',
+        root => {
+          functionFromApi<(input: Record<string, unknown>) => unknown>('listRecords')({ limit: 0, root })
+        },
+      ],
+      [
+        'show id',
+        root => {
+          functionFromApi<(input: Record<string, unknown>) => unknown>('showRecord')({ id: '../bad', root })
+        },
+      ],
+      [
+        'show activeOnly',
+        root => {
+          functionFromApi<(input: Record<string, unknown>) => unknown>('showRecord')({
+            activeOnly: 'yes',
+            id: 'record-1',
+            root,
+          })
+        },
+      ],
+      [
+        'search query',
+        root => {
+          functionFromApi<(input: Record<string, unknown>) => unknown>('searchRecords')({ query: 42, root })
+        },
+      ],
+      [
+        'search kind',
+        root => {
+          functionFromApi<(input: Record<string, unknown>) => unknown>('searchCompactRecords')({
+            kind: '../bad',
+            query: 'safe',
+            root,
+          })
+        },
+      ],
+      [
+        'gather hydrate searches',
+        root => {
+          functionFromApi<(input: Record<string, unknown>) => unknown>('gatherRecords')({
+            hydrate: true,
+            root,
+            searches: 'safe',
+          })
+        },
+      ],
+      [
+        'gather show id',
+        root => {
+          functionFromApi<(input: Record<string, unknown>) => unknown>('gatherRecords')({
+            root,
+            shows: ['../bad'],
+          })
+        },
+      ],
+      [
+        'add kind',
+        root => {
+          functionFromApi<(input: Record<string, unknown>) => unknown>('addRecord')({
+            kind: '../bad',
+            payload: null,
+            root,
+            source: 'agent',
+            subject: 'cache.validation',
+          })
+        },
+      ],
+      [
+        'init booleans',
+        root => {
+          functionFromApi<(input: Record<string, unknown>) => unknown>('initEncephalon')({
+            refreshBaseline: 'yes',
+            root,
+          })
+        },
+      ],
+    ]
+
+    for (const [name, action] of cases) {
+      const root = createRoot()
+      assert.throws(
+        () => action(root),
+        (error: unknown) => {
+          assert.equal((error as { code?: unknown }).code, 'INVALID_ARGUMENT', name)
+          return true
+        },
+      )
+      assert.equal(existsSync(join(root, 'node_modules', '.cache', 'encephalon')), false, name)
+      assert.equal(existsSync(join(root, 'AGENTS.md')), false, name)
+      assert.equal(existsSync(join(root, 'CLAUDE.md')), false, name)
+    }
+  })
+
   test('prepares an empty repository before a cache directory exists', () => {
     const root = createRoot()
     const prepare =

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -136,6 +136,18 @@ describe('SQLite cache and reads', () => {
         },
       ],
       [
+        'add root',
+        () => {
+          functionFromApi<(input: Record<string, unknown>) => unknown>('addRecord')({
+            kind: 'context',
+            payload: null,
+            root: 123,
+            source: 'agent',
+            subject: 'cache.validation',
+          })
+        },
+      ],
+      [
         'init booleans',
         root => {
           functionFromApi<(input: Record<string, unknown>) => unknown>('initEncephalon')({


### PR DESCRIPTION
## Human summary

Invalid JavaScript API calls now fail before Encephalon discovers a repository, opens SQLite, writes instructions, or mutates records.

## Summary

- Add central runtime parsers for root, cache, gather, init, and add-record inputs.
- Validate booleans, limits, ids, kinds, subjects, queries, and gather arrays before repository/cache I/O.
- Reuse canonical record validation for add-record inputs before operation-lock acquisition.
- Preserve existing blank-query behaviour while rejecting non-string queries and invalid array members.
- Add regression coverage proving invalid calls return `INVALID_ARGUMENT` without creating cache or instruction files.
