### PR TITLE
[MAR-2532] Validate kind directories directly

### DIFF
--- a/src/records.ts
+++ b/src/records.ts
@@ -18,7 +18,14 @@ import { hydrateResolvedRepository } from './cache.ts'
 import { EncephalonError, fail, wrapIo } from './errors.ts'
 import { withOperationLock } from './lock.ts'
 import { resolveRepository } from './repository.ts'
-import { assertArtifactFile, createRecordFile, formatRecordFile, MAX_RECORD_BYTES, parseRecordFile } from './schema.ts'
+import {
+  assertArtifactFile,
+  createRecordFile,
+  formatRecordFile,
+  MAX_RECORD_BYTES,
+  parseRecordFile,
+  validateKind,
+} from './schema.ts'
 import type {
   AddRecordInput,
   BrainRecord,
@@ -134,6 +141,15 @@ const readRecord = (root: string, path: string): BrainRecord => {
   return { ...record, path: relativePath }
 }
 
+const kindDirectoryIssue = (name: string, path: string) => {
+  try {
+    validateKind(name)
+    return null
+  } catch {
+    return issue('INVALID_KIND_DIRECTORY', 'Kind directory name is not a portable kind.', path)
+  }
+}
+
 const scanCanonicalRecords = (root: string): RecordScan => {
   const brainDirectory = resolve(root, 'encephalon')
   if (existsSync(brainDirectory)) {
@@ -145,6 +161,7 @@ const scanCanonicalRecords = (root: string): RecordScan => {
       }
     }
 
+    const kindDirectoryNames = new Map<string, string>()
     const scanned = readdirSync(brainDirectory, { withFileTypes: true })
       .sort((first, second) => first.name.localeCompare(second.name))
       .reduce<RecordScan>(
@@ -166,6 +183,24 @@ const scanCanonicalRecords = (root: string): RecordScan => {
           }
           const kindPath = join(brainDirectory, kindEntry.name)
           if (!kindEntry.name.startsWith('_') && kindEntry.isDirectory() && !kindEntry.isSymbolicLink()) {
+            const relativeKindPath = posixRelative(root, kindPath)
+            const invalidKindDirectory = kindDirectoryIssue(kindEntry.name, relativeKindPath)
+            if (invalidKindDirectory !== null) {
+              result.errors.push(invalidKindDirectory)
+            }
+            const collisionKey = kindEntry.name.normalize('NFC').toLowerCase()
+            const collision = kindDirectoryNames.get(collisionKey)
+            if (collision === undefined) {
+              kindDirectoryNames.set(collisionKey, kindEntry.name)
+            } else if (collision !== kindEntry.name) {
+              result.errors.push(
+                issue(
+                  'KIND_DIRECTORY_COLLISION',
+                  'Kind directory names collide after portable normalization.',
+                  relativeKindPath,
+                ),
+              )
+            }
             return readdirSync(kindPath, { withFileTypes: true })
               .sort((first, second) => first.name.localeCompare(second.name))
               .reduce<RecordScan>((kindResult, recordEntry) => {

--- a/test/records.test.ts
+++ b/test/records.test.ts
@@ -175,7 +175,7 @@ describe('canonical records', () => {
         : []),
       ...unicodeNames.map(name => ['INVALID_KIND_DIRECTORY', `encephalon/${name}`]),
       ...(unicodeNames.length === 2 ? [['KIND_DIRECTORY_COLLISION', 'encephalon/café']] : []),
-    ]
+    ].sort((first, second) => String(first[1]).localeCompare(String(second[1])))
 
     const result = api.validateRecords({ root })
     assert.equal(result.valid, expected.length === 0)

--- a/test/records.test.ts
+++ b/test/records.test.ts
@@ -15,6 +15,7 @@ import { afterEach, describe, test } from 'node:test'
 import * as api from '../src/index.ts'
 import { addRecordResolved } from '../src/records.ts'
 import { discoverRepository } from '../src/repository.ts'
+import { validateKind } from '../src/schema.ts'
 import { createTestRepository, ensureParent, removeTestRepository } from '../test/helpers.ts'
 
 const roots: string[] = []
@@ -30,6 +31,15 @@ const assertErrorCode = (operation: () => unknown, code: string) => {
     assert.equal((error as { code?: unknown }).code, code)
     return true
   })
+}
+
+const canCreateDirectory = (root: string, name: string) => {
+  try {
+    mkdirSync(join(root, 'encephalon', name), { recursive: true })
+    return readdirSync(join(root, 'encephalon')).includes(name)
+  } catch {
+    return false
+  }
 }
 
 afterEach(() => {
@@ -125,6 +135,81 @@ describe('canonical records', () => {
     assert.deepEqual(record.artifacts, [artifact])
     assert.deepEqual(readdirSync(join(root, 'encephalon', '_artifacts', 'architecture', id)), ['diagram.svg'])
     assert.equal(api.validateRecords({ root }).valid, true)
+  })
+
+  test('uses the record kind portable path predicate for kind directories', () => {
+    for (const invalid of ['Decision', 'bad kind', 'CON', 'kind.', 'kind ']) {
+      assertErrorCode(() => validateKind(invalid), 'INVALID_ARGUMENT')
+    }
+    assert.equal(validateKind('custom_kind-1'), 'custom_kind-1')
+  })
+
+  test('validates empty invalid kind directories and valid empty custom kinds', () => {
+    const root = createRoot()
+    mkdirSync(join(root, 'encephalon'), { recursive: true })
+    const created = ['Decision', 'bad kind', 'CON', 'kind.', 'kind '].filter(name => canCreateDirectory(root, name))
+    mkdirSync(join(root, 'encephalon', 'custom_kind-1'))
+
+    const result = api.validateRecords({ root })
+    assert.equal(result.valid, false)
+    const expected = created
+      .map(name => ['INVALID_KIND_DIRECTORY', `encephalon/${name}`])
+      .sort((first, second) => String(first[1]).localeCompare(String(second[1])))
+    assert.deepEqual(
+      result.errors.map(error => [error.code, error.path]),
+      expected,
+    )
+  })
+
+  test('detects kind directory case and unicode-normalization collisions', () => {
+    const root = createRoot()
+    mkdirSync(join(root, 'encephalon', 'context'), { recursive: true })
+    const caseVariantCreated = canCreateDirectory(root, 'Context')
+    const unicodeNames = ['cafe\u0301', 'café'].filter(name => canCreateDirectory(root, name))
+    const expected = [
+      ...(caseVariantCreated
+        ? [
+            ['INVALID_KIND_DIRECTORY', 'encephalon/Context'],
+            ['KIND_DIRECTORY_COLLISION', 'encephalon/Context'],
+          ]
+        : []),
+      ...unicodeNames.map(name => ['INVALID_KIND_DIRECTORY', `encephalon/${name}`]),
+      ...(unicodeNames.length === 2 ? [['KIND_DIRECTORY_COLLISION', 'encephalon/café']] : []),
+    ]
+
+    const result = api.validateRecords({ root })
+    assert.equal(result.valid, expected.length === 0)
+    assert.deepEqual(
+      result.errors.map(error => [error.code, error.path]),
+      expected,
+    )
+  })
+
+  test('reports invalid kind directories containing records without rewriting them', () => {
+    const root = createRoot()
+    const directory = join(root, 'encephalon', 'Bad')
+    mkdirSync(directory, { recursive: true })
+    writeFileSync(
+      join(directory, 'record-a.json'),
+      `${JSON.stringify(
+        {
+          createdAt: '2026-08-08T00:00:00.000Z',
+          id: 'record-a',
+          kind: 'context',
+          payload: { summary: 'Wrong parent' },
+          source: 'test',
+          subject: 'invalid.kind-dir',
+        },
+        null,
+        2,
+      )}\n`,
+    )
+
+    const result = api.validateRecords({ root })
+    assert.equal(result.valid, false)
+    assert.equal(result.errors[0]?.code, 'INVALID_KIND_DIRECTORY')
+    assert.equal(result.errors[0]?.path, 'encephalon/Bad')
+    assert.equal(existsSync(join(directory, 'record-a.json')), true)
   })
 
   test('rejects a symlinked internal staging directory before writing records', {

--- a/test/records.test.ts
+++ b/test/records.test.ts
@@ -299,21 +299,19 @@ describe('canonical records', () => {
     mkdirSync(join(root, 'encephalon', 'context'), { recursive: true })
     const caseVariantCreated = canCreateDirectory(root, 'Context')
     const unicodeNames = ['cafe\u0301', 'café'].filter(name => canCreateDirectory(root, name))
-    const unicodeCollisionPaths = readdirSync(join(root, 'encephalon'))
+    const unicodeOrderedNames = readdirSync(join(root, 'encephalon'))
       .filter(name => unicodeNames.includes(name))
       .sort((first, second) => first.localeCompare(second))
-      .reduce<{ paths: string[]; seen: Set<string> }>(
-        (accumulator, name) => {
-          const collisionKey = name.normalize('NFC').toLowerCase()
-          return {
-            paths: accumulator.seen.has(collisionKey)
-              ? [...accumulator.paths, `encephalon/${name}`]
-              : accumulator.paths,
-            seen: new Set([...accumulator.seen, collisionKey]),
-          }
-        },
-        { paths: [], seen: new Set<string>() },
-      ).paths
+    const unicodeCollisionPaths = unicodeOrderedNames.reduce<{ paths: string[]; seen: Set<string> }>(
+      (accumulator, name) => {
+        const collisionKey = name.normalize('NFC').toLowerCase()
+        return {
+          paths: accumulator.seen.has(collisionKey) ? [...accumulator.paths, `encephalon/${name}`] : accumulator.paths,
+          seen: new Set([...accumulator.seen, collisionKey]),
+        }
+      },
+      { paths: [], seen: new Set<string>() },
+    ).paths
     const expected = [
       ...(caseVariantCreated
         ? [
@@ -321,7 +319,7 @@ describe('canonical records', () => {
             ['KIND_DIRECTORY_COLLISION', 'encephalon/Context'],
           ]
         : []),
-      ...unicodeNames.map(name => ['INVALID_KIND_DIRECTORY', `encephalon/${name}`]),
+      ...unicodeOrderedNames.map(name => ['INVALID_KIND_DIRECTORY', `encephalon/${name}`]),
       ...unicodeCollisionPaths.map(path => ['KIND_DIRECTORY_COLLISION', path]),
     ].sort((first, second) => String(first[1]).localeCompare(String(second[1])))
 


### PR DESCRIPTION
## Human summary

Validation now catches invalid or colliding Encephalon kind folders even when those folders are empty.

## Summary

- Validate every non-reserved kind directory with the same portable kind predicate used for record envelopes.
- Report stable directory-level issues for invalid kind names and case/Unicode-normalization collisions.
- Preserve existing record path mismatch checks for records inside scanned directories.
- Add cross-platform tests for portable kind predicates, empty invalid directories, host-supported case/normalization collisions, invalid directories containing records, and valid empty custom kinds.
