### PR TITLE
[MAR-2522] Add API request and response budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ npx --no-install encephalon validate
 
 Active records are returned by default. Add `--include-superseded` to `list`, `search`, or `gather` when historical records are needed. Missing `show` results are `null`, and empty searches are `[]`.
 
+Search queries may contain at most 1,024 UTF-8 bytes and 32 literal terms. Full-record APIs return at most 50 records and stop once the aggregate JSON response would exceed 4 MiB; compact search returns at most 100 results. One `gather` request may include at most 16 searches and 64 shows. Narrow the kind/query or request compact results when a full-record response exceeds these budgets.
+
 ## Add durable knowledge
 
 Search the stable subject first. If the new record replaces active knowledge, repeat `--supersedes` for every active head:

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -854,23 +854,32 @@ Use Node's built-in `util.parseArgs`; do not retain Commander or add another par
 
 - Optional: `--kind`, `--limit`, `--include-superseded`.
 - Default limit: 20.
+- Full-record result limit: 50.
+- Full-record responses fail before returning more than 4 MiB of aggregate record JSON.
 
 `encephalon show`
 
 - Required: `--id`.
 - Optional: `--active-only`.
+- The single returned record is counted against the full-record response budget.
 
 `encephalon search <query...>`
 
 - Optional: `--kind`, `--limit`, `--include-superseded`, `--compact`.
 - Join positional query terms with spaces before tokenisation.
 - Default limit: 20.
+- Query limit: 1,024 UTF-8 bytes and 32 literal terms after tokenisation.
+- Full search result limit: 50 records and the 4 MiB aggregate full-record response budget.
+- Compact search result limit: 100 records.
 
 `encephalon gather`
 
 - Repeated: `--search <query>`, `--show <id>`.
 - Optional: `--kind`, `--limit`, `--include-superseded`, `--hydrate`.
 - Preserve request order and `--hydrate` compatibility.
+- Request limit: 16 searches and 64 shows.
+- Gather searches use compact result limits. Gather shows preserve duplicate order and share the 4 MiB aggregate full-record response budget.
+- Callers should narrow `kind`, reduce `limit`, or use compact search when full-record budgets are exceeded.
 
 ### 14.3 Streams and exit codes
 

--- a/encephalon/review/11729757-beec-4a70-8f78-11ae8408e6c6.json
+++ b/encephalon/review/11729757-beec-4a70-8f78-11ae8408e6c6.json
@@ -1,0 +1,22 @@
+{
+  "createdAt": "2026-08-08T12:10:12.079Z",
+  "id": "11729757-beec-4a70-8f78-11ae8408e6c6",
+  "kind": "review",
+  "payload": {
+    "summary": "Cache budget work must keep compact projections JSON-free, stream full-record rows through byte checks, and validate compact query budgets before cache I/O.",
+    "lessons": [
+      "Do not reuse full-record SELECT helpers for compact search or gather search paths; compact paths should select only cached metadata plus FTS rank/snippet.",
+      "A full-response byte cap applied after StatementSync.all() still allows large transient allocation. Use StatementSync.iterate() or an equivalent cursor-like path so parsing stops when the running byte budget is exceeded.",
+      "Validate root-independent query byte and term budgets for every public search path, including searchCompactRecords, before withPreparedDatabase can resolve the repo or prepare/open cache state.",
+      "When merging older cache-budget branches over newer cache hardening, preserve the split full/compact readers and apply budgets to the current parser/read architecture."
+    ],
+    "verification": [
+      "Inspect compact search SQL for absence of records.record_json before pushing cache budget changes.",
+      "Run cache tests covering request budget pre-I/O rejection for full search, compact search, and gather, plus full-response byte caps after resolving cache conflicts."
+    ]
+  },
+  "searchText": "cache budget compact projection full record streaming compact query before cache I/O Pullfrog",
+  "source": "agent",
+  "subject": "review.cache-budget-streaming",
+  "supersedes": ["76e4ea10-a8cc-4e6d-aa3b-9fb5ece06c6d"]
+}

