### PR TITLE
[MAR-2529] Avoid full JSON in compact search

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -51,6 +51,7 @@ type RecordRow = {
 }
 
 type CompactRow = {
+  created_at: string
   id: string
   kind: string
   subject: string
@@ -616,10 +617,10 @@ const literalMatchQuery = (query: unknown) => {
   return terms.map(term => `"${term.replaceAll('"', '""')}"`).join(' AND ')
 }
 
-const searchRows = (database: DatabaseSync, input: SearchRecordsInput) => {
+const searchParts = (input: SearchRecordsInput) => {
   const match = literalMatchQuery(input.query)
   if (match.length === 0) {
-    return []
+    return null
   }
   const conditions = [
     'record_search MATCH ?',
@@ -627,15 +628,43 @@ const searchRows = (database: DatabaseSync, input: SearchRecordsInput) => {
     input.kind === undefined ? undefined : 'records.kind = ?',
   ].filter((value): value is string => value !== undefined)
   const parameters = [match, ...(input.kind === undefined ? [] : [input.kind]), positiveLimit(input.limit)]
+  return { conditions, parameters }
+}
+
+const fullSearchRows = (database: DatabaseSync, input: SearchRecordsInput) => {
+  const parts = searchParts(input)
+  if (parts === null) {
+    return []
+  }
+  const { conditions, parameters } = parts
   return database
     .prepare(`
     SELECT
-      records.record_json,
+      records.record_json
+    FROM record_search
+    JOIN records ON records.id = record_search.id
+    WHERE ${conditions.join(' AND ')}
+    ORDER BY bm25(record_search) ASC, records.created_at DESC, records.id DESC
+    LIMIT ?
+  `)
+    .all(...parameters) as RecordRow[]
+}
+
+const compactSearchRows = (database: DatabaseSync, input: SearchRecordsInput) => {
+  const parts = searchParts(input)
+  if (parts === null) {
+    return []
+  }
+  const { conditions, parameters } = parts
+  return database
+    .prepare(`
+    SELECT
       records.id,
       records.kind,
       records.subject,
       records.path,
       records.summary,
+      records.created_at,
       bm25(record_search) AS rank,
       snippet(record_search, 1, '[', ']', '...', 16) AS snippet
     FROM record_search
@@ -644,15 +673,15 @@ const searchRows = (database: DatabaseSync, input: SearchRecordsInput) => {
     ORDER BY rank ASC, records.created_at DESC, records.id DESC
     LIMIT ?
   `)
-    .all(...parameters) as Array<RecordRow & CompactRow>
+    .all(...parameters) as CompactRow[]
 }
 
 export const searchRecords = (input: SearchRecordsInput): BrainRecord[] =>
-  withPreparedDatabase(input, database => searchRows(database, input).map(parseRecordRow))
+  withPreparedDatabase(input, database => fullSearchRows(database, input).map(parseRecordRow))
 
 export const searchCompactRecords = (input: SearchRecordsInput): CompactBrainRecord[] =>
   withPreparedDatabase(input, database =>
-    searchRows(database, input).map(row => ({
+    compactSearchRows(database, input).map(row => ({
       id: row.id,
       kind: row.kind,
       path: row.path,
@@ -700,7 +729,7 @@ export const gatherRecords = (input: GatherInput): GatherResult => {
         searches: searches.map(query => ({
           kind: input.kind ?? null,
           query,
-          results: searchRows(database, { ...input, query }).map(row => ({
+          results: compactSearchRows(database, { ...input, query }).map(row => ({
             id: row.id,
             kind: row.kind,
             path: row.path,

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -140,6 +140,70 @@ describe('SQLite cache and reads', () => {
     assert.equal(searchCompactRecords({ query: 'searchable marker', root })[0]?.summary, null)
   })
 
+  test('keeps compact search and repeated gather ordering aligned with full search for large records', () => {
+    const root = createRoot()
+    const largePayload = 'payload filler '.repeat(10_000)
+    const addRecord = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>>('addRecord')
+    const records = [
+      addRecord({
+        id: 'large-search-alpha',
+        kind: 'context',
+        payload: { body: largePayload, summary: 'Alpha compact summary' },
+        root,
+        searchText: 'shared performance needle',
+        source: 'agent',
+        subject: 'search.large.alpha',
+      }),
+      addRecord({
+        id: 'large-search-beta',
+        kind: 'context',
+        payload: { body: largePayload, summary: 'Beta compact summary' },
+        root,
+        searchText: 'shared performance needle',
+        source: 'agent',
+        subject: 'search.large.beta',
+      }),
+    ]
+    const expectedIds = records.map(record => record.id).reverse()
+
+    const searchRecords =
+      functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>[]>('searchRecords')
+    const searchCompactRecords =
+      functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>[]>('searchCompactRecords')
+    const fullIds = searchRecords({ query: 'shared performance needle', root }).map(record => record.id)
+    const compactResults = searchCompactRecords({ query: 'shared performance needle', root })
+
+    assert.deepEqual(fullIds, expectedIds)
+    assert.deepEqual(
+      compactResults.map(record => record.id),
+      fullIds,
+    )
+    assert.deepEqual(
+      compactResults.map(record => Object.keys(record).sort()),
+      compactResults.map(() => ['id', 'kind', 'path', 'rank', 'snippet', 'subject', 'summary']),
+    )
+
+    const gatherRecords = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>>('gatherRecords')
+    const gathered = gatherRecords({
+      root,
+      searches: ['shared performance needle', 'shared performance needle'],
+    }) as { searches: Array<{ results: Array<{ id: string }> }> }
+    assert.deepEqual(
+      gathered.searches.map(entry => entry.results.map(record => record.id)),
+      [fullIds, fullIds],
+    )
+  })
+
+  test('selects record_json only for full search rows', () => {
+    const source = readFileSync(join(import.meta.dirname, '..', 'src', 'cache.ts'), 'utf8')
+    const fullSearchRows = source.match(/const fullSearchRows[\s\S]*?\.all\(\.\.\.parameters\)/)?.[0] ?? ''
+    const compactSearchRows = source.match(/const compactSearchRows[\s\S]*?\.all\(\.\.\.parameters\)/)?.[0] ?? ''
+
+    assert.match(fullSearchRows, /\brecord_json\b/)
+    assert.ok(compactSearchRows.length > 0)
+    assert.doesNotMatch(compactSearchRows, /\brecord_json\b/)
+  })
+
   test('tracks record and referenced-artifact freshness', () => {
     const root = createRoot()
     const id = 'architecture-with-artifact'


### PR DESCRIPTION
## Human summary

Compact search results now avoid reading large full-record JSON blobs, so search and gather stay lighter while returning the same result order.

## Summary

- Split full-record and compact search SQL projections.
- Keep full search returning complete records by selecting and parsing `record_json` only on that path.
- Route compact search and gather search results through a compact projection with id, kind, subject, path, summary, rank, snippet, and ordering data.
- Add regression coverage for large-payload ordering, repeated gather searches, compact result shape, and the compact SQL projection excluding `record_json`.
