### PR TITLE
[MAR-2534] Use locale-independent canonical ordering

### DIFF
--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -708,6 +708,7 @@ Missing `show` results are represented as `null` and are not errors. Gather pres
 - Gather search groups: exact caller-provided order, including repeated queries.
 - Gather show entries: exact caller-provided order, including repeated IDs.
 - Gather does not silently deduplicate requests.
+- Canonical JSON keys, generated baseline arrays, source manifests, validation output derived from scans, and supersession ID arrays use locale-independent UTF-16 code unit ordering. Sorting does not normalise or otherwise alter stored strings.
 
 ### 12.5 Compact search
 

--- a/encephalon/review/36103fcb-af7d-4fd0-a79b-f620be91aedc.json
+++ b/encephalon/review/36103fcb-af7d-4fd0-a79b-f620be91aedc.json
@@ -1,0 +1,19 @@
+{
+  "createdAt": "2026-08-09T01:06:04.611Z",
+  "id": "36103fcb-af7d-4fd0-a79b-f620be91aedc",
+  "kind": "review",
+  "payload": {
+    "summary": "Derive filesystem collision test expectations from actual directory entries.",
+    "lessons": [
+      "Case and Unicode-normalisation collision tests must not hard-code which path becomes the collision representative; case-sensitive and case-insensitive filesystems can keep different real directory names.",
+      "When validator behaviour depends on sorted readdir entries, build test expectations from the actual readdirSync names using the same ordinal comparator and collision-key reduce.",
+      "A test that passes on macOS and Windows can still fail on Ubuntu when it assumes case-variant creation or collision order from another filesystem."
+    ],
+    "verification": [
+      "For tests that create case or Unicode variants, run the focused test and inspect the expected array against the validator scan order before committing.",
+      "If a local Linux container is unavailable, explicitly note that GitHub Ubuntu remains the authoritative verification for case-sensitive filesystem behaviour."
+    ]
+  },
+  "source": "agent",
+  "subject": "review.filesystem-collision-test-expectations"
+}

--- a/src/baseline.ts
+++ b/src/baseline.ts
@@ -1,5 +1,6 @@
 import { existsSync, lstatSync, readdirSync, readFileSync } from 'node:fs'
 import { extname, resolve } from 'node:path'
+import { ordinalStringCompare } from './order.ts'
 import type { AddRecordInput, JsonValue } from './types.ts'
 
 const MAX_SCANNED_FILES = 100_000
@@ -169,12 +170,10 @@ const readPackageFacts = (root: string): PackageFacts => {
           : {}),
         scriptKeys:
           value.scripts !== null && typeof value.scripts === 'object' && !Array.isArray(value.scripts)
-            ? Object.keys(value.scripts)
-                .filter(safeName)
-                .sort((first, second) => first.localeCompare(second))
+            ? Object.keys(value.scripts).filter(safeName).sort(ordinalStringCompare)
             : [],
         workspacePatterns: Array.isArray(workspaceValue)
