### PR TITLE
[MAR-2524] Centralise runtime package version

### DIFF
--- a/encephalon/review/8cebafad-e75b-4719-9911-0ec5a20f1168.json
+++ b/encephalon/review/8cebafad-e75b-4719-9911-0ec5a20f1168.json
@@ -1,0 +1,19 @@
+{
+  "createdAt": "2026-08-08T12:33:29.159Z",
+  "id": "8cebafad-e75b-4719-9911-0ec5a20f1168",
+  "kind": "review",
+  "payload": {
+    "summary": "Package-version generation should quote manifest values safely and root-install mismatches should explain version drift clearly.",
+    "lessons": [
+      "When generating TypeScript constants from package.json values, emit literals with JSON.stringify instead of hand-wrapping strings.",
+      "Keep package contract checks aligned with the generated source shape so stale metadata failures remain meaningful.",
+      "If root-install verification fails because the installed package version differs from the executing bundle, keep the stable error code but use a message that points to rebuild or reinstall."
+    ],
+    "verification": [
+      "Run build, package contract tests, and check:package after changing generated package version metadata."
+    ]
+  },
+  "searchText": "package version generation JSON.stringify root install version mismatch Pullfrog",
+  "source": "agent",
+  "subject": "review.package-version-generation"
+}

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -11,7 +11,7 @@ const generatedDirectory = resolve(root, 'src', 'generated')
 mkdirSync(generatedDirectory, { recursive: true })
 writeFileSync(
   resolve(generatedDirectory, 'version.ts'),
-  `// Generated from package.json by scripts/build.ts.\nexport const PACKAGE_VERSION = '${packageJson.version}'\n`,
+  `// Generated from package.json by scripts/build.ts.\nexport const PACKAGE_VERSION = ${JSON.stringify(packageJson.version)}\n`,
   'utf8',
 )
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -3,6 +3,17 @@ import { resolve } from 'node:path'
 
 const root = resolve(import.meta.dir, '..')
 const outputDirectory = resolve(root, 'dist')
+const packageJson = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as { version?: unknown }
+if (typeof packageJson.version !== 'string') {
+  throw new Error('package.json must declare a string version.')
+}
+const generatedDirectory = resolve(root, 'src', 'generated')
+mkdirSync(generatedDirectory, { recursive: true })
+writeFileSync(
+  resolve(generatedDirectory, 'version.ts'),
+  `// Generated from package.json by scripts/build.ts.\nexport const PACKAGE_VERSION = '${packageJson.version}'\n`,
+  'utf8',
+)
 
 rmSync(outputDirectory, { force: true, recursive: true })
 mkdirSync(outputDirectory, { recursive: true })

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -79,7 +79,7 @@ try {
     throw new Error('Package version must be a string.')
   }
   const generatedVersionSource = readFileSync(resolve(root, 'src', 'generated', 'version.ts'), 'utf8')
