### PR TITLE
[MAR-2535] Require package manager evidence

### DIFF
--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -943,8 +943,9 @@ Persistable facts:
 
 - Safe top-level file and directory names, excluding secret-prone hidden paths.
 - Recognised root manifest, lockfile, and configuration filenames.
-- Root `package.json` package name, `packageManager`, workspace presence, and script keys.
-- Derived package script invocations such as `npm run test`; never the script body.
+- Root `package.json` package name, valid `packageManager` declaration, workspace presence, and script keys.
+- Package-manager evidence is recorded as `unknown`, `declared`, `lockfile-derived`, `declared-and-lockfile`, or `conflicted`; `packageManager` is present only when declaration and lockfile evidence identify one unambiguous manager.
+- Derived package script invocations such as `npm run test`; never the script body. These invocations are omitted when the package manager is unknown or conflicted.
 - CI workflow filenames under `.github/workflows`; never YAML content, triggers, jobs, steps, secrets, or environment values.
 - Recognised language/file counts derived from extensions.
 - Repository identity derived from a safe root package name, or the root directory basename when no manifest provides a name.

--- a/src/baseline.ts
+++ b/src/baseline.ts
@@ -86,14 +86,54 @@ const LANGUAGE_BY_EXTENSION = new Map([
   ['.tsx', 'TypeScript'],
   ['.vue', 'Vue'],
 ])
-const PACKAGE_MANAGERS = new Set(['bun', 'npm', 'pnpm', 'yarn'])
+const PACKAGE_MANAGER_NAMES = ['bun', 'npm', 'pnpm', 'yarn']
+const PACKAGE_MANAGERS = new Set(PACKAGE_MANAGER_NAMES)
+const LOCKFILE_MANAGERS = [
+  { file: 'bun.lock', manager: 'bun' },
+  { file: 'bun.lockb', manager: 'bun' },
+  { file: 'package-lock.json', manager: 'npm' },
+  { file: 'pnpm-lock.yaml', manager: 'pnpm' },
+  { file: 'yarn.lock', manager: 'yarn' },
+] as const
 
 type PackageFacts = {
   name?: string
-  packageManager?: string | undefined
+  packageManager?: string
   workspacePatterns: string[]
   scriptKeys: string[]
 }