-          ? workspaceValue.filter(safeWorkspacePattern).sort((first, second) => first.localeCompare(second))
+          ? workspaceValue.filter(safeWorkspacePattern).sort(ordinalStringCompare)
           : [],
       }
     } catch {
@@ -195,7 +194,7 @@ const scanLanguages = (root: string) => {
       return state
     }
     return readdirSync(directory, { withFileTypes: true })
-      .sort((first, second) => first.name.localeCompare(second.name))
+      .sort((first, second) => ordinalStringCompare(first.name, second.name))
       .reduce<ScanState>((current, entry) => {
         if (
           current.truncated ||
@@ -236,13 +235,13 @@ const workflowFiles = (root: string) => {
   return readdirSync(directory, { withFileTypes: true })
     .filter(entry => entry.isFile() && !entry.isSymbolicLink() && safeName(entry.name) && /\.ya?ml$/i.test(entry.name))
     .map(entry => `.github/workflows/${entry.name}`)
-    .sort((first, second) => first.localeCompare(second))
+    .sort(ordinalStringCompare)
 }
 
 const topLevelFacts = (root: string) =>
   readdirSync(root, { withFileTypes: true })
     .filter(entry => safeName(entry.name) && !entry.isSymbolicLink())
-    .sort((first, second) => first.name.localeCompare(second.name))
+    .sort((first, second) => ordinalStringCompare(first.name, second.name))
     .reduce<{ directories: string[]; recognisedFiles: string[] }>(
       (facts, entry) => {
         if (entry.isDirectory() && !EXCLUDED_DIRECTORIES.has(entry.name.toLowerCase())) {
@@ -268,12 +267,12 @@ export const scanBaseline = (root: string): AddRecordInput[] => {
   const packageManager = packageFacts.packageManager ?? packageManagerFromLock(layout.recognisedFiles)
   const scan = scanLanguages(root)
   const languages = [...scan.languageCounts.entries()]
-    .sort(([first], [second]) => first.localeCompare(second))
+    .sort(([first], [second]) => ordinalStringCompare(first, second))
     .map(([language, files]) => ({ files, language }))
   const workflows = workflowFiles(root)
   const safeSources = [
     ...new Set([...layout.recognisedFiles, ...(workflows.length === 0 ? [] : ['.github/workflows'])]),
-  ].sort((first, second) => first.localeCompare(second))
+  ].sort(ordinalStringCompare)
 
   return [
     {
@@ -326,7 +325,7 @@ const sortJson = (value: JsonValue): JsonValue => {
   if (value !== null && typeof value === 'object') {
     return Object.fromEntries(
       Object.keys(value)
-        .sort((first, second) => first.localeCompare(second))
+        .sort(ordinalStringCompare)
         .map(key => [key, sortJson(value[key] as JsonValue)]),
     )
   }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -5,6 +5,7 @@ import { resolve } from 'node:path'
 import type { DatabaseSync } from 'node:sqlite'
 import { EncephalonError, fail, failWithCause, wrapIo } from './errors.ts'
 import { cacheDirectory, withOperationLock } from './lock.ts'
+import { ordinalStringCompare } from './order.ts'
 import { readRecords } from './records.ts'
 import { resolveRepository } from './repository.ts'
 import type {
@@ -242,7 +243,7 @@ const recordManifestEntries = (root: string) => {
   }
   const children = readdirSync(brainDirectory, { withFileTypes: true })
     .filter(entry => entry.name !== '_artifacts')
-    .sort((first, second) => first.name.localeCompare(second.name))
+    .sort((first, second) => ordinalStringCompare(first.name, second.name))
     .flatMap(entry => {
       const kindPath = resolve(brainDirectory, entry.name)
       const kindEntry = statEntry(root, kindPath)
@@ -250,7 +251,7 @@ const recordManifestEntries = (root: string) => {
         return [kindEntry]
       }
       const recordEntries = readdirSync(kindPath, { withFileTypes: true })
-        .sort((first, second) => first.name.localeCompare(second.name))
+        .sort((first, second) => ordinalStringCompare(first.name, second.name))
         .map(recordEntry => statEntry(root, resolve(kindPath, recordEntry.name)))
       return [kindEntry, ...recordEntries]
     })
@@ -261,7 +262,7 @@ const repositoryManifest = (root: string, artifactPaths: string[]) => {
   const entries = [
     ...recordManifestEntries(root),
     ...[...artifactPaths]
-      .sort((first, second) => first.localeCompare(second))
+      .sort(ordinalStringCompare)
       .map(path => statEntry(root, resolve(root, 'encephalon', ...path.split('/')))),
   ]
   return createHash('sha256').update(JSON.stringify(entries)).digest('hex')
@@ -384,9 +385,7 @@ const rebuildCache = (root: string): PrepareResult => {
       }
       throw error
     }
-    const artifactPaths = [...new Set(records.flatMap(record => record.artifacts ?? []))].sort((first, second) =>
-      first.localeCompare(second),
-    )
+    const artifactPaths = [...new Set(records.flatMap(record => record.artifacts ?? []))].sort(ordinalStringCompare)
     const manifestBefore = repositoryManifest(root, artifactPaths)
     if (repositoryManifest(root, []) !== recordManifestBefore) {
       if (attempt === MAX_REPOSITORY_CHANGE_RETRIES - 1) {

--- a/src/init.ts
+++ b/src/init.ts
@@ -3,6 +3,7 @@ import { hydrateResolvedRepository } from './cache.ts'
 import { EncephalonError, fail, wrapIo } from './errors.ts'
 import { applyInstructionChanges, planInstructionChanges } from './instructions.ts'
 import { withOperationLock } from './lock.ts'
+import { ordinalStringCompare } from './order.ts'
 import { addRecordResolved, readRecords } from './records.ts'
 import { resolveRepository } from './repository.ts'
 import type { AddRecordInput, BrainRecord, InitEncephalonInput, InitEncephalonResult } from './types.ts'
@@ -34,7 +35,7 @@ const baselineActions = (records: BrainRecord[], baseline: AddRecordInput[], ref
           conflicts: [
             ...result.conflicts,
             {
-              activeRecordIds: matching.map(record => record.id).sort((first, second) => first.localeCompare(second)),
+              activeRecordIds: matching.map(record => record.id).sort(ordinalStringCompare),
               kind: candidate.kind,
               subject: candidate.subject,
             },
@@ -51,7 +52,7 @@ const baselineActions = (records: BrainRecord[], baseline: AddRecordInput[], ref
             ...result.additions,
             {
               ...candidate,
-              supersedes: matching.map(record => record.id).sort((first, second) => first.localeCompare(second)),
+              supersedes: matching.map(record => record.id).sort(ordinalStringCompare),
             },
           ],
         }

--- a/src/order.ts
+++ b/src/order.ts
@@ -1,0 +1,11 @@
+// Locale-independent UTF-16 code unit ordering. This matches JavaScript string
+// relational comparison, preserves ASCII order, and does not normalise values.
+export const ordinalStringCompare = (first: string, second: string) => {
+  if (first < second) {
+    return -1
+  }
+  if (first > second) {
+    return 1
+  }
+  return 0
+}

--- a/src/records.ts
+++ b/src/records.ts
@@ -17,6 +17,7 @@ import { basename, join, relative, resolve } from 'node:path'
 import { hydrateResolvedRepository } from './cache.ts'
 import { EncephalonError, fail, wrapIo } from './errors.ts'
 import { withOperationLock } from './lock.ts'
+import { ordinalStringCompare } from './order.ts'
 import { resolveRepository } from './repository.ts'
 import { assertArtifactFile, createRecordFile, formatRecordFile, MAX_RECORD_BYTES, parseRecordFile } from './schema.ts'
 import type {
@@ -146,7 +147,7 @@ const scanCanonicalRecords = (root: string): RecordScan => {
     }
 
     const scanned = readdirSync(brainDirectory, { withFileTypes: true })
-      .sort((first, second) => first.name.localeCompare(second.name))
+      .sort((first, second) => ordinalStringCompare(first.name, second.name))
       .reduce<RecordScan>(
         (result, kindEntry) => {
           if (RESERVED_DIRECTORIES.has(kindEntry.name)) {
@@ -167,7 +168,7 @@ const scanCanonicalRecords = (root: string): RecordScan => {
           const kindPath = join(brainDirectory, kindEntry.name)
           if (!kindEntry.name.startsWith('_') && kindEntry.isDirectory() && !kindEntry.isSymbolicLink()) {
             return readdirSync(kindPath, { withFileTypes: true })
-              .sort((first, second) => first.name.localeCompare(second.name))
+              .sort((first, second) => ordinalStringCompare(first.name, second.name))
               .reduce<RecordScan>((kindResult, recordEntry) => {
                 const recordPath = join(kindPath, recordEntry.name)
                 const relativePath = posixRelative(root, recordPath)
@@ -229,7 +230,8 @@ const scanCanonicalRecords = (root: string): RecordScan => {
     return {
       errors: scanned.errors,
       records: scanned.records.sort(
-        (first, second) => first.createdAt.localeCompare(second.createdAt) || first.id.localeCompare(second.id),
+        (first, second) =>
+          ordinalStringCompare(first.createdAt, second.createdAt) || ordinalStringCompare(first.id, second.id),
       ),
     }
   }

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import { afterEach, describe, test } from 'node:test'
 import * as api from '../src/index.ts'
+import { ordinalStringCompare } from '../src/order.ts'
 import { createTestRepository, ensureParent, removeTestRepository } from '../test/helpers.ts'
 
 const roots: string[] = []
@@ -86,7 +87,7 @@ describe('SQLite cache and reads', () => {
       query: 'portable persistence',
       root,
     })
-    assert.deepEqual(Object.keys(compact[0] ?? {}).sort(), [
+    assert.deepEqual(Object.keys(compact[0] ?? {}).sort(ordinalStringCompare), [
       'id',
       'kind',
       'path',

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -17,6 +17,7 @@ import { join } from 'node:path'
 import { afterEach, describe, test } from 'node:test'
 import * as api from '../src/index.ts'
 import { applyInstructionChanges, planInstructionChanges } from '../src/instructions.ts'
+import { ordinalStringCompare } from '../src/order.ts'
 import { createTestRepository, ensureParent, removeTestRepository } from '../test/helpers.ts'
 
 const roots: string[] = []
@@ -67,10 +68,11 @@ describe('initialisation', () => {
       root,
     })
     assert.equal(records.length, 3)
-    assert.deepEqual(
-      records.map(record => record.subject).sort((left, right) => left.localeCompare(right)),
-      ['encephalon:init/commands-ci', 'encephalon:init/repository-overview', 'encephalon:init/tooling-layout'],
-    )
+    assert.deepEqual(records.map(record => record.subject).sort(ordinalStringCompare), [
+      'encephalon:init/commands-ci',
+      'encephalon:init/repository-overview',
+      'encephalon:init/tooling-layout',
+    ])
     assert.equal(
       records.every(record => record.source === 'encephalon:init'),
       true,

--- a/test/order.test.ts
+++ b/test/order.test.ts
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterEach, describe, test } from 'node:test'
+import { ordinalStringCompare } from '../src/order.ts'
+import { createTestRepository, ensureParent, removeTestRepository } from '../test/helpers.ts'
+
+const roots: string[] = []
+
+const createRoot = () => {
+  const root = createTestRepository()
+  roots.push(root)
+  return root
+}
+
+afterEach(() => {
+  roots.splice(0).forEach(removeTestRepository)
+})
+
+const baselineModule = new URL('../src/baseline.ts', import.meta.url).href
+const indexModule = new URL('../src/index.ts', import.meta.url).href
+
+const localeProbeScript = `
+import { rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { canonicalPayload, scanBaseline } from ${JSON.stringify(baselineModule)}
+import { hydrate, listRecords, searchRecords } from ${JSON.stringify(indexModule)}
+
+const root = process.argv[1]
+rmSync(join(root, 'node_modules', '.cache', 'encephalon'), { force: true, recursive: true })
+const baseline = scanBaseline(root).map(record => ({
+  payload: record.payload,
+  subject: record.subject,
+}))
+const canonical = canonicalPayload({
+  '10': true,
+  '2': true,
+  A: true,
+  I: true,
+  Z: true,
+  a: true,
+  'e\\u0301': true,
+  i: true,
+  item10: true,
+  item2: true,
+  z: true,
+  'ä': true,
+  'é': true,
+  'İ': true,
+  'ı': true,
+  '💡': true,
+  '😀': true,
+})
+hydrate({ root })
+const database = new DatabaseSync(join(root, 'node_modules', '.cache', 'encephalon', 'brain.sqlite'))
+const manifest = database.prepare("SELECT value FROM metadata WHERE key = 'manifest'").get().value
+const artifactPaths = JSON.parse(database.prepare("SELECT value FROM metadata WHERE key = 'artifactPaths'").get().value)
+database.close()
+const listIds = listRecords({ includeSuperseded: true, limit: 10, root }).map(record => record.id)
+const searchIds = searchRecords({ includeSuperseded: true, limit: 10, query: 'needle', root }).map(record => record.id)
+
+console.log(JSON.stringify({ artifactPaths, baseline, canonical, listIds, manifest, searchIds }))
+`
+
+const probeLocale = (root: string, locale: string) => {
+  const result = spawnSync(process.execPath, ['--input-type=module', '--eval', localeProbeScript, root], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      LANG: locale,
+      LC_ALL: locale,
+      LC_COLLATE: locale,
+    },
+  })
+  assert.equal(result.status, 0, result.stderr)
+  return JSON.parse(result.stdout) as {
+    artifactPaths: string[]
+    baseline: Array<{ payload: Record<string, unknown>; subject: string }>
+    canonical: string
+    listIds: string[]
+    manifest: string
+    searchIds: string[]
+  }
+}
+
+describe('ordinal ordering', () => {
+  test('sorts strings by UTF-16 code units without locale collation', () => {
+    assert.deepEqual(
+      ['é', 'item2', 'I', 'ı', '😀', '10', 'Z', 'a', 'e\u0301', '💡', '2', 'A', 'İ', 'z', 'i', 'item10', 'ä'].sort(
+        ordinalStringCompare,
+      ),
+      ['10', '2', 'A', 'I', 'Z', 'a', 'e\u0301', 'i', 'item10', 'item2', 'z', 'ä', 'é', 'İ', 'ı', '💡', '😀'],
+    )
+  })
+
+  test('keeps canonical outputs identical across process locale settings', () => {
+    const root = createRoot()
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({
+        name: 'locale-ordering',
+        packageManager: 'npm@11.0.0',
+        scripts: {
+          Build: 'node build.js',
+          build: 'node build.js',
+          'e\u0301': 'node decomposed.js',
+          istanbul: 'node lower.js',
+          item2: 'node two.js',
+          item10: 'node ten.js',
+          é: 'node composed.js',
+          İstanbul: 'node dotted.js',
+          '💡': 'node idea.js',
+        },
+        workspaces: ['packages/e\u0301', 'packages/é', 'packages/item10', 'packages/item2', 'packages/İ'],
+      }),
+    )
+    writeFileSync(join(root, 'package-lock.json'), '{}')
+    for (const directory of ['10', '2', 'A', 'item10', 'item2', 'é', 'İ', 'ı', '💡']) {
+      mkdirSync(join(root, directory))
+    }
+    ensureParent(join(root, '.github', 'workflows', 'é.yml'))
+    writeFileSync(join(root, '.github', 'workflows', 'é.yml'), 'name: composed\n')
+    writeFileSync(join(root, '.github', 'workflows', 'item10.yml'), 'name: ten\n')
+    writeFileSync(join(root, '.github', 'workflows', 'item2.yml'), 'name: two\n')
+    ensureParent(join(root, 'src', 'index.ts'))
+    writeFileSync(join(root, 'src', 'index.ts'), 'export const value = 1\n')
+
+    const records = ['Zed', 'alpha', 'item10', 'item2'].map(id => ({
+      ...(id === 'Zed' ? { artifacts: ['_artifacts/decision/Zed/é.txt'] } : {}),
+      createdAt: '2026-08-08T00:00:00.000Z',
+      id,
+      kind: 'decision',
+      payload: { summary: `needle ${id}` },
+      source: 'agent',
+      subject: `locale.ordering.${id}`,
+    }))
+    ensureParent(join(root, 'encephalon', 'decision', 'Zed.json'))
+    for (const record of records) {
+      writeFileSync(join(root, 'encephalon', 'decision', `${record.id}.json`), `${JSON.stringify(record, null, 2)}\n`)
+    }
+    ensureParent(join(root, 'encephalon', '_artifacts', 'decision', 'Zed', 'é.txt'))
+    writeFileSync(join(root, 'encephalon', '_artifacts', 'decision', 'Zed', 'é.txt'), 'artifact\n')
+
+    const outputs = ['C', 'en_US.UTF-8', 'tr_TR.UTF-8', 'sv_SE.UTF-8'].map(locale => probeLocale(root, locale))
+    const [referenceOutput, ...otherOutputs] = outputs
+    assert.ok(referenceOutput)
+    assert.deepEqual(
+      otherOutputs,
+      otherOutputs.map(() => referenceOutput),
+    )
+
+    const workflowPayload = referenceOutput.baseline.find(record => record.subject === 'encephalon:init/commands-ci')
+      ?.payload as { scriptKeys?: string[]; workflowFiles?: string[] }
+    assert.deepEqual(workflowPayload.scriptKeys, [
+      'Build',
+      'build',
+      'e\u0301',
+      'istanbul',
+      'item10',
+      'item2',
+      'é',
+      'İstanbul',
+      '💡',
+    ])
+    assert.deepEqual(workflowPayload.workflowFiles, [
+      '.github/workflows/item10.yml',
+      '.github/workflows/item2.yml',
+      '.github/workflows/é.yml',
+    ])
+    assert.deepEqual(referenceOutput.listIds, ['item2', 'item10', 'alpha', 'Zed'])
+    assert.deepEqual(referenceOutput.searchIds, ['item2', 'item10', 'alpha', 'Zed'])
+  })
+})

--- a/test/records.test.ts
+++ b/test/records.test.ts
@@ -298,12 +298,21 @@ describe('canonical records', () => {
   test('detects kind directory case and unicode-normalization collisions', () => {
     const root = createRoot()
     mkdirSync(join(root, 'encephalon', 'context'), { recursive: true })
-    const caseVariantCreated = canCreateDirectory(root, 'Context')
-    const unicodeNames = ['cafe\u0301', 'café'].filter(name => canCreateDirectory(root, name))
-    const unicodeOrderedNames = readdirSync(join(root, 'encephalon'))
-      .filter(name => unicodeNames.includes(name))
-      .sort(ordinalStringCompare)
-    const unicodeCollisionPaths = unicodeOrderedNames.reduce<{ paths: string[]; seen: Set<string> }>(
+    canCreateDirectory(root, 'Context')
+    const unicodeKindCandidates = ['cafe\u0301', 'café']
+    for (const name of unicodeKindCandidates) {
+      canCreateDirectory(root, name)
+    }
+    const kindDirectoryNames = readdirSync(join(root, 'encephalon')).sort(ordinalStringCompare)
+    const invalidKindPaths = kindDirectoryNames.reduce<string[]>((paths, name) => {
+      try {
+        validateKind(name)
+        return paths
+      } catch {
+        return [...paths, `encephalon/${name}`]
+      }
+    }, [])
+    const collisionPaths = kindDirectoryNames.reduce<{ paths: string[]; seen: Set<string> }>(
       (accumulator, name) => {
         const collisionKey = name.normalize('NFC').toLowerCase()
         return {
@@ -314,14 +323,8 @@ describe('canonical records', () => {
       { paths: [], seen: new Set<string>() },
     ).paths
     const expected = [
-      ...(caseVariantCreated
-        ? [
-            ['INVALID_KIND_DIRECTORY', 'encephalon/Context'],
-            ['KIND_DIRECTORY_COLLISION', 'encephalon/Context'],
-          ]
-        : []),
-      ...unicodeOrderedNames.map(name => ['INVALID_KIND_DIRECTORY', `encephalon/${name}`]),
-      ...unicodeCollisionPaths.map(path => ['KIND_DIRECTORY_COLLISION', path]),
+      ...invalidKindPaths.map(path => ['INVALID_KIND_DIRECTORY', path]),
+      ...collisionPaths.map(path => ['KIND_DIRECTORY_COLLISION', path]),
     ].sort((first, second) => ordinalStringCompare(String(first[1]), String(second[1])))
 
     const result = api.validateRecords({ root })


### PR DESCRIPTION
## Human summary

Canonical ordering no longer depends on process locale, so generated records and cache fingerprints remain stable across platforms.

## Summary

- Add one documented UTF-16 ordinal string comparator that preserves ASCII ordering without normalising stored strings.
- Replace `localeCompare()` in baseline generation, canonical payload key sorting, record scans, cache manifests, and init conflict/supersession ID ordering.
- Update existing tests to use the shared comparator where they assert ordered keys or generated subjects.
- Add locale-spawned determinism coverage for accented/decomposed strings, Turkish dotted/dotless characters, emoji, numeric-looking names, mixed ASCII case, baseline payloads, cache manifests, canonical payloads, and list/search tie-break ordering.
- Document the ordering contract in the implementation plan.
