### PR TITLE
[MAR-2530] Plan init records from one snapshot

### DIFF
--- a/encephalon/workflow/b8c49db0-d5cd-4446-9b32-a77752fc4838.json
+++ b/encephalon/workflow/b8c49db0-d5cd-4446-9b32-a77752fc4838.json
@@ -1,0 +1,20 @@
+{
+  "createdAt": "2026-08-08T23:13:29.741Z",
+  "id": "b8c49db0-d5cd-4446-9b32-a77752fc4838",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Use canonical record serialisation for validation byte budgets, never runtime BrainRecord objects with path.",
+    "lessons": [
+      "BrainRecord includes a runtime-only path field that is not written to canonical JSON; budget calculations for canonical corpus bytes must remove path or use planned formatted record bytes.",
+      "Default validation helpers that reconstruct byte counts from records should mirror scanCanonicalRecords byte accounting, not cache/runtime row shapes.",
+      "Regression tests should exercise near-budget corpora so small runtime-only fields would cross the corpus byte limit or per-record formatter limit if counted."
+    ],
+    "verification": [
+      "For planning paths, compare default graph validation with explicit planned formatted byte totals.",
+      "Include a near-MAX_CANONICAL_RECORD_BYTES case where runtime JSON with path is over budget but canonical JSON is within budget."
+    ]
+  },
+  "searchText": "canonical record byte accounting runtime path formatRecordFile assertRecordGraph corpus byte limit",
+  "source": "agent",
+  "subject": "review.canonical-byte-accounting"
+}

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -460,9 +460,10 @@ const rebuildCache = (root: string): PrepareResult => {
   return fail('INTERNAL_ERROR', 'The Encephalon cache rebuild ended unexpectedly.')
 }
 
