### PR TITLE
[MAR-2523] Bound validation corpus traversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ type BrainRecordFile = {
 type BrainRecord = BrainRecordFile & { path: string };
 ```
 
+The v0.x canonical corpus may contain at most 1,000 records, 8 MiB of aggregate record JSON, 1,000 supersession edges, and 1,000 artifact references. Validation returns at most 100 issues; when more issues exist, the result sets `truncated: true` and ends with a `VALIDATION_ISSUES_TRUNCATED` sentinel.
+
 The disposable cache lives at `node_modules/.cache/encephalon/brain.sqlite` and should not be committed. It uses SQLite WAL mode, FTS5, a repository-scoped operation lock, manifest-based freshness, and transactional table rebuilds. Canonical records remain the source of truth.
 
 Artifacts must be regular, non-symlink files beneath `_artifacts/<kind>/<id>/`. Record IDs and artifact paths are checked for traversal, platform portability, Windows-reserved names, case collisions, size limits, and containment.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -446,6 +446,7 @@ export type BrainRecord = BrainRecordFile & {
 - The current record may not supersede itself.
 - Every target must have the same `kind` and exactly the same trimmed `subject`.
 - The graph must contain no cycle.
+- The whole corpus may contain at most 1,000 supersession edges.
 
 `artifacts`:
 
@@ -454,6 +455,7 @@ export type BrainRecord = BrainRecordFile & {
 - May contain at most 256 entries.
 - Each path may contain at most 1,024 UTF-8 bytes.
 - Each path must satisfy the artifact rules below.
+- The whole corpus may contain at most 1,000 artifact references.
 
 `payload`:
 
@@ -469,6 +471,8 @@ export type BrainRecord = BrainRecordFile & {
 - Supplements, rather than replaces, indexed kind/subject/source/payload text.
 
 Unknown top-level fields and a canonical `path` field are validation errors. Optional fields are omitted rather than serialized as `null`.
+
+The v0.x canonical corpus may contain at most 1,000 records and 8 MiB of aggregate record JSON. Validation stops scanning when these hard corpus budgets are exceeded.
 
 ### 9.5 Append-only and supersession semantics
 
@@ -764,6 +768,7 @@ export type ValidateResult = {
   valid: boolean
   recordsChecked: number
   errors: ValidationIssue[]
+  truncated: boolean
 }
 
 export type GatherResult = {
@@ -780,7 +785,7 @@ export type GatherResult = {
 }
 ```
 
-Validation issues should use stable structured fields such as `code`, `message`, and optional repository-relative `path`/`recordId`, rather than unstructured strings alone.
+Validation issues should use stable structured fields such as `code`, `message`, and optional repository-relative `path`/`recordId`, rather than unstructured strings alone. A validation result returns at most 100 issues; when additional issues exist, `truncated` is `true` and the final returned issue has code `VALIDATION_ISSUES_TRUNCATED`.
 
 ### 13.1 Error type
 

--- a/encephalon/review/a2b8d2b9-9f08-4217-981d-b0021ce3a920.json
+++ b/encephalon/review/a2b8d2b9-9f08-4217-981d-b0021ce3a920.json
@@ -1,0 +1,19 @@
+{
+  "createdAt": "2026-08-08T12:24:40.909Z",
+  "id": "a2b8d2b9-9f08-4217-981d-b0021ce3a920",
+  "kind": "review",
+  "payload": {
+    "summary": "Validation issue caps need one coherent shape across scan stopping, returned entries, and sentinel text.",
+    "lessons": [
+      "If validation returns a sentinel within a fixed issue-entry budget, the maximum concrete issue count is one less than the returned entry limit.",
+      "Scan-time stopping should collect only enough concrete issues to justify the sentinel instead of doing one extra discarded read.",
+      "Tests should assert the sentinel code and message, not only the final array length."
+    ],
+    "verification": [
+      "For validation-budget changes, run a malformed-corpus truncation test that checks both the retained issue count and sentinel wording."
+    ]
+  },
+  "searchText": "validation issue truncation sentinel scan cap returned entries Pullfrog",
+  "source": "agent",
+  "subject": "review.validation-truncation-shape"
+}

--- a/encephalon/review/a440a95c-6327-42ac-b5da-375bde4d868e.json
+++ b/encephalon/review/a440a95c-6327-42ac-b5da-375bde4d868e.json
@@ -1,0 +1,19 @@
+{
+  "createdAt": "2026-08-08T12:21:31.412Z",
+  "id": "a440a95c-6327-42ac-b5da-375bde4d868e",
+  "kind": "review",
+  "payload": {
+    "summary": "Validation corpus budgets must be enforced on write paths before canonical publication, not only during scans.",
+    "lessons": [
+      "When adding corpus-wide limits, validate candidate writes against record-count and aggregate-byte budgets before staging or hard-link publication.",
+      "scanCanonicalRecords can stop safely at scan-time limits, but addRecord must still evaluate the already-scanned corpus plus the formatted candidate bytes.",
+      "Regression tests should assert the rejected candidate file does not appear on disk for both count and aggregate-byte overflows."
+    ],
+    "verification": [
+      "Before pushing validation-budget changes, test the 1001st addRecord attempt and a near-limit corpus whose candidate exceeds aggregate bytes."
+    ]
+  },
+  "searchText": "validation corpus budgets addRecord write path candidate formatted bytes before publication Pullfrog",
+  "source": "agent",
+  "subject": "review.corpus-budget-write-validation"
+}

--- a/src/records.ts
+++ b/src/records.ts
@@ -561,7 +561,7 @@ const truncateValidationIssues = (errors: ValidationIssue[]) => {
       ...errors.slice(0, MAX_VALIDATION_ISSUES - 1),
       issue(
         'VALIDATION_ISSUES_TRUNCATED',
-        `Validation stopped reporting after ${MAX_VALIDATION_ISSUES} issues.`,
+        `Validation stopped reporting after ${MAX_VALIDATION_ISSUES - 1} concrete issues.`,
         'encephalon',
       ),
     ],

--- a/src/records.ts
+++ b/src/records.ts
@@ -285,7 +285,7 @@ const scanCanonicalRecords = (root: string, options: ValidateRecordsOptions = {}
     let stopScanning = false
     const addScanError = (validationIssue: ValidationIssue) => {
       scanned.errors.push(validationIssue)
-      if (scanned.errors.length > MAX_VALIDATION_ISSUES) {
+      if (scanned.errors.length >= MAX_VALIDATION_ISSUES) {
         stopScanning = true
       }
     }
@@ -553,7 +553,7 @@ const artifactIssues = (root: string, records: BrainRecord[]) => {
 }
 
 const truncateValidationIssues = (errors: ValidationIssue[]) => {
-  if (errors.length <= MAX_VALIDATION_ISSUES) {
+  if (errors.length < MAX_VALIDATION_ISSUES) {
     return { errors, truncated: false }
   }
   return {

--- a/src/records.ts
+++ b/src/records.ts
@@ -54,6 +54,11 @@ const STAGING_DIRECTORY = '_staging'
 const RESERVED_DIRECTORIES = new Set(['_artifacts', STAGING_DIRECTORY])
 const directoryFlag = constants.O_DIRECTORY ?? 0
 const noFollowFlag = constants.O_NOFOLLOW ?? 0
+export const MAX_CANONICAL_RECORDS = 1000
+export const MAX_CANONICAL_RECORD_BYTES = 8 * 1024 * 1024
+export const MAX_SUPERSESSION_EDGES = 1000
+export const MAX_ARTIFACT_REFERENCES = 1000
+export const MAX_VALIDATION_ISSUES = 100
 
 const posixRelative = (root: string, path: string) => relative(root, path).replaceAll('\\', '/')
 
@@ -63,6 +68,8 @@ const issue = (code: string, message: string, path?: string, recordId?: string):
   ...(path === undefined ? {} : { path }),
   ...(recordId === undefined ? {} : { recordId }),
 })
+
+const corpusIssue = (code: string, message: string, path = 'encephalon') => issue(code, message, path)
 
 const fault = (hooks: RecordWriteHooks | undefined, point: RecordWriteFault) => hooks?.fault?.(point)
 
@@ -145,87 +152,106 @@ const scanCanonicalRecords = (root: string): RecordScan => {
       }
     }
 
-    const scanned = readdirSync(brainDirectory, { withFileTypes: true })
-      .sort((first, second) => first.name.localeCompare(second.name))
-      .reduce<RecordScan>(
-        (result, kindEntry) => {
-          if (RESERVED_DIRECTORIES.has(kindEntry.name)) {
-            return kindEntry.isDirectory() && !kindEntry.isSymbolicLink()
-              ? result
-              : {
-                  errors: [
-                    ...result.errors,
+    const scanned: RecordScan = { errors: [], records: [] }
+    let recordBytes = 0
+    let stopScanning = false
+    const addScanError = (validationIssue: ValidationIssue) => {
+      scanned.errors.push(validationIssue)
+      if (scanned.errors.length > MAX_VALIDATION_ISSUES) {
+        stopScanning = true
+      }
+    }
+    for (const kindEntry of readdirSync(brainDirectory, { withFileTypes: true }).sort((first, second) =>
+      first.name.localeCompare(second.name),
+    )) {
+      if (stopScanning) {
+        break
+      }
+      if (RESERVED_DIRECTORIES.has(kindEntry.name)) {
+        if (!(kindEntry.isDirectory() && !kindEntry.isSymbolicLink())) {
+          addScanError(
+            issue(
+              'INVALID_RECORD_LAYOUT',
+              `${kindEntry.name} must be a real directory.`,
+              `encephalon/${kindEntry.name}`,
+            ),
+          )
+        }
+      } else {
+        const kindPath = join(brainDirectory, kindEntry.name)
+        if (!kindEntry.name.startsWith('_') && kindEntry.isDirectory() && !kindEntry.isSymbolicLink()) {
+          for (const recordEntry of readdirSync(kindPath, { withFileTypes: true }).sort((first, second) =>
+            first.name.localeCompare(second.name),
+          )) {
+            if (stopScanning) {
+              break
+            }
+            const recordPath = join(kindPath, recordEntry.name)
+            const relativePath = posixRelative(root, recordPath)
+            if (recordEntry.isFile() && !recordEntry.isSymbolicLink() && recordEntry.name.endsWith('.json')) {
+              const metadata = lstatSync(recordPath)
+              if (scanned.records.length >= MAX_CANONICAL_RECORDS) {
+                addScanError(
+                  corpusIssue(
+                    'CORPUS_RECORD_LIMIT',
+                    `Canonical corpus may contain at most ${MAX_CANONICAL_RECORDS} records.`,
+                    relativePath,
+                  ),
+                )
+                stopScanning = true
+                break
+              }
+              if (recordBytes + metadata.size > MAX_CANONICAL_RECORD_BYTES) {
+                addScanError(
+                  corpusIssue(
+                    'CORPUS_BYTE_LIMIT',
+                    `Canonical corpus may contain at most ${MAX_CANONICAL_RECORD_BYTES} bytes of record JSON.`,
+                    relativePath,
+                  ),
+                )
+                stopScanning = true
+                break
+              }
+              recordBytes += metadata.size
+              try {
+                const record = readRecord(root, recordPath)
+                const expectedName = `${record.id}.json`
+                if (!(recordEntry.name === expectedName && record.kind === kindEntry.name)) {
+                  addScanError(
                     issue(
-                      'INVALID_RECORD_LAYOUT',
-                      `${kindEntry.name} must be a real directory.`,
-                      `encephalon/${kindEntry.name}`,
-                    ),
-                  ],
-                  records: result.records,
-                }
-          }
-          const kindPath = join(brainDirectory, kindEntry.name)
-          if (!kindEntry.name.startsWith('_') && kindEntry.isDirectory() && !kindEntry.isSymbolicLink()) {
-            return readdirSync(kindPath, { withFileTypes: true })
-              .sort((first, second) => first.name.localeCompare(second.name))
-              .reduce<RecordScan>((kindResult, recordEntry) => {
-                const recordPath = join(kindPath, recordEntry.name)
-                const relativePath = posixRelative(root, recordPath)
-                if (recordEntry.isFile() && !recordEntry.isSymbolicLink() && recordEntry.name.endsWith('.json')) {
-                  try {
-                    const record = readRecord(root, recordPath)
-                    const expectedName = `${record.id}.json`
-                    const pathErrors = [
-                      ...(recordEntry.name === expectedName && record.kind === kindEntry.name
-                        ? []
-                        : [
-                            issue(
-                              'RECORD_PATH_MISMATCH',
-                              'Record filename and parent kind must match its envelope.',
-                              relativePath,
-                              record.id,
-                            ),
-                          ]),
-                    ]
-                    return {
-                      errors: [...kindResult.errors, ...pathErrors],
-                      records: [...kindResult.records, record],
-                    }
-                  } catch (error) {
-                    const message = error instanceof Error ? error.message : 'Record could not be parsed.'
-                    return {
-                      errors: [...kindResult.errors, issue('INVALID_RECORD', message, relativePath)],
-                      records: kindResult.records,
-                    }
-                  }
-                }
-                return {
-                  errors: [
-                    ...kindResult.errors,
-                    issue(
-                      'INVALID_RECORD_LAYOUT',
-                      'Kind directories may contain only direct regular JSON files.',
+                      'RECORD_PATH_MISMATCH',
+                      'Record filename and parent kind must match its envelope.',
                       relativePath,
+                      record.id,
                     ),
-                  ],
-                  records: kindResult.records,
+                  )
                 }
-              }, result)
+                scanned.records.push(record)
+              } catch (error) {
+                const message = error instanceof Error ? error.message : 'Record could not be parsed.'
+                addScanError(issue('INVALID_RECORD', message, relativePath))
+              }
+            } else {
+              addScanError(
+                issue(
+                  'INVALID_RECORD_LAYOUT',
+                  'Kind directories may contain only direct regular JSON files.',
+                  relativePath,
+                ),
+              )
+            }
           }
-          return {
-            errors: [
-              ...result.errors,
-              issue(
-                'INVALID_RECORD_LAYOUT',
-                'The brain root may contain only kind directories and reserved internal directories.',
-                posixRelative(root, kindPath),
-              ),
-            ],
-            records: result.records,
-          }
-        },
-        { errors: [], records: [] },
-      )
+        } else {
+          addScanError(
+            issue(
+              'INVALID_RECORD_LAYOUT',
+              'The brain root may contain only kind directories and reserved internal directories.',
+              posixRelative(root, kindPath),
+            ),
+          )
+        }
+      }
+    }
     return {
       errors: scanned.errors,
       records: scanned.records.sort(
@@ -258,6 +284,15 @@ const duplicateAndCaseIssues = (records: BrainRecord[]) => {
 
 const supersessionIssues = (records: BrainRecord[]) => {
   const byId = new Map(records.map(record => [record.id, record]))
+  const edgeCount = records.reduce((count, record) => count + (record.supersedes?.length ?? 0), 0)
+  if (edgeCount > MAX_SUPERSESSION_EDGES) {
+    return [
+      corpusIssue(
+        'CORPUS_SUPERSEDES_LIMIT',
+        `Canonical corpus may contain at most ${MAX_SUPERSESSION_EDGES} supersession edges.`,
+      ),
+    ]
+  }
   const edgeIssues = records.flatMap(record =>
     (record.supersedes ?? []).flatMap(targetId => {
       const target = byId.get(targetId)
@@ -282,27 +317,43 @@ const supersessionIssues = (records: BrainRecord[]) => {
   )
 
   const cycleIssues: ValidationIssue[] = []
-  const visiting = new Set<string>()
-  const visited = new Set<string>()
-  const visit = (record: BrainRecord) => {
-    if (!visited.has(record.id)) {
-      if (visiting.has(record.id)) {
-        cycleIssues.push(issue('SUPERSEDES_CYCLE', 'The supersession graph contains a cycle.', record.path, record.id))
-      } else {
-        visiting.add(record.id)
-        for (const targetId of record.supersedes ?? []) {
+  const state = new Map<string, 'visited' | 'visiting'>()
+  for (const record of records) {
+    if (state.has(record.id)) {
+      continue
+    }
+    const stack = [{ index: 0, record }]
+    state.set(record.id, 'visiting')
+    while (stack.length > 0) {
+      const frame = stack.at(-1)
+      if (frame !== undefined) {
+        const targets = frame.record.supersedes ?? []
+        if (frame.index >= targets.length) {
+          state.set(frame.record.id, 'visited')
+          stack.pop()
+        } else {
+          const targetId = targets[frame.index] ?? ''
+          frame.index += 1
           const target = byId.get(targetId)
           if (target !== undefined) {
-            visit(target)
+            const targetState = state.get(target.id)
+            if (targetState === 'visiting') {
+              cycleIssues.push(
+                issue(
+                  'SUPERSEDES_CYCLE',
+                  'The supersession graph contains a cycle.',
+                  frame.record.path,
+                  frame.record.id,
+                ),
+              )
+            } else if (targetState !== 'visited') {
+              state.set(target.id, 'visiting')
+              stack.push({ index: 0, record: target })
+            }
           }
         }
-        visiting.delete(record.id)
-        visited.add(record.id)
       }
     }
-  }
-  for (const record of records) {
-    visit(record)
   }
 
   const superseded = new Set(records.flatMap(record => record.supersedes ?? []))
@@ -329,6 +380,15 @@ const supersessionIssues = (records: BrainRecord[]) => {
 }
 
 const artifactIssues = (root: string, records: BrainRecord[]) => {
+  const artifactCount = records.reduce((count, record) => count + (record.artifacts?.length ?? 0), 0)
+  if (artifactCount > MAX_ARTIFACT_REFERENCES) {
+    return [
+      corpusIssue(
+        'CORPUS_ARTIFACT_LIMIT',
+        `Canonical corpus may contain at most ${MAX_ARTIFACT_REFERENCES} artifact references.`,
+      ),
+    ]
+  }
   const brainDirectory = resolve(root, 'encephalon')
   const paths = new Map<string, string>()
   return records.flatMap(record =>
@@ -351,16 +411,35 @@ const artifactIssues = (root: string, records: BrainRecord[]) => {
   )
 }
 
+const truncateValidationIssues = (errors: ValidationIssue[]) => {
+  if (errors.length <= MAX_VALIDATION_ISSUES) {
+    return { errors, truncated: false }
+  }
+  return {
+    errors: [
+      ...errors.slice(0, MAX_VALIDATION_ISSUES - 1),
+      issue(
+        'VALIDATION_ISSUES_TRUNCATED',
+        `Validation stopped reporting after ${MAX_VALIDATION_ISSUES} issues.`,
+        'encephalon',
+      ),
+    ],
+    truncated: true,
+  }
+}
+
 const validateScanned = (root: string, scan: RecordScan): ValidateResult => {
-  const errors = [
+  const collectedErrors = [
     ...scan.errors,
     ...duplicateAndCaseIssues(scan.records),
     ...supersessionIssues(scan.records),
     ...artifactIssues(root, scan.records),
   ]
+  const { errors, truncated } = truncateValidationIssues(collectedErrors)
   return {
     errors,
     recordsChecked: scan.records.length,
+    truncated,
     valid: errors.length === 0,
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,7 @@ export type ValidateResult = {
   valid: boolean
   recordsChecked: number
   errors: ValidationIssue[]
+  truncated: boolean
 }
 
 export type ListRecordsInput = RootInput & {

--- a/test/records.test.ts
+++ b/test/records.test.ts
@@ -25,6 +25,42 @@ const createRoot = () => {
   return root
 }
 
+const timestampAt = (index: number) => new Date(Date.UTC(2026, 0, 1, 0, 0, 0, index)).toISOString()
+
+const writeCanonicalRecord = (
+  root: string,
+  record: {
+    id: string
+    kind?: string
+    subject?: string
+    payload?: Record<string, unknown>
+    supersedes?: string[]
+    artifacts?: string[]
+    createdAt?: string
+  },
+) => {
+  const kind = record.kind ?? 'decision'
+  const path = join(root, 'encephalon', kind, `${record.id}.json`)
+  ensureParent(path)
+  writeFileSync(
+    path,
+    `${JSON.stringify(
+      {
+        createdAt: record.createdAt ?? timestampAt(0),
+        id: record.id,
+        kind,
+        payload: record.payload ?? {},
+        source: 'test',
+        subject: record.subject ?? 'validation.corpus',
+        ...(record.artifacts === undefined ? {} : { artifacts: record.artifacts }),
+        ...(record.supersedes === undefined ? {} : { supersedes: record.supersedes }),
+      },
+      null,
+      2,
+    )}\n`,
+  )
+}
+
 const assertErrorCode = (operation: () => unknown, code: string) => {
   assert.throws(operation, (error: unknown) => {
     assert.equal((error as { code?: unknown }).code, code)
@@ -358,6 +394,111 @@ describe('canonical records', () => {
       supersedes: [second.id, 'record-c'],
     })
     assert.equal(api.validateRecords({ root }).valid, true)
+  })
+
+  test('validates a corpus at the record limit with an iterative supersession chain', () => {
+    const root = createRoot()
+    for (const index of Array.from({ length: 1000 }, (_, value) => value)) {
+      writeCanonicalRecord(root, {
+        createdAt: timestampAt(index),
+        id: `chain-${index}`,
+        ...(index === 0 ? {} : { supersedes: [`chain-${index - 1}`] }),
+      })
+    }
+
+    const result = api.validateRecords({ root }) as { truncated?: boolean } & ReturnType<typeof api.validateRecords>
+    assert.equal(result.valid, true)
+    assert.equal(result.recordsChecked, 1000)
+    assert.equal(result.errors.length, 0)
+    assert.equal(result.truncated, false)
+  })
+
+  test('reports corpus budget overflows deterministically', () => {
+    const recordCountRoot = createRoot()
+    for (const index of Array.from({ length: 1001 }, (_, value) => value)) {
+      writeCanonicalRecord(recordCountRoot, {
+        createdAt: timestampAt(index),
+        id: `count-${index}`,
+        subject: `validation.count.${index}`,
+      })
+    }
+    const recordCountResult = api.validateRecords({ root: recordCountRoot })
+    assert.equal(recordCountResult.valid, false)
+    assert.equal(recordCountResult.errors[0]?.code, 'CORPUS_RECORD_LIMIT')
+    assert.equal(recordCountResult.recordsChecked, 1000)
+
+    const byteRoot = createRoot()
+    for (const index of Array.from({ length: 10 }, (_, value) => value)) {
+      writeCanonicalRecord(byteRoot, {
+        createdAt: timestampAt(index),
+        id: `bytes-${index}`,
+        payload: { text: 'x'.repeat(900 * 1024) },
+        subject: `validation.bytes.${index}`,
+      })
+    }
+    const byteResult = api.validateRecords({ root: byteRoot })
+    assert.equal(byteResult.valid, false)
+    assert.equal(byteResult.errors[0]?.code, 'CORPUS_BYTE_LIMIT')
+
+    const edgeRoot = createRoot()
+    writeCanonicalRecord(edgeRoot, {
+      id: 'too-many-edges',
+      supersedes: Array.from({ length: 1001 }, (_, index) => `missing-${index}`),
+    })
+    const edgeResult = api.validateRecords({ root: edgeRoot })
+    assert.equal(edgeResult.valid, false)
+    assert.equal(edgeResult.errors[0]?.code, 'CORPUS_SUPERSEDES_LIMIT')
+
+    const artifactRoot = createRoot()
+    for (const recordIndex of Array.from({ length: 201 }, (_, value) => value)) {
+      const id = `artifact-${recordIndex}`
+      writeCanonicalRecord(artifactRoot, {
+        artifacts: Array.from(
+          { length: 5 },
+          (_, artifactIndex) => `_artifacts/decision/${id}/file-${artifactIndex}.txt`,
+        ),
+        id,
+        subject: `validation.artifacts.${recordIndex}`,
+      })
+    }
+    const artifactResult = api.validateRecords({ root: artifactRoot })
+    assert.equal(artifactResult.valid, false)
+    assert.equal(artifactResult.errors[0]?.code, 'CORPUS_ARTIFACT_LIMIT')
+  })
+
+  test('detects a long supersession cycle without recursive stack growth', () => {
+    const root = createRoot()
+    for (const index of Array.from({ length: 1000 }, (_, value) => value)) {
+      writeCanonicalRecord(root, {
+        createdAt: timestampAt(index),
+        id: `cycle-${index}`,
+        supersedes: index === 0 ? ['cycle-999'] : [`cycle-${index - 1}`],
+      })
+    }
+
+    assert.doesNotThrow(() => api.validateRecords({ root }))
+    const result = api.validateRecords({ root })
+    assert.equal(result.valid, false)
+    assert.equal(
+      result.errors.some(error => error.code === 'SUPERSEDES_CYCLE'),
+      true,
+    )
+  })
+
+  test('truncates validation issues with a deterministic sentinel', () => {
+    const root = createRoot()
+    for (const index of Array.from({ length: 105 }, (_, value) => value)) {
+      const path = join(root, 'encephalon', 'decision', `invalid-${String(index).padStart(3, '0')}.json`)
+      ensureParent(path)
+      writeFileSync(path, '{invalid')
+    }
+
+    const result = api.validateRecords({ root }) as { truncated?: boolean } & ReturnType<typeof api.validateRecords>
+    assert.equal(result.valid, false)
+    assert.equal(result.truncated, true)
+    assert.equal(result.errors.length, 100)
+    assert.equal(result.errors[0]?.path, 'encephalon/decision/invalid-000.json')
+    assert.equal(result.errors.at(-1)?.code, 'VALIDATION_ISSUES_TRUNCATED')
   })
 
   test('rejects non-JSON payloads and unsafe portable paths', () => {

--- a/test/records.test.ts
+++ b/test/records.test.ts
@@ -571,6 +571,7 @@ describe('canonical records', () => {
     assert.equal(result.errors.length, 100)
     assert.equal(result.errors[0]?.path, 'encephalon/decision/invalid-000.json')
     assert.equal(result.errors.at(-1)?.code, 'VALIDATION_ISSUES_TRUNCATED')
+    assert.equal(result.errors.at(-1)?.message, 'Validation stopped reporting after 99 concrete issues.')
   })
 
   test('rejects non-JSON payloads and unsafe portable paths', () => {


### PR DESCRIPTION
## Human summary

Validation now has explicit corpus limits and stops reporting runaway errors predictably, so large or malformed repositories cannot exhaust memory or the call stack.

## Summary

- Add documented v0.x limits for canonical record count, aggregate record JSON bytes, supersession edges, artifact references, and returned validation issues.
- Replace recursive supersession cycle detection with an iterative state traversal that handles long chains and cycles without stack growth.
- Stop scanning once hard record-count, aggregate-byte, or scan-error budgets are exceeded.
- Add `ValidateResult.truncated` and a deterministic `VALIDATION_ISSUES_TRUNCATED` sentinel when more than 100 issues exist.
- Add regression coverage for exact record-count boundary, corpus budget overflows, long chains, long cycles, excess artifacts/edges, byte overflow, and deterministic issue truncation.