+
+type PackageManagerLockfile = {
+  file: string
+  manager: string
+}
+
+type PackageManagerEvidence =
+  | {
+      status: 'conflicted'
+      candidates: string[]
+      declared?: string
+      lockfiles: PackageManagerLockfile[]
+    }
+  | {
+      status: 'declared'
+      declared: string
+      manager: string
+    }
+  | {
+      status: 'declared-and-lockfile'
+      declared: string
+      lockfiles: PackageManagerLockfile[]
+      manager: string
+    }
+  | {
+      status: 'lockfile-derived'
+      lockfiles: PackageManagerLockfile[]
+      manager: string
+    }
+  | {
+      status: 'unknown'
+    }
 
 type ScanState = {
   filesSeen: number
@@ -113,20 +153,45 @@ const safeName = (value: string) =>
   !hasControlCharacters(value) &&
   !/(?:^|[._-])(secret|credential|password|token|private)(?:$|[._-])/i.test(value)
 
-const packageManagerFromLock = (files: string[]) => {
-  if (files.includes('bun.lock') || files.includes('bun.lockb')) {
-    return 'bun'
+const declaredPackageManager = (value: unknown) => {
+  if (typeof value === 'string') {
+    const manager = value.split('@')[0]?.toLowerCase()
+    if (manager !== undefined && PACKAGE_MANAGERS.has(manager)) {
+      return manager
+    }
   }
-  if (files.includes('pnpm-lock.yaml')) {
-    return 'pnpm'
+}
+
+const lockfileEvidence = (files: string[]): PackageManagerLockfile[] =>
+  LOCKFILE_MANAGERS.filter(lockfile => files.includes(lockfile.file))
+
+const packageManagerEvidence = (
+  declared: string | undefined,
+  lockfiles: PackageManagerLockfile[],
+): PackageManagerEvidence => {
+  const lockfileManagers = [...new Set(lockfiles.map(lockfile => lockfile.manager))]
+  if (declared === undefined && lockfileManagers.length === 0) {
+    return { status: 'unknown' }
   }
-  if (files.includes('yarn.lock')) {
-    return 'yarn'
+  if (declared !== undefined && lockfileManagers.length === 0) {
+    return { declared, manager: declared, status: 'declared' }
   }
-  if (files.includes('package-lock.json')) {
-    return 'npm'
+  if (declared === undefined && lockfileManagers.length === 1) {
+    const [manager] = lockfileManagers
+    if (manager !== undefined) {
+      return { lockfiles, manager, status: 'lockfile-derived' }
+    }
   }
-  return 'npm'
+  if (declared !== undefined && lockfileManagers.length === 1 && lockfileManagers[0] === declared) {
+    return { declared, lockfiles, manager: declared, status: 'declared-and-lockfile' }
+  }
+  const evidencedManagers = new Set([...(declared === undefined ? [] : [declared]), ...lockfileManagers])
+  return {
+    ...(declared === undefined ? {} : { declared }),
+    candidates: PACKAGE_MANAGER_NAMES.filter(manager => evidencedManagers.has(manager)),
+    lockfiles,
+    status: 'conflicted',
+  }
 }
 
 const safeWorkspacePattern = (value: unknown): value is string =>
@@ -159,14 +224,10 @@ const readPackageFacts = (root: string): PackageFacts => {
       } else if (value.workspaces !== null && typeof value.workspaces === 'object' && 'packages' in value.workspaces) {
         workspaceValue = (value.workspaces as { packages?: unknown }).packages
       }
+      const packageManager = declaredPackageManager(value.packageManager)
       return {
         ...(typeof value.name === 'string' && safeName(value.name) ? { name: value.name } : {}),
-        ...(typeof value.packageManager === 'string' &&
-        PACKAGE_MANAGERS.has(value.packageManager.split('@')[0]?.toLowerCase() ?? '')
-          ? {
-              packageManager: value.packageManager.split('@')[0]?.toLowerCase(),
-            }
-          : {}),
+        ...(packageManager === undefined ? {} : { packageManager }),
         scriptKeys:
           value.scripts !== null && typeof value.scripts === 'object' && !Array.isArray(value.scripts)
             ? Object.keys(value.scripts)
@@ -265,7 +326,11 @@ const commandForScript = (manager: string, script: string) =>
 export const scanBaseline = (root: string): AddRecordInput[] => {
   const layout = topLevelFacts(root)
   const packageFacts = readPackageFacts(root)
-  const packageManager = packageFacts.packageManager ?? packageManagerFromLock(layout.recognisedFiles)
+  const packageEvidence = packageManagerEvidence(packageFacts.packageManager, lockfileEvidence(layout.recognisedFiles))
+  const packageManager =
+    packageEvidence.status === 'unknown' || packageEvidence.status === 'conflicted'
+      ? undefined
+      : packageEvidence.manager
   const scan = scanLanguages(root)
   const languages = [...scan.languageCounts.entries()]
     .sort(([first], [second]) => first.localeCompare(second))
@@ -295,7 +360,8 @@ export const scanBaseline = (root: string): AddRecordInput[] => {
       payload: {
         summary: 'Derived package and tooling layout captured during Encephalon initialisation.',
         ...(packageFacts.name === undefined ? {} : { packageName: packageFacts.name }),
-        packageManager,
+        ...(packageManager === undefined ? {} : { packageManager }),
+        packageManagerEvidence: packageEvidence,
         recognisedFiles: layout.recognisedFiles,
         sources: layout.recognisedFiles,
         workspaceConfigured: packageFacts.workspacePatterns.length > 0,
@@ -307,7 +373,10 @@ export const scanBaseline = (root: string): AddRecordInput[] => {
     {
       kind: 'workflow',
       payload: {
-        commands: packageFacts.scriptKeys.map(script => commandForScript(packageManager, script)),
+        commands:
+          packageManager === undefined
+            ? []
+            : packageFacts.scriptKeys.map(script => commandForScript(packageManager, script)),
         scriptKeys: packageFacts.scriptKeys,
         sources: [...(layout.recognisedFiles.includes('package.json') ? ['package.json'] : []), ...workflows],
         summary: 'Derived package-script entry points and CI workflow filenames.',

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -27,6 +27,12 @@ const createRoot = () => {
   return root
 }
 
+const generatedPayload = (records: api.BrainRecord[], subject: string) => {
+  const payload = records.find(record => record.subject === subject)?.payload
+  assert.equal(payload !== null && typeof payload === 'object' && !Array.isArray(payload), true)
+  return payload as Record<string, unknown>
+}
+
 afterEach(() => {
   roots.splice(0).forEach(removeTestRepository)
 })
@@ -102,6 +108,7 @@ describe('initialisation', () => {
       packagePath,
       JSON.stringify({
         name: 'sample-project',
+        packageManager: 'npm@11.0.0',
         scripts: { test: 'node --test' },
       }),
     )
@@ -116,6 +123,7 @@ describe('initialisation', () => {
       packagePath,
       JSON.stringify({
         name: 'sample-project',
+        packageManager: 'npm@11.0.0',
         scripts: { lint: 'lint-private-body', test: 'node --test' },
       }),
     )
@@ -128,6 +136,171 @@ describe('initialisation', () => {
     assert.match(JSON.stringify(workflow[0]?.payload), /npm run lint/)
     assert.doesNotMatch(JSON.stringify(workflow[0]?.payload), /lint-private-body/)
     assert.equal(api.listRecords({ limit: 20, root }).length, 3)
+  })
+
+  test('records package-manager facts only when evidence supports them', () => {
+    const packageJson = {
+      name: 'sample-project',
+      scripts: { test: 'node --test' },
+    }
+    const cases = [
+      {
+        commands: [],
+        evidence: { status: 'unknown' },
+        files: { 'go.mod': 'module example.invalid/project\n' },
+        manager: undefined,
+        name: 'non-JavaScript repository',
+        scriptKeys: [],
+      },
+      {
+        commands: [],
+        evidence: { status: 'unknown' },
+        files: { 'package.json': JSON.stringify(packageJson) },
+        manager: undefined,
+        name: 'package.json without manager evidence',
+        scriptKeys: ['test'],
+      },
+      {
+        commands: ['bun run test'],
+        evidence: { lockfiles: [{ file: 'bun.lock', manager: 'bun' }], manager: 'bun', status: 'lockfile-derived' },
+        files: { 'bun.lock': '', 'package.json': JSON.stringify(packageJson) },
+        manager: 'bun',
+        name: 'bun text lockfile',
+        scriptKeys: ['test'],
+      },
+      {
+        commands: ['bun run test'],
+        evidence: { lockfiles: [{ file: 'bun.lockb', manager: 'bun' }], manager: 'bun', status: 'lockfile-derived' },
+        files: { 'bun.lockb': '', 'package.json': JSON.stringify(packageJson) },
+        manager: 'bun',
+        name: 'bun binary lockfile',
+        scriptKeys: ['test'],
+      },
+      {
+        commands: ['npm run test'],
+        evidence: {
+          lockfiles: [{ file: 'package-lock.json', manager: 'npm' }],
+          manager: 'npm',
+          status: 'lockfile-derived',
+        },
+        files: { 'package-lock.json': '{}', 'package.json': JSON.stringify(packageJson) },
+        manager: 'npm',
+        name: 'npm lockfile',
+        scriptKeys: ['test'],
+      },
+      {
+        commands: ['pnpm run test'],
+        evidence: {
+          lockfiles: [{ file: 'pnpm-lock.yaml', manager: 'pnpm' }],
+          manager: 'pnpm',
+          status: 'lockfile-derived',
+        },
+        files: { 'package.json': JSON.stringify(packageJson), 'pnpm-lock.yaml': '' },
+        manager: 'pnpm',
+        name: 'pnpm lockfile',
+        scriptKeys: ['test'],
+      },
+      {
+        commands: ['yarn test'],
+        evidence: { lockfiles: [{ file: 'yarn.lock', manager: 'yarn' }], manager: 'yarn', status: 'lockfile-derived' },
+        files: { 'package.json': JSON.stringify(packageJson), 'yarn.lock': '' },
+        manager: 'yarn',
+        name: 'yarn lockfile',
+        scriptKeys: ['test'],
+      },
+      {
+        commands: ['pnpm run test'],
+        evidence: { declared: 'pnpm', manager: 'pnpm', status: 'declared' },
+        files: { 'package.json': JSON.stringify({ ...packageJson, packageManager: 'pnpm@9.0.0' }) },
+        manager: 'pnpm',
+        name: 'valid declaration without lockfile',
+        scriptKeys: ['test'],
+      },
+      {
+        commands: ['npm run test'],
+        evidence: {
+          declared: 'npm',
+          lockfiles: [{ file: 'package-lock.json', manager: 'npm' }],
+          manager: 'npm',
+          status: 'declared-and-lockfile',
+        },
+        files: {
+          'package-lock.json': '{}',
+          'package.json': JSON.stringify({ ...packageJson, packageManager: 'npm@11.0.0' }),
+        },
+        manager: 'npm',
+        name: 'matching declaration and lockfile',
+        scriptKeys: ['test'],
+      },
+      {
+        commands: [],
+        evidence: {
+          candidates: ['npm', 'yarn'],
+          declared: 'npm',
+          lockfiles: [{ file: 'yarn.lock', manager: 'yarn' }],
+          status: 'conflicted',
+        },
+        files: { 'package.json': JSON.stringify({ ...packageJson, packageManager: 'npm@11.0.0' }), 'yarn.lock': '' },
+        manager: undefined,
+        name: 'conflicting declaration and lockfile',
+        scriptKeys: ['test'],
+      },
+      {
+        commands: [],
+        evidence: {
+          candidates: ['npm', 'pnpm'],
+          lockfiles: [
+            { file: 'package-lock.json', manager: 'npm' },
+            { file: 'pnpm-lock.yaml', manager: 'pnpm' },
+          ],
+          status: 'conflicted',
+        },
+        files: { 'package-lock.json': '{}', 'package.json': JSON.stringify(packageJson), 'pnpm-lock.yaml': '' },
+        manager: undefined,
+        name: 'multiple package-manager lockfiles',
+        scriptKeys: ['test'],
+      },
+    ] as const
+
+    for (const entry of cases) {
+      const root = createRoot()
+      for (const [path, content] of Object.entries(entry.files)) {
+        writeFileSync(join(root, path), content)
+      }
+
+      const result = api.initEncephalon({ root })
+      const architecture = generatedPayload(result.recordsCreated, 'encephalon:init/tooling-layout')
+      const workflow = generatedPayload(result.recordsCreated, 'encephalon:init/commands-ci')
+
+      assert.deepEqual(architecture.packageManagerEvidence, entry.evidence, entry.name)
+      assert.equal(architecture.packageManager, entry.manager, entry.name)
+      assert.deepEqual(workflow.scriptKeys, entry.scriptKeys, entry.name)
+      assert.deepEqual(workflow.commands, entry.commands, entry.name)
+    }
+  })
+
+  test('refreshes generated records when package-manager evidence changes', () => {
+    const root = createRoot()
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({
+        name: 'sample-project',
+        scripts: { test: 'node --test' },
+      }),
+    )
+
+    api.initEncephalon({ root })
+    writeFileSync(join(root, 'package-lock.json'), '{}')
+
+    const refreshed = api.initEncephalon({ refreshBaseline: true, root })
+    assert.deepEqual(
+      refreshed.recordsCreated.map(record => record.subject).sort((left, right) => left.localeCompare(right)),
+      ['encephalon:init/commands-ci', 'encephalon:init/repository-overview', 'encephalon:init/tooling-layout'],
+    )
+    const architecture = generatedPayload(refreshed.recordsCreated, 'encephalon:init/tooling-layout')
+    const workflow = generatedPayload(refreshed.recordsCreated, 'encephalon:init/commands-ci')
+    assert.equal(architecture.packageManager, 'npm')
+    assert.deepEqual(workflow.commands, ['npm run test'])
   })
 
   test('skips a reserved subject owned by an agent-authored active record', () => {


### PR DESCRIPTION
## Human summary

Generated baselines no longer claim npm unless a package-manager declaration or recognised lockfile supports it.

## Summary

- Replace the unconditional npm fallback with explicit package-manager evidence states: `unknown`, `declared`, `lockfile-derived`, `declared-and-lockfile`, and `conflicted`.
- Keep `packageManager` and derived script commands only when the evidence identifies one unambiguous manager.
- Preserve safe script keys even when the manager is unknown or conflicted, while omitting shell-like command strings in those cases.
- Surface declaration and lockfile conflicts deterministically through `packageManagerEvidence`.
- Document the new evidence contract in the implementation plan.
- Add init coverage for non-JavaScript repositories, package-only JavaScript repositories, every supported lockfile, declaration-only and matching declaration cases, conflicting declaration/lockfile evidence, multiple lockfiles, and baseline refresh after package-manager evidence changes.
