### PR TITLE
[MAR-2526] Report committed add failures explicitly

### DIFF
--- a/src/records.ts
+++ b/src/records.ts
@@ -50,6 +50,34 @@ type AddRecordOptions = {
   hydrate?: boolean
 }
 
+type PostCommitPhase = 'cacheHydration' | 'publicationFlush' | 'stagingCleanup'
+
+const POST_COMMIT_RECOVERY_ACTION =
+  'Run prepare to rebuild disposable cache state, then validate before retrying this add.'
+
+const postCommitPriority: Record<PostCommitPhase, number> = {
+  cacheHydration: 2,
+  publicationFlush: 3,
+  stagingCleanup: 1,
+}
+
+const postCommitMessage = (recordId: string, phase: PostCommitPhase) =>
+  `Record ${recordId} was committed, but the ${phase} post-commit phase failed. ${POST_COMMIT_RECOVERY_ACTION}`
+
+const postCommitError = (record: BrainRecord, phase: PostCommitPhase, cause: unknown) =>
+  new EncephalonError(
+    'IO_ERROR',
+    postCommitMessage(record.id, phase),
+    {
+      canonicalCommitted: true,
+      path: record.path,
+      postCommitPhase: phase,
+      recordId: record.id,
+      recoveryAction: POST_COMMIT_RECOVERY_ACTION,
+    },
+    { cause },
+  )
+
 const STAGING_DIRECTORY = '_staging'
 const RESERVED_DIRECTORIES = new Set(['_artifacts', STAGING_DIRECTORY])
 const directoryFlag = constants.O_DIRECTORY ?? 0