--- a/encephalon/review/76e4ea10-a8cc-4e6d-aa3b-9fb5ece06c6d.json
+++ b/encephalon/review/76e4ea10-a8cc-4e6d-aa3b-9fb5ece06c6d.json
@@ -1,0 +1,20 @@
+{
+  "createdAt": "2026-08-08T12:07:03.860Z",
+  "id": "76e4ea10-a8cc-4e6d-aa3b-9fb5ece06c6d",
+  "kind": "review",
+  "payload": {
+    "summary": "Cache budget work must keep compact projections JSON-free and stream full-record rows through byte checks.",
+    "lessons": [
+      "Do not reuse full-record SELECT helpers for compact search or gather search paths; compact paths should select only cached metadata plus FTS rank/snippet.",
+      "A full-response byte cap applied after StatementSync.all() still allows large transient allocation. Use StatementSync.iterate() or an equivalent cursor-like path so parsing stops when the running byte budget is exceeded.",
+      "When merging older cache-budget branches over newer cache hardening, preserve the split full/compact readers and apply budgets to the current parser/read architecture."
+    ],
+    "verification": [
+      "Inspect compact search SQL for absence of records.record_json before pushing cache budget changes.",
+      "Run cache tests covering request budget pre-I/O rejection and full-response byte caps after resolving cache conflicts."
+    ]
+  },
+  "searchText": "cache budget compact projection full record streaming Pullfrog",
+  "source": "agent",
+  "subject": "review.cache-budget-streaming"
+}

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -850,9 +850,9 @@ const parseRecordRowWithinBudget = (row: RecordRow, budget: FullResponseBudget) 
   return parseRecordRow(row)
 }
 
-const parseRecordRowsWithinBudget = (rows: RecordRow[]) => {
+const parseRecordRowsWithinBudget = (rows: Iterable<RecordRow>) => {
   const budget = { bytes: 0 }
-  return rows.map(row => parseRecordRowWithinBudget(row, budget))
+  return Array.from(rows, row => parseRecordRowWithinBudget(row, budget))
 }
 
 export const listRecords = (input: ListRecordsInput = {}): BrainRecord[] => {
@@ -874,7 +874,7 @@ export const listRecords = (input: ListRecordsInput = {}): BrainRecord[] => {
       .prepare(
         `SELECT record_json, length(cast(record_json AS BLOB)) AS record_bytes FROM records ${where} ORDER BY created_at DESC, id DESC LIMIT ?`,
       )
-      .all(...parameters) as RecordRow[]
+      .iterate(...parameters) as Iterable<RecordRow>
     return parseRecordRowsWithinBudget(rows)
   })
 }
