### PR TITLE
[MAR-2533] Harden artifact path portability

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -7,11 +7,14 @@ import type { AddRecordInput, BrainRecordFile, JsonValue } from './types.ts'
 export const MAX_RECORD_BYTES = 1024 * 1024
 const MAX_SEARCH_TEXT_BYTES = 256 * 1024
 const MAX_TEXT_BYTES = 1024
+// Portable path components must fit common 255-byte and 255-UTF-16-code-unit filesystem limits.
+const MAX_PATH_COMPONENT_BYTES = 255
+const MAX_PATH_COMPONENT_UTF16_UNITS = 255
 const MAX_ARTIFACTS = 256
 const KIND_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/
 const ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/
 const TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
-const RESERVED_WINDOWS_NAMES = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$/i
+const RESERVED_WINDOWS_NAMES = /^(?:con|prn|aux|nul|com[1-9¹²³]|lpt[1-9¹²³])(?:\..*)?$/i
 const hasControlCharacters = (value: string) =>
   [...value].some(character => {
     const code = character.codePointAt(0) ?? 0
@@ -33,6 +36,9 @@ let lastCreatedAtMilliseconds = 0
 
 const byteLength = (value: string) => Buffer.byteLength(value, 'utf8')
 
+const hasPortableComponentLength = (value: string) =>
+  byteLength(value) <= MAX_PATH_COMPONENT_BYTES && value.length <= MAX_PATH_COMPONENT_UTF16_UNITS
+
 const requiredText = (value: unknown, field: string) => {
   if (typeof value === 'string' && value.length > 0 && value === value.trim() && byteLength(value) <= MAX_TEXT_BYTES) {
     return value
@@ -43,7 +49,13 @@ const requiredText = (value: unknown, field: string) => {
 }
 
 const assertPortableSegment = (value: string, field: string, pattern: RegExp) => {
-  if (pattern.test(value) && !RESERVED_WINDOWS_NAMES.test(value) && !value.endsWith('.') && !value.endsWith(' ')) {
+  if (
+    pattern.test(value) &&
+    hasPortableComponentLength(value) &&
+    !RESERVED_WINDOWS_NAMES.test(value) &&
+    !value.endsWith('.') &&
+    !value.endsWith(' ')
+  ) {
     return value
   }
   return fail('INVALID_ARGUMENT', `${field} is not a portable path segment.`, {
@@ -166,6 +178,7 @@ const portableArtifactSegments = (value: unknown) => {
         segment.length > 0 &&
         segment !== '.' &&
         segment !== '..' &&
+        hasPortableComponentLength(segment) &&
         !hasControlCharacters(segment) &&
         !/[<>:"|?*]/.test(segment) &&
         !segment.endsWith('.') &&

--- a/test/records.test.ts
+++ b/test/records.test.ts
@@ -374,6 +374,39 @@ describe('canonical records', () => {
         }),
       'INVALID_ARGUMENT',
     )
+    const reservedArtifactNames = [
+      'con',
+      'CON',
+      'CoN.txt',
+      'prn',
+      'AUX.md',
+      'nul',
+      'COM1',
+      'com9.log',
+      'LPT1',
+      'lpt9.txt',
+      'COM¹',
+      'com².txt',
+      'CoM³.log',
+      'LPT¹',
+      'lpt².txt',
+      'LpT³.log',
+    ]
+    for (const artifactName of reservedArtifactNames) {
+      assertErrorCode(
+        () =>
+          api.addRecord({
+            artifacts: [`_artifacts/decision/record-safe/${artifactName}`],
+            id: 'record-safe',
+            kind: 'decision',
+            payload: {},
+            root,
+            source: 'agent',
+            subject: 'x',
+          }),
+        'INVALID_ARGUMENT',
+      )
+    }
     assertErrorCode(
       () =>
         api.addRecord({
@@ -524,6 +557,42 @@ describe('canonical records', () => {
         }),
       'INVALID_ARGUMENT',
     )
+  })
+
+  test('enforces portable artifact path component lengths', () => {
+    const root = createRoot()
+    const validComponent = 'a'.repeat(255)
+    const validArtifact = `_artifacts/decision/record-safe/${validComponent}`
+    const validArtifactPath = join(root, 'encephalon', ...validArtifact.split('/'))
+    ensureParent(validArtifactPath)
+    writeFileSync(validArtifactPath, 'artifact')
+
+    const record = api.addRecord({
+      artifacts: [validArtifact],
+      id: 'record-safe',
+      kind: 'decision',
+      payload: {},
+      root,
+      source: 'agent',
+      subject: 'component.length',
+    })
+    assert.deepEqual(record.artifacts, [validArtifact])
+
+    for (const artifactName of ['a'.repeat(256), 'é'.repeat(128)]) {
+      assertErrorCode(
+        () =>
+          api.addRecord({
+            artifacts: [`_artifacts/decision/too-long/${artifactName}`],
+            id: 'too-long',
+            kind: 'decision',
+            payload: {},
+            root,
+            source: 'agent',
+            subject: 'component.length',
+          }),
+        'INVALID_ARGUMENT',
+      )
+    }
   })
 
   test('reports malformed files without rewriting them', () => {


### PR DESCRIPTION
## Human summary

Artifact paths now reject more Windows-incompatible names and overlong path parts before records are written.

## Summary

- Extend the Windows reserved-name predicate to reject superscript COM/LPT device basenames, case-insensitively and with extensions.
- Apply a portable path-component limit of 255 UTF-8 bytes and 255 UTF-16 code units to record IDs, kinds, and every artifact segment.
- Preserve the existing aggregate 1,024-byte artifact path limit and all other unsafe path checks.
- Add table-driven API tests for ordinary and superscript reserved artifact names plus ASCII and multibyte component length boundaries.