@@ -433,6 +461,14 @@ export const addRecordResolved = (root: string, input: AddRecordInput, options: 
   let published = false
   let operationFailed = false
   let cleanupError: unknown
+  let committedError: EncephalonError | undefined
+  let committedErrorPhase: PostCommitPhase | undefined
+  const capturePostCommitError = (phase: PostCommitPhase, error: unknown) => {
+    if (committedErrorPhase === undefined || postCommitPriority[phase] > postCommitPriority[committedErrorPhase]) {
+      committedError = postCommitError(candidate, phase, error)
+      committedErrorPhase = phase
+    }
+  }
   try {
     assertRealDirectory(root, stagingDirectory)
     const descriptor = openSync(
@@ -463,8 +499,8 @@ export const addRecordResolved = (root: string, input: AddRecordInput, options: 
       fault(options.hooks, 'after-publication')
       fault(options.hooks, 'during-publication-flush')
       fsyncDirectory(kindDirectory)
-    } catch {
-      // The canonical hard link is already visible; do not report a committed mutation as failed.
+    } catch (error) {
+      capturePostCommitError('publicationFlush', error)
     }
   } catch (error) {
     operationFailed = true
@@ -475,7 +511,9 @@ export const addRecordResolved = (root: string, input: AddRecordInput, options: 
       rmSync(stagingPath, { force: true })
       fsyncDirectory(stagingDirectory)
     } catch (error) {
-      if (!(operationFailed || published)) {
+      if (published) {
+        capturePostCommitError('stagingCleanup', error)
+      } else if (!operationFailed) {
         cleanupError = error
       }
     }
@@ -483,13 +521,16 @@ export const addRecordResolved = (root: string, input: AddRecordInput, options: 
   if (cleanupError !== undefined) {
     throw cleanupError
   }
-  if (options.hydrate !== false) {
+  if (committedErrorPhase !== 'publicationFlush' && options.hydrate !== false) {
     try {
       fault(options.hooks, 'during-hydration')
       hydrateResolvedRepository(root, false)
-    } catch {
-      // Cache rebuild is derived state after the record commit point; the next read can rebuild it.
+    } catch (error) {
+      capturePostCommitError('cacheHydration', error)
     }
+  }
+  if (committedError !== undefined) {
+    throw committedError
   }
   return candidate
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -71,6 +71,44 @@ describe('command-line interface', () => {
     })
   })
 
+  test('reports post-commit add failures with committed record details', () => {
+    const root = createRoot()
+    mkdirSync(join(root, 'node_modules', '.cache', 'encephalon', 'brain.sqlite'), { recursive: true })
+
+    const result = run(root, [
+      'add',
+      '--root',
+      root,
+      '--id',
+      'cli-post-commit',
+      '--kind',
+      'decision',
+      '--subject',
+      'post.commit',
+      '--source',
+      'agent',
+      '--data',
+      '{"summary":"Published"}',
+    ])
+
+    assert.equal(result.status, 2)
+    assert.equal(result.stdout, '')
+    assert.deepEqual(JSON.parse(result.stderr), {
+      error: {
+        code: 'IO_ERROR',
+        details: {
+          canonicalCommitted: true,
+          path: 'encephalon/decision/cli-post-commit.json',
+          postCommitPhase: 'cacheHydration',
+          recordId: 'cli-post-commit',
+          recoveryAction: 'Run prepare to rebuild disposable cache state, then validate before retrying this add.',
+        },
+        message:
+          'Record cli-post-commit was committed, but the cacheHydration post-commit phase failed. Run prepare to rebuild disposable cache state, then validate before retrying this add.',
+      },
+    })
+  })
+
   test('prints invalid validation results once to stdout and exits 2', () => {
     const root = createRoot()
     const path = join(root, 'encephalon', 'decision')

--- a/test/records.test.ts
+++ b/test/records.test.ts
@@ -32,6 +32,31 @@ const assertErrorCode = (operation: () => unknown, code: string) => {
   })
 }
 
+const assertPostCommitError = (
+  operation: () => unknown,
+  expected: {
+    phase: string
+    path: string
+    recordId: string
+  },
+) => {
+  assert.throws(operation, (error: unknown) => {
+    const actual = error as {
+      code?: unknown
+      details?: Record<string, unknown>
+    }
+    assert.equal(actual.code, 'IO_ERROR')
+    assert.deepEqual(actual.details, {
+      canonicalCommitted: true,
+      path: expected.path,
+      postCommitPhase: expected.phase,
+      recordId: expected.recordId,
+      recoveryAction: 'Run prepare to rebuild disposable cache state, then validate before retrying this add.',
+    })
+    return true
+  })
+}
+
 afterEach(() => {
   roots.splice(0).forEach(removeTestRepository)
 })
@@ -210,90 +235,77 @@ describe('canonical records', () => {
     assert.equal(existsSync(join(root, 'encephalon', 'decision', 'after-orphan.json')), true)
   })
 
-  test('does not misreport cleanup failure after canonical publication', () => {
+  test('reports staging cleanup failure after canonical publication as committed', () => {
     const root = createRoot()
-    const record = addRecordResolved(
-      root,
-      {
-        id: 'cleanup-failure',
-        kind: 'decision',
-        payload: { summary: 'Published' },
-        source: 'agent',
-        subject: 'cleanup.failure',
-      },
-      {
-        hooks: {
-          fault: point => {
-            if (point === 'during-cleanup') {
-              throw new Error('Injected cleanup failure')
-            }
+    assertPostCommitError(
+      () =>
+        addRecordResolved(
+          root,
+          {
+            id: 'cleanup-failure',
+            kind: 'decision',
+            payload: { summary: 'Published' },
+            source: 'agent',
+            subject: 'cleanup.failure',
           },
-        },
-        hydrate: false,
+          {
+            hooks: {
+              fault: point => {
+                if (point === 'during-cleanup') {
+                  throw Object.assign(new Error('Injected cleanup failure'), { code: 'EIO' })
+                }
+              },
+            },
+            hydrate: false,
+          },
+        ),
+      {
+        path: 'encephalon/decision/cleanup-failure.json',
+        phase: 'stagingCleanup',
+        recordId: 'cleanup-failure',
       },
     )
 
-    assert.equal(record.id, 'cleanup-failure')
-    assert.equal(existsSync(join(root, record.path)), true)
+    assert.equal(existsSync(join(root, 'encephalon', 'decision', 'cleanup-failure.json')), true)
     assert.equal(readdirSync(join(root, 'encephalon', '_staging')).length, 1)
   })
 
-  test('does not misreport directory flush failure after canonical publication', () => {
+  test('reports cache hydration failure after canonical publication as committed', () => {
     const root = createRoot()
-    const record = addRecordResolved(
-      root,
-      {
-        id: 'flush-failure',
-        kind: 'decision',
-        payload: { summary: 'Published' },
-        source: 'agent',
-        subject: 'flush.failure',
-      },
-      {
-        hooks: {
-          fault: point => {
-            if (point === 'during-publication-flush') {
-              throw new Error('Injected directory flush failure')
-            }
+    assertPostCommitError(
+      () =>
+        addRecordResolved(
+          root,
+          {
+            id: 'hydration-failure',
+            kind: 'decision',
+            payload: { summary: 'Published' },
+            source: 'agent',
+            subject: 'hydration.failure',
           },
-        },
-        hydrate: false,
+          {
+            hooks: {
+              fault: point => {
+                if (point === 'during-hydration') {
+                  throw Object.assign(new Error('Injected hydration failure'), { code: 'EIO' })
+                }
+              },
+            },
+          },
+        ),
+      {
+        path: 'encephalon/decision/hydration-failure.json',
+        phase: 'cacheHydration',
+        recordId: 'hydration-failure',
       },
     )
 
-    assert.equal(record.id, 'flush-failure')
-    assert.equal(existsSync(join(root, record.path)), true)
-    assert.deepEqual(readdirSync(join(root, 'encephalon', '_staging')), [])
-  })
-
-  test('does not misreport cache hydration failure after canonical publication', () => {
-    const root = createRoot()
-    const record = addRecordResolved(
-      root,
-      {
-        id: 'hydration-failure',
-        kind: 'decision',
-        payload: { summary: 'Published' },
-        source: 'agent',
-        subject: 'hydration.failure',
-      },
-      {
-        hooks: {
-          fault: point => {
-            if (point === 'during-hydration') {
-              throw new Error('Injected hydration failure')
-            }
-          },
-        },
-      },
-    )
-
-    assert.equal(record.id, 'hydration-failure')
-    assert.equal(existsSync(join(root, record.path)), true)
+    assert.equal(existsSync(join(root, 'encephalon', 'decision', 'hydration-failure.json')), true)
+    assert.deepEqual(api.prepare({ root }), { hydrated: true, recordsIndexed: 1 })
     assertErrorCode(
       () =>
         api.addRecord({
-          id: record.id,
+          id: 'hydration-failure',
           kind: 'decision',
           payload: { summary: 'Retry' },
           root,
@@ -302,6 +314,40 @@ describe('canonical records', () => {
         }),
       'RECORD_EXISTS',
     )
+  })
+
+  test('does not let cleanup failure replace publication flush failure after commit', () => {
+    const root = createRoot()
+    assertPostCommitError(
+      () =>
+        addRecordResolved(
+          root,
+          {
+            id: 'flush-and-cleanup-failure',
+            kind: 'decision',
+            payload: { summary: 'Published' },
+            source: 'agent',
+            subject: 'flush.cleanup',
+          },
+          {
+            hooks: {
+              fault: point => {
+                if (point === 'during-publication-flush' || point === 'during-cleanup') {
+                  throw Object.assign(new Error(`Injected ${point}`), { code: 'EIO' })
+                }
+              },
+            },
+            hydrate: false,
+          },
+        ),
+      {
+        path: 'encephalon/decision/flush-and-cleanup-failure.json',
+        phase: 'publicationFlush',
+        recordId: 'flush-and-cleanup-failure',
+      },
+    )
+
+    assert.equal(existsSync(join(root, 'encephalon', 'decision', 'flush-and-cleanup-failure.json')), true)
   })
 
   test('validates supersession graphs and permits a multi-head resolver', () => {


### PR DESCRIPTION
## Human summary

When a record is already committed but cleanup or cache work fails afterward, Encephalon now says so clearly instead of hiding the committed record state.

## Summary

- Define hard-link publication as the canonical record commit point for add operations.
- Report post-commit publication-flush, staging-cleanup, and cache-hydration failures as `IO_ERROR` with `canonicalCommitted: true`, record ID, repository-relative path, failed phase, and recovery action details.
- Keep cleanup failures from replacing more important publication-flush or cache-hydration failures.
- Preserve deterministic retry behaviour: the canonical file remains present and retrying the same add returns `RECORD_EXISTS`.
- Add CLI coverage showing committed post-commit failures are emitted in structured stderr with safe relative details.
- Add recovery coverage proving a later `prepare()` rebuilds disposable cache state without deleting the committed record.
