### PR TITLE
[MAR-2525] Separate expected I/O failures from defects

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { fail } from './errors.ts'
+import { cliErrorResponse, fail } from './errors.ts'
 import {
   addRecord,
   EncephalonError,
@@ -340,14 +340,9 @@ export const runCli = (arguments_: string[] = process.argv.slice(2)) => {
     return result.exitCode ?? 0
   } catch (error) {
     if (error instanceof EncephalonError) {
-      writeJson(process.stderr, {
-        error: {
-          code: error.code,
-          details: error.details,
-          message: error.message,
-        },
-      })
-      return 2
+      const response = cliErrorResponse(error)
+      writeJson(process.stderr, response.body)
+      return response.exitCode
     }
     writeJson(process.stderr, {
       error: {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -38,11 +38,16 @@ const MAX_CLI_STRING_LENGTH = 256
 const MAX_CLI_ARRAY_LENGTH = 25
 const MAX_CLI_OBJECT_KEYS = 25
 const MAX_CLI_NUMBER_MAGNITUDE = 1_000_000_000_000
-const ABSOLUTE_PATH_PATTERN = /(^|[\s("'=])(?:\/|[A-Za-z]:[\\/]|\\\\)/
 const UNSAFE_CLI_DETAIL_KEYS = new Set(['cause', 'stack'])
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && !Array.isArray(value) && typeof value === 'object'
+
+const containsAbsolutePath = (value: string) =>
+  /(^|[\s("'=:;,])(\/|[A-Za-z]:[\\/]|\\\\)/.test(value) ||
+  /(^|[\s("'=:;,])\\[A-Za-z]/.test(value) ||
+  /(^|[\s("'=:;,])file:\/\//i.test(value) ||
+  /^[a-z][a-z0-9+.-]*:\//i.test(value)
 
 const isRecognizedFilesystemError = (error: unknown) => {
   if (!isRecord(error)) {
@@ -69,7 +74,7 @@ const errorCodeForCause = (cause: unknown): EncephalonErrorCode =>
   isRecognizedFilesystemError(cause) || isRecognizedSQLiteError(cause) ? 'IO_ERROR' : 'INTERNAL_ERROR'
 
 const isCliSafeString = (value: string) =>
-  value.length <= MAX_CLI_STRING_LENGTH && !/[\r\n]/.test(value) && !ABSOLUTE_PATH_PATTERN.test(value)
+  value.length <= MAX_CLI_STRING_LENGTH && !/[\r\n]/.test(value) && !containsAbsolutePath(value)
 
 const cliSafeValue = (value: JsonValue): JsonValue | undefined => {
   if (value === null || typeof value === 'boolean') {
@@ -82,14 +87,12 @@ const cliSafeValue = (value: JsonValue): JsonValue | undefined => {
     return isCliSafeString(value) ? value : undefined
   }
   if (Array.isArray(value)) {
-    if (value.length > MAX_CLI_ARRAY_LENGTH) {
-      return
+    const withinLimit = value.length <= MAX_CLI_ARRAY_LENGTH
+    const projected = withinLimit ? value.map(item => cliSafeValue(item)) : undefined
+    if (projected?.every(item => item !== undefined)) {
+      return projected as JsonValue[]
     }
-    const safeValues = value.flatMap(item => {
-      const safe = cliSafeValue(item)
-      return safe === undefined ? [] : [safe]
-    })
-    return safeValues
+    return
   }
   const safeEntries = Object.entries(value)
     .slice(0, MAX_CLI_OBJECT_KEYS)

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,7 +2,9 @@ import type { EncephalonErrorCode, JsonValue } from './types.ts'
 
 const FILESYSTEM_ERROR_CODES = new Set([
   'EACCES',
+  'EAGAIN',
   'EBUSY',
+  'EDQUOT',
   'EEXIST',
   'EIO',
   'EISDIR',
@@ -16,9 +18,22 @@ const FILESYSTEM_ERROR_CODES = new Set([
   'ENOTEMPTY',
   'EPERM',
   'EROFS',
+  'ESTALE',
   'EXDEV',
 ])
-const SQLITE_ERROR_CODE_PREFIX = 'SQLITE_'
+const SQLITE_IO_ERROR_CODES = new Set([3, 5, 6, 7, 8, 10, 11, 13, 14, 26])
+const SQLITE_IO_STRING_CODES = new Set([
+  'SQLITE_BUSY',
+  'SQLITE_CANTOPEN',
+  'SQLITE_CORRUPT',
+  'SQLITE_FULL',
+  'SQLITE_IOERR',
+  'SQLITE_LOCKED',
+  'SQLITE_NOMEM',
+  'SQLITE_NOTADB',
+  'SQLITE_PERM',
+  'SQLITE_READONLY',
+])
 const MAX_CLI_STRING_LENGTH = 256
 const MAX_CLI_ARRAY_LENGTH = 25
 const MAX_CLI_OBJECT_KEYS = 25
@@ -41,10 +56,10 @@ const isRecognizedSQLiteError = (error: unknown) => {
     return false
   }
   return (
-    (typeof error.code === 'string' && error.code.startsWith(SQLITE_ERROR_CODE_PREFIX)) ||
-    typeof error.errcode === 'number' ||
+    (typeof error.code === 'string' && SQLITE_IO_STRING_CODES.has(error.code)) ||
+    (typeof error.errcode === 'number' && SQLITE_IO_ERROR_CODES.has(error.errcode)) ||
     (typeof error.message === 'string' &&
-      /database disk image is malformed|database is locked|file is not a database|SQLITE_(?:BUSY|LOCKED)/i.test(
+      /database disk image is malformed|database is locked|file is not a database|SQLITE_(?:BUSY|CANTOPEN|CORRUPT|FULL|IOERR|LOCKED|NOMEM|NOTADB|PERM|READONLY)/i.test(
         error.message,
       ))
   )

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -62,7 +62,7 @@ const isRecognizedSQLiteError = (error: unknown) => {
   }
   return (
     (typeof error.code === 'string' && SQLITE_IO_STRING_CODES.has(error.code)) ||
-    (typeof error.errcode === 'number' && SQLITE_IO_ERROR_CODES.has(error.errcode)) ||
+    (typeof error.errcode === 'number' && SQLITE_IO_ERROR_CODES.has(error.errcode & 0xff)) ||
     (typeof error.message === 'string' &&
       /database disk image is malformed|database is locked|file is not a database|SQLITE_(?:BUSY|CANTOPEN|CORRUPT|FULL|IOERR|LOCKED|NOMEM|NOTADB|PERM|READONLY)/i.test(
         error.message,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,93 @@
 import type { EncephalonErrorCode, JsonValue } from './types.ts'
 
+const FILESYSTEM_ERROR_CODES = new Set([
+  'EACCES',
+  'EBUSY',
+  'EEXIST',
+  'EIO',
+  'EISDIR',
+  'ELOOP',
+  'EMFILE',
+  'ENAMETOOLONG',
+  'ENFILE',
+  'ENOENT',
+  'ENOSPC',
+  'ENOTDIR',
+  'ENOTEMPTY',
+  'EPERM',
+  'EROFS',
+  'EXDEV',
+])
+const SQLITE_ERROR_CODE_PREFIX = 'SQLITE_'
+const MAX_CLI_STRING_LENGTH = 256
+const MAX_CLI_ARRAY_LENGTH = 25
+const MAX_CLI_OBJECT_KEYS = 25
+const MAX_CLI_NUMBER_MAGNITUDE = 1_000_000_000_000
+const ABSOLUTE_PATH_PATTERN = /(^|[\s("'=])(?:\/|[A-Za-z]:[\\/]|\\\\)/
+const UNSAFE_CLI_DETAIL_KEYS = new Set(['cause', 'stack'])
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && !Array.isArray(value) && typeof value === 'object'
+
+const isRecognizedFilesystemError = (error: unknown) => {
+  if (!isRecord(error)) {
+    return false
+  }
+  return typeof error.code === 'string' && FILESYSTEM_ERROR_CODES.has(error.code)
+}
+
+const isRecognizedSQLiteError = (error: unknown) => {
+  if (!isRecord(error)) {
+    return false
+  }
+  return (
+    (typeof error.code === 'string' && error.code.startsWith(SQLITE_ERROR_CODE_PREFIX)) ||
+    typeof error.errcode === 'number' ||
+    (typeof error.message === 'string' &&
+      /database disk image is malformed|database is locked|file is not a database|SQLITE_(?:BUSY|LOCKED)/i.test(
+        error.message,
+      ))
+  )
+}
+
+const errorCodeForCause = (cause: unknown): EncephalonErrorCode =>
+  isRecognizedFilesystemError(cause) || isRecognizedSQLiteError(cause) ? 'IO_ERROR' : 'INTERNAL_ERROR'
+
+const isCliSafeString = (value: string) =>
+  value.length <= MAX_CLI_STRING_LENGTH && !/[\r\n]/.test(value) && !ABSOLUTE_PATH_PATTERN.test(value)
+
+const cliSafeValue = (value: JsonValue): JsonValue | undefined => {
+  if (value === null || typeof value === 'boolean') {
+    return value
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && Math.abs(value) <= MAX_CLI_NUMBER_MAGNITUDE ? value : undefined
+  }
+  if (typeof value === 'string') {
+    return isCliSafeString(value) ? value : undefined
+  }
+  if (Array.isArray(value)) {
+    if (value.length > MAX_CLI_ARRAY_LENGTH) {
+      return
+    }
+    const safeValues = value.flatMap(item => {
+      const safe = cliSafeValue(item)
+      return safe === undefined ? [] : [safe]
+    })
+    return safeValues
+  }
+  const safeEntries = Object.entries(value)
+    .slice(0, MAX_CLI_OBJECT_KEYS)
+    .flatMap(([key, entry]) => {
+      if (UNSAFE_CLI_DETAIL_KEYS.has(key)) {
+        return []
+      }
+      const safe = cliSafeValue(entry)
+      return safe === undefined ? [] : [[key, safe] as const]
+    })
+  return Object.fromEntries(safeEntries) as Record<string, JsonValue>
+}
+
 export class EncephalonError extends Error {
   readonly code: EncephalonErrorCode
   readonly details: Record<string, JsonValue>
@@ -30,4 +118,26 @@ export const failWithCause = (
   throw new EncephalonError(code, message, details, { cause })
 }
 
-export const wrapIo = (message: string, cause: unknown): never => failWithCause('IO_ERROR', message, {}, cause)
+export const wrapIo = (message: string, cause: unknown): never =>
+  failWithCause(errorCodeForCause(cause), message, {}, cause)
+
+const cliSafeMessage = (error: EncephalonError) => {
+  if (error.code === 'INTERNAL_ERROR') {
+    return 'An unexpected internal error occurred.'
+  }
+  if (isCliSafeString(error.message)) {
+    return error.message
+  }
+  return 'The command failed.'
+}
+
+export const cliErrorResponse = (error: EncephalonError) => ({
+  body: {
+    error: {
+      code: error.code,
+      details: cliSafeValue(error.details) as Record<string, JsonValue>,
+      message: cliSafeMessage(error),
+    },
+  },
+  exitCode: error.code === 'INTERNAL_ERROR' ? 1 : 2,
+})

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -367,7 +367,7 @@ const writeAll = (descriptor: number, bytes: Buffer, plan: FilePlan, hooks: Atom
   while (offset < bytes.length) {
     const written = writeSync(descriptor, bytes, offset, bytes.length - offset, offset)
     if (written <= 0) {
-      throw new Error(`Unable to write ${plan.filename}.`)
+      throw Object.assign(new Error(`Unable to write ${plan.filename}.`), { code: 'EIO' })
     }
     offset += written
   }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
 import { afterEach, describe, test } from 'node:test'
 import { createTestRepository, removeTestRepository } from '../test/helpers.ts'
 
@@ -67,6 +68,31 @@ describe('command-line interface', () => {
         code: 'INVALID_ARGUMENT',
         details: {},
         message: 'add requires --kind, --subject, --source, and --data.',
+      },
+    })
+  })
+
+  test('redacts CLI details that contain absolute repository paths', () => {
+    const root = createRoot()
+    const prepared = run(root, ['prepare', '--root', root])
+    assert.equal(prepared.status, 0)
+
+    const database = new DatabaseSync(join(root, 'node_modules', '.cache', 'encephalon', 'brain.sqlite'))
+    database
+      .prepare("UPDATE metadata SET value = ? WHERE key = 'repositoryRealpath'")
+      .run(join(root, '..', 'other-repository'))
+    database.close()
+
+    const result = run(root, ['prepare', '--root', root])
+    assert.equal(result.status, 2)
+    assert.equal(result.stdout, '')
+    assert.equal(result.stderr.includes(root), false)
+    assert.equal(result.stderr.includes('Error:'), false)
+    assert.deepEqual(JSON.parse(result.stderr), {
+      error: {
+        code: 'CACHE_SCOPE_MISMATCH',
+        details: {},
+        message: 'The Encephalon cache belongs to a different repository.',
       },
     })
   })

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { describe, test } from 'node:test'
-import { wrapIo } from '../src/errors.ts'
+import { cliErrorResponse, EncephalonError, wrapIo } from '../src/errors.ts'
 import type { EncephalonErrorCode } from '../src/types.ts'
 
 const assertWrappedCode = (cause: unknown, code: EncephalonErrorCode) => {
@@ -34,5 +34,38 @@ describe('error classification', () => {
       Object.assign(new Error('file is not a database'), { code: 'ERR_SQLITE_ERROR', errcode: 26 }),
       'IO_ERROR',
     )
+  })
+
+  test('classifies plain errors without errno as internal defects', () => {
+    assertWrappedCode(new Error('Unable to write file.'), 'INTERNAL_ERROR')
+  })
+})
+
+describe('CLI error projection', () => {
+  test('uses exit 2 for expected errors and exit 1 for internal defects', () => {
+    assert.equal(cliErrorResponse(new EncephalonError('IO_ERROR', 'Disk full.')).exitCode, 2)
+    assert.equal(cliErrorResponse(new EncephalonError('INTERNAL_ERROR', 'Boom.')).exitCode, 1)
+  })
+
+  test('redacts absolute, URL-like, and Windows path shapes from CLI details', () => {
+    const response = cliErrorResponse(
+      new EncephalonError('CACHE_SCOPE_MISMATCH', 'Wrong cache.', {
+        cachedRepository: 'file:///home/secret/repo',
+        csvPath: 'path,/var/lib/x',
+        openPath: 'open:/tmp/secret',
+        relative: 'records/foo.json',
+        windowsPath: '\\Users\\secret\\repo',
+      }),
+    )
+    assert.deepEqual(response.body.error.details, { relative: 'records/foo.json' })
+  })
+
+  test('drops detail arrays that contain any unsafe element', () => {
+    const response = cliErrorResponse(
+      new EncephalonError('VALIDATION_FAILED', 'Bad input.', {
+        paths: ['records/a.json', '/etc/passwd', 'records/b.json'],
+      }),
+    )
+    assert.deepEqual(response.body.error.details, {})
   })
 })

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -31,8 +31,16 @@ describe('error classification', () => {
       'IO_ERROR',
     )
     assertWrappedCode(
+      Object.assign(new Error('disk I/O error'), { code: 'ERR_SQLITE_ERROR', errcode: 266 }),
+      'IO_ERROR',
+    )
+    assertWrappedCode(
       Object.assign(new Error('file is not a database'), { code: 'ERR_SQLITE_ERROR', errcode: 26 }),
       'IO_ERROR',
+    )
+    assertWrappedCode(
+      Object.assign(new Error('UNIQUE constraint failed'), { code: 'ERR_SQLITE_ERROR', errcode: 1555 }),
+      'INTERNAL_ERROR',
     )
   })
 

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,64 +1,38 @@
 import assert from 'node:assert/strict'
 import { describe, test } from 'node:test'
-import { cliErrorResponse, EncephalonError, wrapIo } from '../src/errors.ts'
+import { wrapIo } from '../src/errors.ts'
+import type { EncephalonErrorCode } from '../src/types.ts'
 
-const wrappedError = (cause: unknown) => {
-  try {
-    wrapIo('Unable to complete the operation.', cause)
-  } catch (error) {
-    assert.equal(error instanceof EncephalonError, true)
-    return error as EncephalonError
-  }
-  return assert.fail('wrapIo must throw.')
+const assertWrappedCode = (cause: unknown, code: EncephalonErrorCode) => {
+  assert.throws(
+    () => wrapIo('Wrapped failure.', cause),
+    (error: unknown) => {
+      assert.equal((error as { code?: unknown }).code, code)
+      return true
+    },
+  )
 }
 
 describe('error classification', () => {
-  test('wraps recognized filesystem and SQLite failures as expected I/O errors', () => {
-    const causes = [
-      Object.assign(new Error('missing'), { code: 'ENOENT' }),
-      Object.assign(new Error('permission denied'), { code: 'EACCES' }),
-      Object.assign(new Error('no space left'), { code: 'ENOSPC' }),
-      Object.assign(new Error('database is busy'), { code: 'SQLITE_BUSY' }),
-      Object.assign(new Error('database is locked'), { errcode: 5 }),
-      Object.assign(new Error('database disk image is malformed'), { errcode: 11 }),
-      Object.assign(new Error('file is not a database'), { errcode: 26 }),
-    ]
-
-    for (const cause of causes) {
-      const error = wrappedError(cause)
-      assert.equal(error.code, 'IO_ERROR')
-      assert.equal(error.cause, cause)
+  test('classifies expected filesystem errno values as I/O failures', () => {
+    for (const code of ['EDQUOT', 'ESTALE', 'EAGAIN']) {
+      assertWrappedCode(Object.assign(new Error(code), { code }), 'IO_ERROR')
     }
   })
 
-  test('wraps programming defects as internal errors while preserving the API cause', () => {
-    for (const cause of [new TypeError('bad invariant'), new RangeError('bad range')]) {
-      const error = wrappedError(cause)
-      assert.equal(error.code, 'INTERNAL_ERROR')
-      assert.equal(error.cause, cause)
-    }
-  })
-
-  test('projects internal errors as exit status 1 with CLI-safe details', () => {
-    const error = new EncephalonError('INTERNAL_ERROR', '/tmp/repository leaked', {
-      cause: { message: 'raw cause' },
-      field: 'payload',
-      path: 'encephalon/decision/example.json',
-      stack: 'Error: leaked',
-    })
-
-    assert.deepEqual(cliErrorResponse(error), {
-      body: {
-        error: {
-          code: 'INTERNAL_ERROR',
-          details: {
-            field: 'payload',
-            path: 'encephalon/decision/example.json',
-          },
-          message: 'An unexpected internal error occurred.',
-        },
-      },
-      exitCode: 1,
-    })
+  test('keeps SQLite programmer errors internal while allowing environmental failures', () => {
+    assertWrappedCode(
+      Object.assign(new Error('constraint failed'), { code: 'ERR_SQLITE_ERROR', errcode: 19 }),
+      'INTERNAL_ERROR',
+    )
+    assertWrappedCode(Object.assign(new Error('bad SQL'), { code: 'ERR_SQLITE_ERROR', errcode: 1 }), 'INTERNAL_ERROR')
+    assertWrappedCode(
+      Object.assign(new Error('database is locked'), { code: 'ERR_SQLITE_ERROR', errcode: 5 }),
+      'IO_ERROR',
+    )
+    assertWrappedCode(
+      Object.assign(new Error('file is not a database'), { code: 'ERR_SQLITE_ERROR', errcode: 26 }),
+      'IO_ERROR',
+    )
   })
 })

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import { cliErrorResponse, EncephalonError, wrapIo } from '../src/errors.ts'
+
+const wrappedError = (cause: unknown) => {
+  try {
+    wrapIo('Unable to complete the operation.', cause)
+  } catch (error) {
+    assert.equal(error instanceof EncephalonError, true)
+    return error as EncephalonError
+  }
+  return assert.fail('wrapIo must throw.')
+}
+
+describe('error classification', () => {
+  test('wraps recognized filesystem and SQLite failures as expected I/O errors', () => {
+    const causes = [
+      Object.assign(new Error('missing'), { code: 'ENOENT' }),
+      Object.assign(new Error('permission denied'), { code: 'EACCES' }),
+      Object.assign(new Error('no space left'), { code: 'ENOSPC' }),
+      Object.assign(new Error('database is busy'), { code: 'SQLITE_BUSY' }),
+      Object.assign(new Error('database is locked'), { errcode: 5 }),
+      Object.assign(new Error('database disk image is malformed'), { errcode: 11 }),
+      Object.assign(new Error('file is not a database'), { errcode: 26 }),
+    ]
+
+    for (const cause of causes) {
+      const error = wrappedError(cause)
+      assert.equal(error.code, 'IO_ERROR')
+      assert.equal(error.cause, cause)
+    }
+  })
+
+  test('wraps programming defects as internal errors while preserving the API cause', () => {
+    for (const cause of [new TypeError('bad invariant'), new RangeError('bad range')]) {
+      const error = wrappedError(cause)
+      assert.equal(error.code, 'INTERNAL_ERROR')
+      assert.equal(error.cause, cause)
+    }
+  })
+
+  test('projects internal errors as exit status 1 with CLI-safe details', () => {
+    const error = new EncephalonError('INTERNAL_ERROR', '/tmp/repository leaked', {
+      cause: { message: 'raw cause' },
+      field: 'payload',
+      path: 'encephalon/decision/example.json',
+      stack: 'Error: leaked',
+    })
+
+    assert.deepEqual(cliErrorResponse(error), {
+      body: {
+        error: {
+          code: 'INTERNAL_ERROR',
+          details: {
+            field: 'payload',
+            path: 'encephalon/decision/example.json',
+          },
+          message: 'An unexpected internal error occurred.',
+        },
+      },
+      exitCode: 1,
+    })
+  })
+})

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -376,7 +376,7 @@ describe('initialisation', () => {
         applyInstructionChanges(root, [agentsPlan], {
           fault: point => {
             if (point === 'after-backup-validation') {
-              throw new Error('Injected publication failure')
+              throw Object.assign(new Error('Injected publication failure'), { code: 'EIO' })
             }
             if (point === 'during-backup-restore') {
               writeFileSync(path, changed)
@@ -484,7 +484,7 @@ describe('initialisation', () => {
           applyInstructionChanges(root, [agentsPlan], {
             fault: point => {
               if (point === faultPoint) {
-                throw new Error(`Injected ${point}`)
+                throw Object.assign(new Error(`Injected ${point}`), { code: 'EIO' })
               }
             },
           }),


### PR DESCRIPTION
## Human summary

Encephalon now reports expected filesystem and SQLite failures separately from internal defects, and CLI errors no longer expose local paths or raw internals.

## Summary

- Classify only recognised filesystem and SQLite error shapes as `IO_ERROR`; unexpected defects now become `INTERNAL_ERROR` while preserving the original API cause.
- Add a CLI-safe error projection that redacts absolute paths, raw causes, stack fields, unsafe strings, and oversized diagnostics before writing stderr.
- Return CLI exit status 1 for internal errors while preserving exit status 2 for expected Encephalon errors.
- Keep repository-relative paths and stable detail fields in safe CLI output.
- Update fault-injection tests to model operational I/O failures with errno-shaped errors.
- Add regression coverage for `ENOENT`, `EACCES`, `ENOSPC`, `SQLITE_BUSY`, malformed SQLite shapes, `TypeError`, `RangeError`, CLI-safe projection, and cache-scope path redaction.
