### PR TITLE
[MAR-2527] Run package contract checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,20 @@ jobs:
       - run: bun run test
       - run: bun run lint
       - run: bun run build
+      - run: bun run check:package
+      - name: Create release-equivalent package artifact
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          mkdir -p package-artifacts
+          npm pack --dry-run=false --ignore-scripts --json --pack-destination package-artifacts > package-artifacts/npm-pack.json
+      - name: Upload release-equivalent package artifact
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: encephalon-npm-package
+          path: package-artifacts/*
+          if-no-files-found: error
+      - name: Check npm publish dry run
+        if: matrix.os == 'ubuntu-latest'
+        run: bun run check:publish

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ bun run check:package
 bun run check:publish
 ```
 
-`check:package` inspects the npm tarball, installs it with lifecycle scripts disabled, imports the public API, and runs the bundled CLI using Node. `check:publish` exercises npm's publish-time manifest normalisation without uploading anything.
+`check:package` inspects the npm tarball, installs it with lifecycle scripts disabled, imports the public API, and runs the bundled CLI using Node. `check:publish` exercises npm's publish-time manifest normalisation without uploading anything. The Ubuntu CI job is the release-equivalent package gate: it runs both checks and uploads the generated `npm pack` tarball for inspection.
 
 ## Licence
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "build": "bun run scripts/build.ts",
     "check:package": "bun run scripts/check-package.ts",
-    "check:publish": "npm publish --dry-run --access public --json",
+    "check:publish": "bun run scripts/check-publish.ts",
     "lint": "ultracite check",
     "prepack": "bun run build && bun run check:package",
     "test": "node --test test/*.test.ts",

--- a/scripts/check-publish.ts
+++ b/scripts/check-publish.ts
@@ -1,7 +1,11 @@
+import { resolve } from 'node:path'
+
+const root = resolve(import.meta.dir, '..')
 const command = ['npm', 'publish', '--dry-run', '--ignore-scripts', '--access', 'public', '--json']
 
 const result = Bun.spawnSync({
   cmd: command,
+  cwd: root,
   stderr: 'pipe',
   stdout: 'pipe',
 })
@@ -15,8 +19,39 @@ if (result.exitCode === 0) {
   process.exit(0)
 }
 
-const output = `${stdout}\n${stderr}`
-if (output.includes('You cannot publish over the previously published versions')) {
+type NpmJsonError = {
+  code?: unknown
+  summary?: unknown
+}
+
+const readNpmJsonError = (text: string): NpmJsonError | undefined => {
+  try {
+    const payload = JSON.parse(text) as { error?: NpmJsonError }
+    if (payload.error !== undefined && typeof payload.error === 'object' && payload.error !== null) {
+      return payload.error
+    }
+  } catch {
+    // npm may emit non-JSON diagnostics alongside --json; ignore parse failures.
+  }
+}
+
+const conflictSummary = /^You cannot publish over the previously published versions(?::|\b)/
+const conflictCodes = new Set(['EPUBLISHCONFLICT', 'E403'])
+
+const isPublishConflictError = (error: NpmJsonError): boolean => {
+  const summary = typeof error.summary === 'string' ? error.summary : undefined
+  const code = typeof error.code === 'string' ? error.code : undefined
+  const hasConflictSummary = summary !== undefined && conflictSummary.test(summary)
+  const hasConflictCode = code !== undefined && conflictCodes.has(code)
+  return hasConflictSummary && (hasConflictCode || code === undefined)
+}
+
+const jsonErrors = [stdout, stderr].map(readNpmJsonError).filter((error): error is NpmJsonError => error !== undefined)
+const combined = `${stdout}\n${stderr}`
+const hasTextConflictCode = /(?:^|\n)npm error code (EPUBLISHCONFLICT|E403)(?:\n|$)/.test(combined)
+const hasTextConflictMessage = /You cannot publish over the previously published versions/.test(combined)
+
+if (jsonErrors.some(isPublishConflictError) || (hasTextConflictCode && hasTextConflictMessage)) {
   process.exit(0)
 }
 

--- a/scripts/check-publish.ts
+++ b/scripts/check-publish.ts
@@ -1,0 +1,23 @@
+const command = ['npm', 'publish', '--dry-run', '--ignore-scripts', '--access', 'public', '--json']
+
+const result = Bun.spawnSync({
+  cmd: command,
+  stderr: 'pipe',
+  stdout: 'pipe',
+})
+const stdout = result.stdout.toString()
+const stderr = result.stderr.toString()
+
+process.stdout.write(stdout)
+process.stderr.write(stderr)
+
+if (result.exitCode === 0) {
+  process.exit(0)
+}
+
+const output = `${stdout}\n${stderr}`
+if (output.includes('You cannot publish over the previously published versions')) {
+  process.exit(0)
+}
+
+throw new Error(`npm publish dry-run failed with exit code ${result.exitCode}.`)

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -34,4 +34,22 @@ describe('package contract', () => {
     assert.equal(skill.includes('npx --no-install encephalon validate'), true)
     assert.equal(skill.includes('Do not stage, commit, push'), true)
   })
+
+  test('runs package and publish-contract checks in CI without publishing', () => {
+    const workflow = readFileSync(resolve(root, '.github', 'workflows', 'ci.yml'), 'utf8')
+    const publishCheck = readFileSync(resolve(root, 'scripts', 'check-publish.ts'), 'utf8')
+    const packageJson = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as {
+      scripts?: Record<string, unknown>
+    }
+    const publishScript = String(packageJson.scripts?.['check:publish'])
+
+    assert.equal(workflow.includes('bun run check:package'), true)
+    assert.equal(workflow.includes('bun run check:publish'), true)
+    assert.equal(workflow.includes("matrix.os == 'ubuntu-latest'"), true)
+    assert.equal(workflow.includes('actions/upload-artifact'), true)
+    assert.equal(publishScript, 'bun run scripts/check-publish.ts')
+    assert.equal(publishCheck.includes("'--dry-run'"), true)
+    assert.equal(publishCheck.includes("'--ignore-scripts'"), true)
+    assert.equal(publishCheck.includes('You cannot publish over the previously published versions'), true)
+  })
 })


### PR DESCRIPTION
## Human summary

CI now checks the npm package and publish dry-run contract before release, without publishing anything or rerunning package lifecycle scripts.

## Summary

- Run `bun run check:package` after build on Ubuntu, macOS, and Windows.
- Add an Ubuntu-only release-equivalent package gate that creates and uploads an inspectable `npm pack` tarball artifact.
- Run `bun run check:publish` only on Ubuntu, using an `npm publish --dry-run --ignore-scripts` wrapper so the gate never publishes and never recursively reruns `prepack`.
- Treat npm's already-published-version dry-run response as an acceptable non-publishing validation result for the current `0.1.0` package.
- Document the Ubuntu CI job as the release-equivalent package gate.
- Add a package contract regression test covering the workflow gates and dry-run publish wrapper.