@@ -932,21 +932,14 @@ const searchRows = (database: DatabaseSync, input: SearchRecordsInput, match: st
     .prepare(`
     SELECT
       records.record_json,
-      length(cast(records.record_json AS BLOB)) AS record_bytes,
-      records.id,
-      records.kind,
-      records.subject,
-      records.path,
-      records.summary,
-      bm25(record_search) AS rank,
-      snippet(record_search, 1, '[', ']', '...', 16) AS snippet
+      length(cast(records.record_json AS BLOB)) AS record_bytes
     FROM record_search
     JOIN records ON records.id = record_search.id
     WHERE ${conditions.join(' AND ')}
-    ORDER BY rank ASC, records.created_at DESC, records.id DESC
+    ORDER BY bm25(record_search) ASC, records.created_at DESC, records.id DESC
     LIMIT ?
   `)
-    .all(...parameters) as Array<RecordRow & CompactRow>
+    .iterate(...parameters) as Iterable<RecordRow>
 }
 
 const compactText = (value: unknown, field: string) => {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1027,6 +1027,7 @@ export const searchRecords = (input: SearchRecordsInput): BrainRecord[] => {
 
 export const searchCompactRecords = (input: SearchRecordsInput): CompactBrainRecord[] => {
   const parsed = parseSearchRecordsInput(input)
+  literalMatchQuery(parsed.query)
   compactResultLimit(parsed.limit)
   return withPreparedDatabase(parsed, database => createCompactSearchReader(database, parsed)(parsed.query))
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -24,6 +24,13 @@ const PACKAGE_VERSION = '0.1.0'
 const SCHEMA_VERSION = '1'
 const MAX_REPOSITORY_CHANGE_RETRIES = 3
 const DATABASE_FILENAME = 'brain.sqlite'
+export const MAX_QUERY_BYTES = 1024
+export const MAX_QUERY_TERMS = 32
+export const MAX_GATHER_SEARCHES = 16
+export const MAX_GATHER_SHOWS = 64
+export const MAX_FULL_RESULT_LIMIT = 50
+export const MAX_COMPACT_RESULT_LIMIT = 100
+export const MAX_FULL_RESPONSE_BYTES = 4 * 1024 * 1024
 
 type SQLiteModule = {
   DatabaseSync: new (path: string) => DatabaseSync
@@ -48,6 +55,7 @@ type ManifestEntry = {
 
 type RecordRow = {
   record_json: string
+  record_bytes?: number
 }
 
 type CompactRow = {
@@ -545,13 +553,26 @@ export const hydrate = (input: RootInput = {}): HydrateResult => {
   }
 }
 
-const positiveLimit = (value: unknown, fallback = 20) => {
+const byteLength = (value: string) => Buffer.byteLength(value, 'utf8')
+
+const budgetFailure = (field: string, budget: string, maximum: number, message: string) =>
+  fail('INVALID_ARGUMENT', message, {
+    budget,
+    field,
+    maximum,
+  })
+
+const positiveLimit = (value: unknown, maximum: number, budget: string, fallback = 20) => {
   const limit = value === undefined ? fallback : value
-  if (typeof limit === 'number' && Number.isInteger(limit) && limit > 0 && limit <= 1000) {
+  if (typeof limit === 'number' && Number.isInteger(limit) && limit > 0 && limit <= maximum) {
     return limit
   }
-  return fail('INVALID_ARGUMENT', 'limit must be an integer between 1 and 1000.', { field: 'limit' })
+  return budgetFailure('limit', budget, maximum, `limit must be an integer between 1 and ${maximum}.`)
 }
+
+const fullResultLimit = (value: unknown) => positiveLimit(value, MAX_FULL_RESULT_LIMIT, 'fullResultLimit')
+
+const compactResultLimit = (value: unknown) => positiveLimit(value, MAX_COMPACT_RESULT_LIMIT, 'compactResultLimit')
 
 const withPreparedDatabase = <Result>(input: RootInput, read: (database: DatabaseSync) => Result) => {
   const root = resolveRepository(input)
@@ -573,8 +594,38 @@ const withPreparedDatabase = <Result>(input: RootInput, read: (database: Databas
 
 const parseRecordRow = (row: RecordRow) => JSON.parse(row.record_json) as BrainRecord
 
-export const listRecords = (input: ListRecordsInput = {}): BrainRecord[] =>
-  withPreparedDatabase(input, database => {
+type FullResponseBudget = {
+  bytes: number
+}
+
+const recordRowBytes = (row: RecordRow) => {
+  if (typeof row.record_bytes === 'number' && Number.isFinite(row.record_bytes) && row.record_bytes >= 0) {
+    return row.record_bytes
+  }
+  return byteLength(row.record_json)
+}
+
+const parseRecordRowWithinBudget = (row: RecordRow, budget: FullResponseBudget) => {
+  budget.bytes += recordRowBytes(row)
+  if (budget.bytes > MAX_FULL_RESPONSE_BYTES) {
+    return budgetFailure(
+      'response',
+      'fullResponseBytes',
+      MAX_FULL_RESPONSE_BYTES,
+      `full-record responses may contain at most ${MAX_FULL_RESPONSE_BYTES} UTF-8 bytes.`,
+    )
+  }
+  return parseRecordRow(row)
+}
+
+const parseRecordRowsWithinBudget = (rows: RecordRow[]) => {
+  const budget = { bytes: 0 }
+  return rows.map(row => parseRecordRowWithinBudget(row, budget))
+}
+
+export const listRecords = (input: ListRecordsInput = {}): BrainRecord[] => {
+  const limit = fullResultLimit(input.limit)
+  return withPreparedDatabase(input, database => {
     const conditions = [
       input.includeSuperseded === true ? undefined : 'active = 1',
       input.kind === undefined ? undefined : 'kind = ?',
@@ -583,14 +634,17 @@ export const listRecords = (input: ListRecordsInput = {}): BrainRecord[] =>
     const parameters = [
       ...(input.kind === undefined ? [] : [input.kind]),
       ...(input.subject === undefined ? [] : [input.subject]),
-      positiveLimit(input.limit),
+      limit,
     ]
     const where = conditions.length === 0 ? '' : `WHERE ${conditions.join(' AND ')}`
     const rows = database
-      .prepare(`SELECT record_json FROM records ${where} ORDER BY created_at DESC, id DESC LIMIT ?`)
+      .prepare(
+        `SELECT record_json, length(cast(record_json AS BLOB)) AS record_bytes FROM records ${where} ORDER BY created_at DESC, id DESC LIMIT ?`,
+      )
       .all(...parameters) as RecordRow[]
-    return rows.map(parseRecordRow)
+    return parseRecordRowsWithinBudget(rows)
   })
+}
 
 export const showRecord = (input: ShowRecordInput): BrainRecord | null =>
   withPreparedDatabase(input, database => {
@@ -600,10 +654,12 @@ export const showRecord = (input: ShowRecordInput): BrainRecord | null =>
       })
     }
     const activeClause = input.activeOnly === true ? ' AND active = 1' : ''
-    const row = database.prepare(`SELECT record_json FROM records WHERE id = ?${activeClause}`).get(input.id) as
-      | RecordRow
-      | undefined
-    return row === undefined ? null : parseRecordRow(row)
+    const row = database
+      .prepare(
+        `SELECT record_json, length(cast(record_json AS BLOB)) AS record_bytes FROM records WHERE id = ?${activeClause}`,
+      )
+      .get(input.id) as RecordRow | undefined
+    return row === undefined ? null : parseRecordRowWithinBudget(row, { bytes: 0 })
   })
 
 const literalMatchQuery = (query: unknown) => {
@@ -612,12 +668,27 @@ const literalMatchQuery = (query: unknown) => {
       field: 'query',
     })
   }
+  if (byteLength(query) > MAX_QUERY_BYTES) {
+    return budgetFailure(
+      'query',
+      'queryBytes',
+      MAX_QUERY_BYTES,
+      `query must contain at most ${MAX_QUERY_BYTES} UTF-8 bytes.`,
+    )
+  }
   const terms = query.split(/[^A-Za-z0-9_]+/u).filter(term => term.length > 0)
+  if (terms.length > MAX_QUERY_TERMS) {
+    return budgetFailure(
+      'query',
+      'queryTerms',
+      MAX_QUERY_TERMS,
+      `query may contain at most ${MAX_QUERY_TERMS} literal terms.`,
+    )
+  }
   return terms.map(term => `"${term.replaceAll('"', '""')}"`).join(' AND ')
 }
 
-const searchRows = (database: DatabaseSync, input: SearchRecordsInput) => {
-  const match = literalMatchQuery(input.query)
+const searchRows = (database: DatabaseSync, input: SearchRecordsInput, match: string, limit: number) => {
   if (match.length === 0) {
     return []
   }
@@ -626,11 +697,12 @@ const searchRows = (database: DatabaseSync, input: SearchRecordsInput) => {
     input.includeSuperseded === true ? undefined : 'records.active = 1',
     input.kind === undefined ? undefined : 'records.kind = ?',
   ].filter((value): value is string => value !== undefined)
-  const parameters = [match, ...(input.kind === undefined ? [] : [input.kind]), positiveLimit(input.limit)]
+  const parameters = [match, ...(input.kind === undefined ? [] : [input.kind]), limit]
   return database
     .prepare(`
     SELECT
       records.record_json,
+      length(cast(records.record_json AS BLOB)) AS record_bytes,
       records.id,
       records.kind,
       records.subject,
@@ -647,12 +719,17 @@ const searchRows = (database: DatabaseSync, input: SearchRecordsInput) => {
     .all(...parameters) as Array<RecordRow & CompactRow>
 }
 
-export const searchRecords = (input: SearchRecordsInput): BrainRecord[] =>
-  withPreparedDatabase(input, database => searchRows(database, input).map(parseRecordRow))
+export const searchRecords = (input: SearchRecordsInput): BrainRecord[] => {
+  const match = literalMatchQuery(input.query)
+  const limit = fullResultLimit(input.limit)
+  return withPreparedDatabase(input, database => parseRecordRowsWithinBudget(searchRows(database, input, match, limit)))
+}
 
-export const searchCompactRecords = (input: SearchRecordsInput): CompactBrainRecord[] =>
-  withPreparedDatabase(input, database =>
-    searchRows(database, input).map(row => ({
+export const searchCompactRecords = (input: SearchRecordsInput): CompactBrainRecord[] => {
+  const match = literalMatchQuery(input.query)
+  const limit = compactResultLimit(input.limit)
+  return withPreparedDatabase(input, database =>
+    searchRows(database, input, match, limit).map(row => ({
       id: row.id,
       kind: row.kind,
       path: row.path,
@@ -662,8 +739,51 @@ export const searchCompactRecords = (input: SearchRecordsInput): CompactBrainRec
       summary: row.summary,
     })),
   )
+}
+
+const gatherSearches = (value: unknown) => {
+  const searches = value ?? []
+  if (!(Array.isArray(searches) && searches.every(query => typeof query === 'string'))) {
+    return fail('INVALID_ARGUMENT', 'searches must be an array of strings.', {
+      field: 'searches',
+    })
+  }
+  if (searches.length > MAX_GATHER_SEARCHES) {
+    return budgetFailure(
+      'searches',
+      'gatherSearches',
+      MAX_GATHER_SEARCHES,
+      `gather may contain at most ${MAX_GATHER_SEARCHES} searches.`,
+    )
+  }
+  return searches.map(query => ({
+    match: literalMatchQuery(query),
+    query,
+  }))
+}
+
+const gatherShows = (value: unknown) => {
+  const shows = value ?? []
+  if (!(Array.isArray(shows) && shows.every(id => typeof id === 'string'))) {
+    return fail('INVALID_ARGUMENT', 'shows must be an array of strings.', {
+      field: 'shows',
+    })
+  }
+  if (shows.length > MAX_GATHER_SHOWS) {
+    return budgetFailure(
+      'shows',
+      'gatherShows',
+      MAX_GATHER_SHOWS,
+      `gather may contain at most ${MAX_GATHER_SHOWS} shows.`,
+    )
+  }
+  return shows
+}
 
 export const gatherRecords = (input: GatherInput): GatherResult => {
+  const searches = gatherSearches(input.searches)
+  const shows = gatherShows(input.shows)
+  const limit = compactResultLimit(input.limit)
   const root = resolveRepository(input)
   try {
     let hydrated: HydrateResult | null = null
@@ -674,33 +794,24 @@ export const gatherRecords = (input: GatherInput): GatherResult => {
     } else {
       prepareResolved(root)
     }
-    const searches = input.searches ?? []
-    const shows = input.shows ?? []
-    if (!(Array.isArray(searches) && searches.every(query => typeof query === 'string'))) {
-      return fail('INVALID_ARGUMENT', 'searches must be an array of strings.', {
-        field: 'searches',
-      })
-    }
-    if (!(Array.isArray(shows) && shows.every(id => typeof id === 'string'))) {
-      return fail('INVALID_ARGUMENT', 'shows must be an array of strings.', {
-        field: 'shows',
-      })
-    }
     const database = openDatabase(root)
     try {
+      const showBudget = { bytes: 0 }
       return {
         hydrated,
         records: shows.map(id => {
           const activeClause = input.includeSuperseded === true ? '' : ' AND active = 1'
-          const row = database.prepare(`SELECT record_json FROM records WHERE id = ?${activeClause}`).get(id) as
-            | RecordRow
-            | undefined
-          return { id, record: row === undefined ? null : parseRecordRow(row) }
+          const row = database
+            .prepare(
+              `SELECT record_json, length(cast(record_json AS BLOB)) AS record_bytes FROM records WHERE id = ?${activeClause}`,
+            )
+            .get(id) as RecordRow | undefined
+          return { id, record: row === undefined ? null : parseRecordRowWithinBudget(row, showBudget) }
         }),
-        searches: searches.map(query => ({
+        searches: searches.map(({ match, query }) => ({
           kind: input.kind ?? null,
           query,
-          results: searchRows(database, { ...input, query }).map(row => ({
+          results: searchRows(database, { ...input, query }, match, limit).map(row => ({
             id: row.id,
             kind: row.kind,
             path: row.path,

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -22,6 +22,16 @@ afterEach(() => {
 
 const functionFromApi = <T>(name: string) => (api as unknown as Record<string, T>)[name] as T
 
+const assertBudgetError = (operation: () => unknown, budget: string) => {
+  assert.throws(operation, (error: unknown) => {
+    assert.equal((error as { code?: unknown }).code, 'INVALID_ARGUMENT')
+    assert.equal((error as { details?: { budget?: unknown } }).details?.budget, budget)
+    return true
+  })
+}
+
+const cacheDirectoryPath = (root: string) => join(root, 'node_modules', '.cache', 'encephalon')
+
 describe('SQLite cache and reads', () => {
   test('prepares an empty repository before a cache directory exists', () => {
     const root = createRoot()
@@ -138,6 +148,91 @@ describe('SQLite cache and reads', () => {
       subject: 'no.summary',
     })
     assert.equal(searchCompactRecords({ query: 'searchable marker', root })[0]?.summary, null)
+  })
+
+  test('accepts request budget boundaries and rejects one unit over before cache I/O', () => {
+    const validRoot = createRoot()
+    const listRecords = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>[]>('listRecords')
+    const searchRecords =
+      functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>[]>('searchRecords')
+    const searchCompactRecords =
+      functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>[]>('searchCompactRecords')
+    const gatherRecords = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>>('gatherRecords')
+
+    assert.deepEqual(listRecords({ limit: 50, root: validRoot }), [])
+    assert.deepEqual(searchRecords({ limit: 50, query: 'x'.repeat(1024), root: validRoot }), [])
+    assert.deepEqual(
+      searchRecords({ limit: 50, query: Array.from({ length: 32 }, () => 'x').join(' '), root: validRoot }),
+      [],
+    )
+    assert.deepEqual(searchCompactRecords({ limit: 100, query: 'x', root: validRoot }), [])
+    const gathered = gatherRecords({
+      limit: 100,
+      root: validRoot,
+      searches: Array.from({ length: 16 }, () => 'x'),
+      shows: Array.from({ length: 64 }, () => 'missing'),
+    }) as {
+      records: Array<{ id: string }>
+      searches: Array<{ query: string }>
+    }
+    assert.deepEqual(
+      gathered.searches.map(search => search.query),
+      Array.from({ length: 16 }, () => 'x'),
+    )
+    assert.deepEqual(
+      gathered.records.map(record => record.id),
+      Array.from({ length: 64 }, () => 'missing'),
+    )
+
+    const invalidCases: Array<{ budget: string; run: (root: string) => void }> = [
+      { budget: 'fullResultLimit', run: root => listRecords({ limit: 51, root }) },
+      { budget: 'fullResultLimit', run: root => searchRecords({ limit: 51, query: 'x', root }) },
+      { budget: 'compactResultLimit', run: root => searchCompactRecords({ limit: 101, query: 'x', root }) },
+      { budget: 'queryBytes', run: root => searchRecords({ query: `${'x'.repeat(1024)}y`, root }) },
+      {
+        budget: 'queryTerms',
+        run: root => searchRecords({ query: Array.from({ length: 33 }, () => 'x').join(' '), root }),
+      },
+      {
+        budget: 'gatherSearches',
+        run: root => gatherRecords({ root, searches: Array.from({ length: 17 }, () => 'x') }),
+      },
+      {
+        budget: 'gatherShows',
+        run: root => gatherRecords({ root, shows: Array.from({ length: 65 }, () => 'missing') }),
+      },
+      { budget: 'compactResultLimit', run: root => gatherRecords({ limit: 101, root, searches: ['x'] }) },
+    ]
+
+    for (const invalidCase of invalidCases) {
+      const root = createRoot()
+      assertBudgetError(() => invalidCase.run(root), invalidCase.budget)
+      assert.equal(existsSync(cacheDirectoryPath(root)), false)
+    }
+  })
+
+  test('stops full-record responses at the aggregate byte budget while compact search remains usable', () => {
+    const root = createRoot()
+    const addRecord = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>>('addRecord')
+    for (const index of Array.from({ length: 5 }, (_, value) => value)) {
+      addRecord({
+        id: `large-response-${index}`,
+        kind: 'context',
+        payload: { text: 'x'.repeat(900 * 1024) },
+        root,
+        searchText: 'response budget marker',
+        source: 'agent',
+        subject: `response.budget.${index}`,
+      })
+    }
+
+    const searchRecords =
+      functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>[]>('searchRecords')
+    assertBudgetError(() => searchRecords({ limit: 5, query: 'response budget marker', root }), 'fullResponseBytes')
+
+    const searchCompactRecords =
+      functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>[]>('searchCompactRecords')
+    assert.equal(searchCompactRecords({ limit: 5, query: 'response budget marker', root }).length, 5)
   })
 
   test('tracks record and referenced-artifact freshness', () => {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -339,9 +339,14 @@ describe('SQLite cache and reads', () => {
       { budget: 'fullResultLimit', run: root => searchRecords({ limit: 51, query: 'x', root }) },
       { budget: 'compactResultLimit', run: root => searchCompactRecords({ limit: 101, query: 'x', root }) },
       { budget: 'queryBytes', run: root => searchRecords({ query: `${'x'.repeat(1024)}y`, root }) },
+      { budget: 'queryBytes', run: root => searchCompactRecords({ query: `${'x'.repeat(1024)}y`, root }) },
       {
         budget: 'queryTerms',
         run: root => searchRecords({ query: Array.from({ length: 33 }, () => 'x').join(' '), root }),
+      },
+      {
+        budget: 'queryTerms',
+        run: root => searchCompactRecords({ query: Array.from({ length: 33 }, () => 'x').join(' '), root }),
       },
       {
         budget: 'gatherSearches',


### PR DESCRIPTION
## Human summary

Search, list, and gather calls now have explicit size limits so large requests fail predictably instead of building oversized full-record responses.

## Summary

- Add documented budgets for query bytes, literal term count, gather searches, gather shows, compact result count, full-record result count, and aggregate full-record response bytes.
- Validate root-independent request budgets before repository discovery, cache preparation, or SQLite I/O.
- Apply full-record result and aggregate byte budgets to list, show, full search, and gather show responses.
- Keep compact search and gather search results on their own higher result-count budget while preserving accepted gather duplicate/order semantics.
- Return structured `INVALID_ARGUMENT` errors with stable `details.budget` names and no oversized input echoing.
- Add boundary tests at and one unit over each budget, no-cache assertions for root-independent rejections, and near-1-MiB record coverage proving full search stops while compact search remains usable.