-  if (!generatedVersionSource.includes(`PACKAGE_VERSION = '${packageJson.version}'`)) {
+  if (!generatedVersionSource.includes(`PACKAGE_VERSION = ${JSON.stringify(packageJson.version)}`)) {
     throw new Error('Generated runtime package version is stale.')
   }
   if (

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -75,9 +75,15 @@ try {
     dependencies?: unknown
     scripts?: Record<string, unknown>
   }
+  if (typeof packageJson.version !== 'string') {
+    throw new Error('Package version must be a string.')
+  }
+  const generatedVersionSource = readFileSync(resolve(root, 'src', 'generated', 'version.ts'), 'utf8')
+  if (!generatedVersionSource.includes(`PACKAGE_VERSION = '${packageJson.version}'`)) {
+    throw new Error('Generated runtime package version is stale.')
+  }
   if (
     packageJson.name !== 'encephalon' ||
-    packageJson.version !== '0.1.0' ||
     packageJson.license !== 'MIT' ||
     packageJson.type !== 'module' ||
     JSON.stringify(packageJson.engines) !== JSON.stringify({ node: '>=24.15.0' }) ||
@@ -128,6 +134,10 @@ try {
     .join('\n')
   if (/from\s+["'][^"']+\.ts["']/.test(declarations)) {
     throw new Error('The declarations contain unresolved TypeScript source imports.')
+  }
+  const cliVersion = run(['node', resolve(root, 'dist', 'cli.mjs'), '--version'])
+  if (cliVersion !== `${packageJson.version}\n`) {
+    throw new Error('The built CLI reports a stale package version.')
   }
 
   const packOutput = run([

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module'
 import { resolve } from 'node:path'
 import type { DatabaseSync } from 'node:sqlite'
 import { EncephalonError, fail, failWithCause, wrapIo } from './errors.ts'
+import { PACKAGE_VERSION } from './generated/version.ts'
 import { cacheDirectory, withOperationLock } from './lock.ts'
 import { readRecords } from './records.ts'
 import { resolveRepository } from './repository.ts'
@@ -20,7 +21,6 @@ import type {
   ShowRecordInput,
 } from './types.ts'
 
-const PACKAGE_VERSION = '0.1.0'
 const SCHEMA_VERSION = '1'
 const MAX_REPOSITORY_CHANGE_RETRIES = 3
 const DATABASE_FILENAME = 'brain.sqlite'
@@ -326,7 +326,6 @@ const metadataIsFresh = (root: string, metadata: Metadata | undefined): metadata
   return (
     metadata !== undefined &&
     metadata.schemaVersion === SCHEMA_VERSION &&
-    metadata.packageVersion === PACKAGE_VERSION &&
     metadata.manifest === repositoryManifest(root, metadata.artifactPaths)
   )
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { fail } from './errors.ts'
+import { PACKAGE_VERSION } from './generated/version.ts'
 import {
   addRecord,
   EncephalonError,
@@ -16,7 +17,6 @@ import {
 } from './index.ts'
 import type { JsonValue } from './types.ts'
 
-const VERSION = '0.1.0'
 const HELP = `Usage: encephalon [--root <path>] <command> [options]
 
 Commands:
@@ -160,7 +160,7 @@ const dispatch = (arguments_: string[]): CommandResult => {
     return { value: HELP }
   }
   if (arguments_.includes('--version') || arguments_.includes('-v')) {
-    return { value: `${VERSION}\n` }
+    return { value: `${PACKAGE_VERSION}\n` }
   }
   const extracted = extractRoot(arguments_)
   const [command, ...commandArguments] = extracted.remaining

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -1,0 +1,2 @@
+// Generated from package.json by scripts/build.ts.
+export const PACKAGE_VERSION = '0.1.0'

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -1,2 +1,2 @@
 // Generated from package.json by scripts/build.ts.
-export const PACKAGE_VERSION = '0.1.0'
+export const PACKAGE_VERSION = "0.1.0"

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -2,6 +2,7 @@ import { existsSync, lstatSync, readFileSync, realpathSync } from 'node:fs'
 import { dirname, isAbsolute, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { fail, wrapIo } from './errors.ts'
+import { PACKAGE_VERSION } from './generated/version.ts'
 
 export type DiscoverRepositoryInput = {
   root?: string
@@ -106,7 +107,7 @@ export const assertRootInstallation = (root: string) => {
           name?: unknown
           version?: unknown
         }
-        if (packageJson.name === 'encephalon' && typeof packageJson.version === 'string') {
+        if (packageJson.name === 'encephalon' && packageJson.version === PACKAGE_VERSION) {
           return installedRoot
         }
       }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -110,6 +110,13 @@ export const assertRootInstallation = (root: string) => {
         if (packageJson.name === 'encephalon' && packageJson.version === PACKAGE_VERSION) {
           return installedRoot
         }
+        if (packageJson.name === 'encephalon') {
+          const installedVersion = typeof packageJson.version === 'string' ? packageJson.version : 'unknown'
+          return fail(
+            'ROOT_INSTALL_REQUIRED',
+            `Root Encephalon package version ${installedVersion} does not match executing version ${PACKAGE_VERSION}. Rebuild or reinstall Encephalon at the repository root before running this command.`,
+          )
+        }
       }
     } catch (error) {
       return wrapIo('Unable to verify the root Encephalon installation.', error)

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -5,6 +5,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync
 import { join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import { afterEach, describe, test } from 'node:test'
+import { PACKAGE_VERSION } from '../src/generated/version.ts'
 import * as api from '../src/index.ts'
 import { createTestRepository, ensureParent, removeTestRepository } from '../test/helpers.ts'
 
@@ -34,6 +35,31 @@ describe('SQLite cache and reads', () => {
       >('prepare')
     assert.deepEqual(prepare({ root }), { hydrated: true, recordsIndexed: 0 })
     assert.deepEqual(prepare({ root }), { hydrated: false, recordsIndexed: 0 })
+  })
+
+  test('uses schema version rather than package version for cache compatibility', () => {
+    const root = createRoot()
+    const prepare =
+      functionFromApi<
+        (input: Record<string, unknown>) => {
+          hydrated: boolean
+          recordsIndexed: number
+        }
+      >('prepare')
+    assert.deepEqual(prepare({ root }), { hydrated: true, recordsIndexed: 0 })
+    const database = new DatabaseSync(join(root, 'node_modules', '.cache', 'encephalon', 'brain.sqlite'))
+    const metadata = database.prepare("SELECT value FROM metadata WHERE key = 'packageVersion'").get()
+    assert.equal(metadata?.value, PACKAGE_VERSION)
+    database.prepare("UPDATE metadata SET value = '9.9.9' WHERE key = 'packageVersion'").run()
+    database.close()
+
+    assert.deepEqual(prepare({ root }), { hydrated: false, recordsIndexed: 0 })
+
+    const schemaDatabase = new DatabaseSync(join(root, 'node_modules', '.cache', 'encephalon', 'brain.sqlite'))
+    schemaDatabase.prepare("UPDATE metadata SET value = '0' WHERE key = 'schemaVersion'").run()
+    schemaDatabase.close()
+
+    assert.deepEqual(prepare({ root }), { hydrated: true, recordsIndexed: 0 })
   })
 
   test('automatically prepares active list, show, search, compact search, and gather reads', () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -3,6 +3,7 @@ import { spawnSync } from 'node:child_process'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, describe, test } from 'node:test'
+import { PACKAGE_VERSION } from '../src/generated/version.ts'
 import { createTestRepository, removeTestRepository } from '../test/helpers.ts'
 
 const roots: string[] = []
@@ -90,6 +91,6 @@ describe('command-line interface', () => {
     assert.match(help.stdout, /^Usage: encephalon/m)
     const version = run(root, ['--version'])
     assert.equal(version.status, 0)
-    assert.equal(version.stdout, '0.1.0\n')
+    assert.equal(version.stdout, `${PACKAGE_VERSION}\n`)
   })
 })

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -33,7 +33,7 @@ describe('package contract', () => {
     const packageJson = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as { version?: unknown }
 
     assert.equal(PACKAGE_VERSION, packageJson.version)
-    assert.match(generated, new RegExp(`PACKAGE_VERSION = '${PACKAGE_VERSION}'`))
+    assert.equal(generated.includes(`PACKAGE_VERSION = ${JSON.stringify(PACKAGE_VERSION)}`), true)
   })
 
   test('ships the generic repository-memory skill', () => {

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { existsSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, test } from 'node:test'
+import { PACKAGE_VERSION } from '../src/generated/version.ts'
 
 const root = resolve(import.meta.dirname, '..')
 
@@ -10,7 +11,7 @@ describe('package contract', () => {
     const packageJson = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as Record<string, unknown>
 
     assert.equal(packageJson.name, 'encephalon')
-    assert.equal(packageJson.version, '0.1.0')
+    assert.equal(packageJson.version, PACKAGE_VERSION)
     assert.equal(packageJson.type, 'module')
     assert.deepEqual(packageJson.engines, { node: '>=24.15.0' })
     assert.deepEqual(packageJson.bin, { encephalon: 'dist/cli.mjs' })
@@ -25,6 +26,14 @@ describe('package contract', () => {
 
   test('has a side-effect-free TypeScript API entrypoint', () => {
     assert.equal(existsSync(resolve(root, 'src/index.ts')), true)
+  })
+
+  test('keeps generated runtime version metadata in sync with the manifest', () => {
+    const generated = readFileSync(resolve(root, 'src', 'generated', 'version.ts'), 'utf8')
+    const packageJson = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as { version?: unknown }
+
+    assert.equal(PACKAGE_VERSION, packageJson.version)
+    assert.match(generated, new RegExp(`PACKAGE_VERSION = '${PACKAGE_VERSION}'`))
   })
 
   test('ships the generic repository-memory skill', () => {


### PR DESCRIPTION
## Human summary

Encephalon now gets its runtime version from package.json, rejects stale root installs, and keeps compatible caches across package-only version changes.

## Summary

- Generate `src/generated/version.ts` from `package.json` during build and use it for CLI output, cache metadata, and root-install verification.
- Stop treating diagnostic package-version metadata as part of cache freshness; schema version remains the cache compatibility key.
- Reject root installations whose manifest version differs from the executing bundle.
- Teach package checks to fail when generated version metadata or built CLI output is stale.
- Add regression coverage for package-version cache reuse, schema-version rebuilds, CLI version output, and generated metadata sync.