-const prepareResolvedWithoutCorruptionRecovery = (root: string): PrepareResult => {
+const prepareResolvedWithoutCorruptionRecovery = (root: string, lock = true): PrepareResult => {
+  const serialize = <Result>(operation: () => Result) => (lock ? withOperationLock(root, operation) : operation())
   if (!existsSync(databasePath(root))) {
-    return withOperationLock(root, () => {
+    return serialize(() => {
       if (existsSync(databasePath(root))) {
         const recheck = openDatabase(root)
         try {
@@ -489,7 +490,7 @@ const prepareResolvedWithoutCorruptionRecovery = (root: string): PrepareResult =
   } finally {
     database.close()
   }
-  return withOperationLock(root, () => {
+  return serialize(() => {
     const recheck = openDatabase(root)
     try {
       const metadata = readMetadata(recheck)
@@ -506,16 +507,18 @@ const prepareResolvedWithoutCorruptionRecovery = (root: string): PrepareResult =
   })
 }
 
-const prepareResolved = (root: string): PrepareResult => {
+const prepareResolved = (root: string, lock = true): PrepareResult => {
   try {
-    return prepareResolvedWithoutCorruptionRecovery(root)
+    return prepareResolvedWithoutCorruptionRecovery(root, lock)
   } catch (error) {
     if (!isRecoverableCacheFailure(error)) {
       throw error
     }
-    return withOperationLock(root, () => rebuildCache(root))
+    return lock ? withOperationLock(root, () => rebuildCache(root)) : rebuildCache(root)
   }
 }
+
+export const prepareResolvedRepository = (root: string, lock = true): PrepareResult => prepareResolved(root, lock)
 
 export const hydrateResolvedRepository = (root: string, lock = true): PrepareResult =>
   lock ? withOperationLock(root, () => rebuildCache(root)) : rebuildCache(root)

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,14 +1,27 @@
 import { canonicalPayload, scanBaseline } from './baseline.ts'
-import { hydrateResolvedRepository } from './cache.ts'
+import { hydrateResolvedRepository, prepareResolvedRepository } from './cache.ts'
 import { EncephalonError, fail, wrapIo } from './errors.ts'
 import { applyInstructionChanges, planInstructionChanges } from './instructions.ts'
 import { withOperationLock } from './lock.ts'
-import { addRecordResolved, readRecords } from './records.ts'
+import {
+  assertRecordGraph,
+  planRecordAddition,
+  publishPlannedRecord,
+  type RecordReadHooks,
+  type RecordWriteHooks,
+  readRecordsResolved,
+} from './records.ts'
 import { resolveRepository } from './repository.ts'
-import type { AddRecordInput, BrainRecord, InitEncephalonInput, InitEncephalonResult } from './types.ts'
+import type { AddRecordInput, BrainRecord, InitEncephalonInput, InitEncephalonResult, PrepareResult } from './types.ts'
 
 const NEXT_ACTION =
   'Read ./node_modules/encephalon/skills/encephalon/SKILL.md and perform optional semantic enrichment for durable repository knowledge.'
+
+type InitHooks = RecordReadHooks & {
+  baselineScan?: () => void
+  hydration?: (result: PrepareResult) => void
+  recordWriteHooks?: RecordWriteHooks
+}
 
 const activeRecords = (records: BrainRecord[]) => {
   const superseded = new Set(records.flatMap(record => record.supersedes ?? []))
@@ -61,7 +74,7 @@ const baselineActions = (records: BrainRecord[], baseline: AddRecordInput[], ref
     { additions: [], conflicts: [] },
   )
 
-const initResolved = (input: InitEncephalonInput): InitEncephalonResult => {
+const initResolved = (input: InitEncephalonInput, hooks: InitHooks = {}): InitEncephalonResult => {
   if (input.remove === true && input.refreshBaseline === true) {
     return fail('INVALID_ARGUMENT', 'init cannot refresh and remove managed instructions in the same operation.')
   }
@@ -77,14 +90,25 @@ const initResolved = (input: InitEncephalonInput): InitEncephalonResult => {
     }))
   }
 
-  readRecords({ root })
   return withOperationLock(root, () => {
     const instructionPlans = planInstructionChanges(root, false)
-    const actions = baselineActions(readRecords({ root }), scanBaseline(root), input.refreshBaseline === true)
-    const recordsCreated = actions.additions.map(addition =>
-      addRecordResolved(root, { ...addition, root }, { hydrate: false }),
-    )
-    hydrateResolvedRepository(root, false)
+    const records = readRecordsResolved(root, hooks)
+    hooks.baselineScan?.()
+    const actions = baselineActions(records, scanBaseline(root), input.refreshBaseline === true)
+    const plans = actions.additions.map(addition => planRecordAddition(root, { ...addition, root }))
+    if (plans.length > 0) {
+      assertRecordGraph(
+        root,
+        [...records, ...plans.map(plan => plan.record)],
+        'The generated baseline would make canonical records invalid.',
+        hooks,
+      )
+    }
+    const recordWriteOptions = hooks.recordWriteHooks === undefined ? {} : { hooks: hooks.recordWriteHooks }
+    const recordsCreated = plans.map(plan => publishPlannedRecord(root, plan, recordWriteOptions))
+    const cacheResult =
+      recordsCreated.length === 0 ? prepareResolvedRepository(root, false) : hydrateResolvedRepository(root, false)
+    hooks.hydration?.(cacheResult)
     const instructionFiles = applyInstructionChanges(root, instructionPlans)
     return {
       instructionFiles,
@@ -98,6 +122,20 @@ const initResolved = (input: InitEncephalonInput): InitEncephalonResult => {
 export const initEncephalon = (input: InitEncephalonInput = {}): InitEncephalonResult => {
   try {
     return initResolved(input)
+  } catch (error) {
+    if (error instanceof EncephalonError) {
+      throw error
+    }
+    return wrapIo('Unable to initialise Encephalon.', error)
+  }
+}
+
+export const initEncephalonWithHooks = (
+  input: InitEncephalonInput = {},
+  hooks: InitHooks = {},
+): InitEncephalonResult => {
+  try {
+    return initResolved(input, hooks)
   } catch (error) {
     if (error instanceof EncephalonError) {
       throw error

--- a/src/records.ts
+++ b/src/records.ts
@@ -118,6 +118,11 @@ const postCommitError = (record: BrainRecord, phase: PostCommitPhase, cause: unk
     { cause },
   )
 
+const canonicalRecordBytes = (record: BrainRecord) => {
+  const { path: _path, ...recordFile } = record
+  return Buffer.byteLength(formatRecordFile(recordFile), 'utf8')
+}
+
 const STAGING_DIRECTORY = '_staging'
 const RESERVED_DIRECTORIES = new Set(['_artifacts', STAGING_DIRECTORY])
 const directoryFlag = constants.O_DIRECTORY ?? 0
@@ -759,7 +764,7 @@ export const assertRecordGraph = (
   const result = validateScanned(
     root,
     {
-      bytes: bytes ?? records.reduce((total, record) => total + Buffer.byteLength(formatRecordFile(record), 'utf8'), 0),
+      bytes: bytes ?? records.reduce((total, record) => total + canonicalRecordBytes(record), 0),
       errors: [],
       records,
     },

--- a/src/records.ts
+++ b/src/records.ts
@@ -33,7 +33,7 @@ type RecordScan = {
   errors: ValidationIssue[]
 }
 
-type RecordWriteFault =
+export type RecordWriteFault =
   | 'after-publication'
   | 'before-publication'
   | 'during-cleanup'
@@ -41,13 +41,26 @@ type RecordWriteFault =
   | 'during-publication-flush'
   | 'during-staging-write'
 
-type RecordWriteHooks = {
+export type RecordWriteHooks = {
   fault?: (point: RecordWriteFault) => void
+}
+
+export type RecordReadHooks = {
+  canonicalScan?: () => void
+  graphValidation?: () => void
 }
 
 type AddRecordOptions = {
   hooks?: RecordWriteHooks
   hydrate?: boolean
+}
+
+type PlannedRecord = {
+  formatted: string
+  path: string
+  record: BrainRecord
+  recordFile: BrainRecordFile
+  relativePath: string
 }
 
 const STAGING_DIRECTORY = '_staging'
@@ -351,7 +364,8 @@ const artifactIssues = (root: string, records: BrainRecord[]) => {
   )
 }
 
-const validateScanned = (root: string, scan: RecordScan): ValidateResult => {
+const validateScanned = (root: string, scan: RecordScan, hooks: RecordReadHooks = {}): ValidateResult => {
+  hooks.graphValidation?.()
   const errors = [
     ...scan.errors,
     ...duplicateAndCaseIssues(scan.records),
@@ -377,10 +391,10 @@ export const validateRecords = (input: RootInput = {}): ValidateResult => {
   }
 }
 
-export const readRecords = (input: RootInput = {}) => {
-  const root = resolveRepository(input)
+export const readRecordsResolved = (root: string, hooks: RecordReadHooks = {}) => {
+  hooks.canonicalScan?.()
   const scan = scanCanonicalRecords(root)
-  const result = validateScanned(root, scan)
+  const result = validateScanned(root, scan, hooks)
   if (result.valid) {
     return scan.records
   }
@@ -392,7 +406,9 @@ export const readRecords = (input: RootInput = {}) => {
   })
 }
 
-export const addRecordResolved = (root: string, input: AddRecordInput, options: AddRecordOptions = {}): BrainRecord => {
+export const readRecords = (input: RootInput = {}) => readRecordsResolved(resolveRepository(input))
+
+export const planRecordAddition = (root: string, input: AddRecordInput): PlannedRecord => {
   const recordFile = createRecordFile(input)
   const relativePath = `encephalon/${recordFile.kind}/${recordFile.id}.json`
   const path = resolve(root, ...relativePath.split('/'))
@@ -401,32 +417,48 @@ export const addRecordResolved = (root: string, input: AddRecordInput, options: 
       path: relativePath,
     })
   }
-
-  cleanupStagingDirectory(root, options.hooks)
-  const scan = scanCanonicalRecords(root)
-  if (scan.errors.length > 0) {
-    return fail('VALIDATION_FAILED', 'Existing canonical records are invalid.', {
-      errors: scan.errors.map(error => ({
-        code: error.code,
-        message: error.message,
-      })),
-    })
+  const record: BrainRecord = { ...recordFile, path: relativePath }
+  return {
+    formatted: formatRecordFile(recordFile),
+    path,
+    record,
+    recordFile,
+    relativePath,
   }
-  const candidate: BrainRecord = { ...recordFile, path: relativePath }
-  const candidateResult = validateScanned(root, {
-    errors: [],
-    records: [...scan.records, candidate],
+}
+
+export const assertRecordGraph = (
+  root: string,
+  records: BrainRecord[],
+  message = 'Canonical records are invalid.',
+  hooks: RecordReadHooks = {},
+) => {
+  const result = validateScanned(
+    root,
+    {
+      errors: [],
+      records,
+    },
+    hooks,
+  )
+  if (result.valid) {
+    return
+  }
+  return fail('VALIDATION_FAILED', message, {
+    errors: result.errors.map(error => ({
+      code: error.code,
+      message: error.message,
+    })),
   })
-  if (!candidateResult.valid) {
-    return fail('VALIDATION_FAILED', 'The new record would make canonical records invalid.', {
-      errors: candidateResult.errors.map(error => ({
-        code: error.code,
-        message: error.message,
-      })),
-    })
-  }
+}
 
-  const formatted = formatRecordFile(recordFile)
+export const publishPlannedRecord = (
+  root: string,
+  plan: PlannedRecord,
+  options: { hooks?: RecordWriteHooks } = {},
+): BrainRecord => {
+  cleanupStagingDirectory(root, options.hooks)
+  const { formatted, path, record, recordFile, relativePath } = plan
   const kindDirectory = ensureDirectoryChain(root, ['encephalon', recordFile.kind])
   const stagingDirectory = ensureDirectoryChain(root, ['encephalon', STAGING_DIRECTORY])
   const stagingPath = resolve(stagingDirectory, `record-${process.pid}-${randomUUID()}.tmp`)
@@ -483,6 +515,35 @@ export const addRecordResolved = (root: string, input: AddRecordInput, options: 
   if (cleanupError !== undefined) {
     throw cleanupError
   }
+  return record
+}
+
+export const addRecordResolved = (root: string, input: AddRecordInput, options: AddRecordOptions = {}): BrainRecord => {
+  const plan = planRecordAddition(root, input)
+  const scan = scanCanonicalRecords(root)
+  if (scan.errors.length > 0) {
+    return fail('VALIDATION_FAILED', 'Existing canonical records are invalid.', {
+      errors: scan.errors.map(error => ({
+        code: error.code,
+        message: error.message,
+      })),
+    })
+  }
+  const candidateResult = validateScanned(root, {
+    errors: [],
+    records: [...scan.records, plan.record],
+  })
+  if (!candidateResult.valid) {
+    return fail('VALIDATION_FAILED', 'The new record would make canonical records invalid.', {
+      errors: candidateResult.errors.map(error => ({
+        code: error.code,
+        message: error.message,
+      })),
+    })
+  }
+
+  const publishOptions = options.hooks === undefined ? {} : { hooks: options.hooks }
+  const candidate = publishPlannedRecord(root, plan, publishOptions)
   if (options.hydrate !== false) {
     try {
       fault(options.hooks, 'during-hydration')

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -16,10 +16,56 @@ import {
 import { join } from 'node:path'
 import { afterEach, describe, test } from 'node:test'
 import * as api from '../src/index.ts'
+import { initEncephalonWithHooks } from '../src/init.ts'
 import { applyInstructionChanges, planInstructionChanges } from '../src/instructions.ts'
 import { createTestRepository, ensureParent, removeTestRepository } from '../test/helpers.ts'
 
 const roots: string[] = []
+
+type InitCounts = {
+  baselineScans: number
+  canonicalScans: number
+  graphValidations: number
+  hydrations: number
+}
+
+type InitFaultPoint =
+  | 'after-publication'
+  | 'before-publication'
+  | 'during-cleanup'
+  | 'during-hydration'
+  | 'during-publication-flush'
+  | 'during-staging-write'
+
+const initWithCounts = (
+  input: Parameters<typeof initEncephalonWithHooks>[0],
+  fault?: (point: InitFaultPoint) => void,
+) => {
+  const counts: InitCounts = {
+    baselineScans: 0,
+    canonicalScans: 0,
+    graphValidations: 0,
+    hydrations: 0,
+  }
+  const result = initEncephalonWithHooks(input, {
+    baselineScan: () => {
+      counts.baselineScans += 1
+    },
+    canonicalScan: () => {
+      counts.canonicalScans += 1
+    },
+    graphValidation: () => {
+      counts.graphValidations += 1
+    },
+    hydration: cacheResult => {
+      if (cacheResult.hydrated) {
+        counts.hydrations += 1
+      }
+    },
+    ...(fault === undefined ? {} : { recordWriteHooks: { fault } }),
+  })
+  return { counts, result }
+}
 
 const createRoot = () => {
   const root = createTestRepository()
@@ -128,6 +174,120 @@ describe('initialisation', () => {
     assert.match(JSON.stringify(workflow[0]?.payload), /npm run lint/)
     assert.doesNotMatch(JSON.stringify(workflow[0]?.payload), /lint-private-body/)
     assert.equal(api.listRecords({ limit: 20, root }).length, 3)
+  })
+
+  test('plans first and idempotent baseline additions against one canonical snapshot', () => {
+    const root = createRoot()
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({
+        name: 'sample-project',
+        scripts: { test: 'node --test' },
+      }),
+    )
+
+    const first = initWithCounts({ root })
+    assert.equal(first.result.recordsCreated.length, 3)
+    assert.deepEqual(first.counts, {
+      baselineScans: 1,
+      canonicalScans: 1,
+      graphValidations: 2,
+      hydrations: 1,
+    })
+
+    const second = initWithCounts({ root })
+    assert.deepEqual(second.result.recordsCreated, [])
+    assert.deepEqual(second.counts, {
+      baselineScans: 1,
+      canonicalScans: 1,
+      graphValidations: 1,
+      hydrations: 0,
+    })
+  })
+
+  test('refreshes one or three changed generated subjects with one planning scan', () => {
+    const root = createRoot()
+    const packagePath = join(root, 'package.json')
+    writeFileSync(
+      packagePath,
+      JSON.stringify({
+        name: 'sample-project',
+        scripts: { test: 'node --test' },
+      }),
+    )
+    initWithCounts({ root })
+
+    writeFileSync(
+      packagePath,
+      JSON.stringify({
+        name: 'sample-project',
+        scripts: { lint: 'lint-private-body', test: 'node --test' },
+      }),
+    )
+    const oneChanged = initWithCounts({ refreshBaseline: true, root })
+    assert.equal(oneChanged.result.recordsCreated.length, 1)
+    assert.deepEqual(oneChanged.counts, {
+      baselineScans: 1,
+      canonicalScans: 1,
+      graphValidations: 2,
+      hydrations: 1,
+    })
+
+    writeFileSync(
+      packagePath,
+      JSON.stringify({
+        name: 'renamed-project',
+        scripts: { build: 'private-build-command', lint: 'lint-private-body', test: 'node --test' },
+      }),
+    )
+    ensureParent(join(root, 'src', 'index.ts'))
+    writeFileSync(join(root, 'src', 'index.ts'), 'export const value = 1')
+    const threeChanged = initWithCounts({ refreshBaseline: true, root })
+    assert.equal(threeChanged.result.recordsCreated.length, 3)
+    assert.deepEqual(threeChanged.counts, {
+      baselineScans: 1,
+      canonicalScans: 1,
+      graphValidations: 2,
+      hydrations: 1,
+    })
+    assert.equal(api.validateRecords({ root }).valid, true)
+  })
+
+  test('reruns safely after a mid-batch baseline publication failure', () => {
+    const root = createRoot()
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({
+        name: 'sample-project',
+        scripts: { test: 'node --test' },
+      }),
+    )
+    let publicationAttempts = 0
+    assert.throws(
+      () =>
+        initWithCounts({ root }, point => {
+          if (point === 'before-publication') {
+            publicationAttempts += 1
+            if (publicationAttempts === 2) {
+              throw new Error('Injected mid-batch failure')
+            }
+          }
+        }),
+      (error: unknown) => {
+        assert.equal((error as { code?: unknown }).code, 'IO_ERROR')
+        return true
+      },
+    )
+
+    assert.equal(api.validateRecords({ root }).valid, true)
+    assert.equal(api.listRecords({ includeSuperseded: true, limit: 20, root }).length, 1)
+
+    const rerun = initWithCounts({ root })
+    assert.equal(rerun.result.recordsCreated.length, 2)
+    assert.equal(api.validateRecords({ root }).valid, true)
+    const records = api.listRecords({ includeSuperseded: true, limit: 20, root })
+    assert.equal(records.length, 3)
+    assert.deepEqual(new Set(records.map(record => record.subject)).size, 3)
   })
 
   test('skips a reserved subject owned by an agent-authored active record', () => {

--- a/test/records.test.ts
+++ b/test/records.test.ts
@@ -14,7 +14,14 @@ import {
 import { join } from 'node:path'
 import { afterEach, describe, test } from 'node:test'
 import * as api from '../src/index.ts'
-import { addRecordResolved, MAX_CANONICAL_RECORDS, validateRecordsResolved } from '../src/records.ts'
+import {
+  addRecordResolved,
+  assertRecordGraph,
+  MAX_CANONICAL_RECORD_BYTES,
+  MAX_CANONICAL_RECORDS,
+  planRecordAddition,
+  validateRecordsResolved,
+} from '../src/records.ts'
 import { discoverRepository } from '../src/repository.ts'
 import type { ValidateResult } from '../src/types.ts'
 import { createTestRepository, ensureParent, removeTestRepository } from '../test/helpers.ts'
@@ -215,6 +222,42 @@ describe('canonical records', () => {
     assert.deepEqual(record.artifacts, [artifact])
     assert.deepEqual(readdirSync(join(root, 'encephalon', '_artifacts', 'architecture', id)), ['diagram.svg'])
     assert.equal(api.validateRecords({ root }).valid, true)
+  })
+
+  test('validates planned graph bytes without counting runtime paths', () => {
+    const root = createRoot()
+    const plans = Array.from({ length: 8 }, (_, index) =>
+      planRecordAddition(root, {
+        id: `planned-byte-accounting-${index}`,
+        kind: 'decision',
+        payload: { summary: 'x'.repeat(1_048_350) },
+        source: 'agent',
+        subject: `planning.bytes.${index}`,
+      }),
+    )
+    const canonicalBytes = plans.reduce((total, plan) => total + Buffer.byteLength(plan.formatted, 'utf8'), 0)
+    const runtimeBytes = plans.reduce(
+      (total, plan) => total + Buffer.byteLength(`${JSON.stringify(plan.record, null, 2)}\n`, 'utf8'),
+      0,
+    )
+
+    assert.equal(canonicalBytes <= MAX_CANONICAL_RECORD_BYTES, true)
+    assert.equal(runtimeBytes > MAX_CANONICAL_RECORD_BYTES, true)
+    assert.doesNotThrow(() =>
+      assertRecordGraph(
+        root,
+        plans.map(plan => plan.record),
+      ),
+    )
+    assert.doesNotThrow(() =>
+      assertRecordGraph(
+        root,
+        plans.map(plan => plan.record),
+        'Canonical records are invalid.',
+        {},
+        canonicalBytes,
+      ),
+    )
   })
 
   test('rejects a symlinked internal staging directory before writing records', {


### PR DESCRIPTION
## Human summary

Initialisation now plans generated records from one repository snapshot, reducing repeated scans while preserving durable writes and safe reruns.

## Summary

- Refactor record creation into reusable planning, combined-graph validation, and durable publication helpers.
- Update `init` to read canonical records once under the operation lock, scan the generated baseline once, validate the planned combined graph once, and publish planned records without rescanning for each addition.
- Use freshness-aware cache preparation when no generated records changed, while still forcing cache hydration after new canonical records are published.
- Add instrumentation-backed init tests for first run, idempotent rerun, one-subject refresh, three-subject refresh, and mid-batch publication failure convergence.
