### PR TITLE
[MAR-2536] Replace the CLI parser

### DIFF
--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -215,14 +215,73 @@ try {
     ],
     consumer,
   )
-  const prepared = JSON.parse(
-    run(
-      ['node', resolve(consumer, 'node_modules', 'encephalon', 'dist', 'cli.mjs'), '--root', consumer, 'prepare'],
-      consumer,
-    ),
-  ) as { hydrated?: unknown; recordsIndexed?: unknown }
+  const installedCli = resolve(consumer, 'node_modules', 'encephalon', 'dist', 'cli.mjs')
+  const cli = (arguments_: string[]) => run(['node', installedCli, ...arguments_], consumer)
+  const cliJson = (arguments_: string[]) => JSON.parse(cli(arguments_)) as unknown
+
+  if (!/^Usage: encephalon/m.test(cli(['--help'])) || cli(['--version']) !== '0.1.0\n') {
+    throw new Error('The packed Node-only CLI help/version contract failed.')
+  }
+
+  const prepared = cliJson(['--root', consumer, 'prepare']) as { hydrated?: unknown; recordsIndexed?: unknown }
   if (prepared.hydrated !== true || prepared.recordsIndexed !== 0) {
-    throw new Error('The packed Node-only CLI smoke test returned an unexpected result.')
+    throw new Error('The packed Node-only CLI prepare command returned an unexpected result.')
+  }
+  const initialised = cliJson(['init', '--root', consumer]) as { recordsCreated?: unknown }
+  if (!Array.isArray(initialised.recordsCreated) || initialised.recordsCreated.length !== 3) {
+    throw new Error('The packed Node-only CLI init command returned an unexpected result.')
+  }
+  const added = cliJson([
+    'add',
+    '--root',
+    consumer,
+    '--id',
+    'packed-cli-record',
+    '--kind',
+    'decision',
+    '--subject',
+    'packed.cli',
+    '--source',
+    'package-contract',
+    '--data',
+    '{"summary":"Packed CLI record"}',
+    '--text',
+    'packed-contract-marker',
+  ]) as { id?: unknown }
+  if (added.id !== 'packed-cli-record') {
+    throw new Error('The packed Node-only CLI add command returned an unexpected result.')
+  }
+  const hydrated = cliJson(['hydrate', '--root', consumer]) as { recordsIndexed?: unknown }
+  if (hydrated.recordsIndexed !== 4) {
+    throw new Error('The packed Node-only CLI hydrate command returned an unexpected result.')
+  }
+  const validated = cliJson(['validate', '--root', consumer]) as { valid?: unknown }
+  if (validated.valid !== true) {
+    throw new Error('The packed Node-only CLI validate command returned an unexpected result.')
+  }
+  const listed = cliJson(['list', '--root', consumer, '--include-superseded', '--limit=10']) as unknown[]
+  if (!listed.some(record => (record as { id?: unknown }).id === 'packed-cli-record')) {
+    throw new Error('The packed Node-only CLI list command returned an unexpected result.')
+  }
+  const shown = cliJson(['show', '--root', consumer, '--id', 'packed-cli-record']) as { id?: unknown }
+  if (shown.id !== 'packed-cli-record') {
+    throw new Error('The packed Node-only CLI show command returned an unexpected result.')
+  }
+  const searched = cliJson(['search', '--root', consumer, '--compact', '--', 'packed-contract-marker']) as unknown[]
+  if (!searched.some(record => (record as { id?: unknown }).id === 'packed-cli-record')) {
+    throw new Error('The packed Node-only CLI search command returned an unexpected result.')
+  }
+  const gathered = cliJson([
+    'gather',
+    '--root',
+    consumer,
+    '--search',
+    'packed-contract-marker',
+    '--show',
+    'packed-cli-record',
+  ]) as { records?: unknown; searches?: unknown }
+  if (!(Array.isArray(gathered.records) && Array.isArray(gathered.searches))) {
+    throw new Error('The packed Node-only CLI gather command returned an unexpected result.')
   }
 } finally {
   rmSync(temporaryDirectory, { force: true, recursive: true })

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -229,7 +229,7 @@ try {
   const cli = (arguments_: string[]) => run(['node', installedCli, ...arguments_], consumer)
   const cliJson = (arguments_: string[]) => JSON.parse(cli(arguments_)) as unknown
 
-  if (!/^Usage: encephalon/m.test(cli(['--help'])) || cli(['--version']) !== '0.1.0\n') {
+  if (!/^Usage: encephalon/m.test(cli(['--help'])) || cli(['--version']) !== `${packageJson.version}\n`) {
     throw new Error('The packed Node-only CLI help/version contract failed.')
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { parseArgs } from 'node:util'
 import { fail } from './errors.ts'
 import {
   addRecord,
@@ -20,15 +21,17 @@ const VERSION = '0.1.0'
 const HELP = `Usage: encephalon [--root <path>] <command> [options]
 
 Commands:
-  init [--refresh-baseline | --remove]
-  add --kind <kind> --subject <subject> --source <source> --data <json>
+  init [--refresh-baseline] [--remove]
+  add [--id <id>] --kind <kind> --subject <subject> --source <source> --data <json>
+      [--confidence <0..1>] [--text <text>] [--supersedes <id> ...] [--artifact <path> ...]
   prepare
   hydrate
   validate
-  list [--kind <kind>] [--subject <subject>] [--include-superseded]
+  list [--kind <kind>] [--subject <subject>] [--include-superseded] [--limit <1..1000>]
   show --id <id> [--active-only]
-  search <query> [--compact] [--kind <kind>] [--include-superseded]
-  gather [--search <query> ...] [--show <id> ...] [--hydrate]
+  search [--compact] [--kind <kind>] [--include-superseded] [--limit <1..1000>] [--] <query>
+  gather [--search <query> ...] [--show <id> ...] [--hydrate] [--include-superseded]
+         [--kind <kind>] [--limit <1..1000>]
 
 Global options:
   --root <path>   Use this exact Git repository root.
@@ -45,6 +48,7 @@ type ParsedOptions = {
 type CommandResult = {
   value: unknown
   exitCode?: number
+  format?: 'json' | 'text'
 }
 
 const invalid = (message: string, details: Record<string, JsonValue> = {}): never =>
@@ -53,14 +57,18 @@ const invalid = (message: string, details: Record<string, JsonValue> = {}): neve
 const extractRoot = (arguments_: string[]) => {
   const roots: string[] = []
   const remaining: string[] = []
+  let terminated = false
   for (let index = 0; index < arguments_.length; index += 1) {
     const argument = arguments_[index] ?? ''
-    if (argument === '--root') {
+    if (argument === '--') {
+      terminated = true
+      remaining.push(argument)
+    } else if (!terminated && argument === '--root') {
       const value = arguments_[index + 1]
       const requiredValue = value === undefined || value.startsWith('--') ? invalid('--root requires a path.') : value
       roots.push(requiredValue)
       index += 1
-    } else if (argument.startsWith('--root=')) {
+    } else if (!terminated && argument.startsWith('--root=')) {
       roots.push(argument.slice('--root='.length))
     } else {
       remaining.push(argument)
@@ -83,44 +91,71 @@ const parseOptions = (
   const valueOptions = new Set([...(configuration.values ?? []), ...(configuration.repeated ?? [])])
   const repeatedOptions = new Set(configuration.repeated ?? [])
   const flagOptions = new Set(configuration.flags ?? [])
-  const parsed: ParsedOptions = {
-    flags: new Set(),
-    positionals: [],
-    values: new Map(),
+  const options = Object.fromEntries([
+    ...[...valueOptions].map(name => [name, { multiple: repeatedOptions.has(name), type: 'string' }] as const),
+    ...[...flagOptions].map(name => [name, { type: 'boolean' }] as const),
+  ])
+
+  let parsed: ReturnType<typeof parseArgs>
+  try {
+    parsed = parseArgs({
+      allowPositionals: true,
+      args: arguments_,
+      options,
+      strict: true,
+      tokens: true,
+    })
+  } catch (error) {
+    const candidate = error as { code?: unknown; message?: unknown }
+    const message = typeof candidate.message === 'string' ? candidate.message : ''
+    const option = (/option '([^']+)'/i.exec(message)?.[1] ?? 'option').split(' ')[0] ?? 'option'
+    if (candidate.code === 'ERR_PARSE_ARGS_UNKNOWN_OPTION') {
+      invalid(`Unknown option ${option}.`)
+    }
+    if (candidate.code === 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE') {
+      invalid(
+        message.includes('does not take an argument')
+          ? `${option} does not take a value.`
+          : `${option} requires a value.`,
+      )
+    }
+    throw error
   }
 
-  for (let index = 0; index < arguments_.length; index += 1) {
-    const argument = arguments_[index] ?? ''
-    if (argument.startsWith('--')) {
-      const equals = argument.indexOf('=')
-      const name = equals === -1 ? argument.slice(2) : argument.slice(2, equals)
-      if (flagOptions.has(name)) {
-        if (equals !== -1 || parsed.flags.has(name)) {
-          invalid(`--${name} does not take a value and may be supplied once.`)
-        }
-        parsed.flags.add(name)
-      } else if (valueOptions.has(name)) {
-        const value = equals === -1 ? arguments_[index + 1] : argument.slice(equals + 1)
-        const requiredValue =
-          value === undefined || value.length === 0 || (equals === -1 && value.startsWith('--'))
-            ? invalid(`--${name} requires a value.`)
-            : value
-        if (equals === -1) {
-          index += 1
-        }
-        const existing = parsed.values.get(name) ?? []
-        if (!repeatedOptions.has(name) && existing.length > 0) {
-          invalid(`--${name} may be supplied only once.`)
-        }
-        parsed.values.set(name, [...existing, requiredValue])
-      } else {
-        invalid(`Unknown option --${name}.`)
-      }
-    } else {
-      parsed.positionals.push(argument)
+  const seen = new Map<string, number>()
+  for (const token of parsed.tokens ?? []) {
+    if (token.kind === 'option') {
+      seen.set(token.name, (seen.get(token.name) ?? 0) + 1)
     }
   }
-  return parsed
+  for (const [name, count] of seen.entries()) {
+    if (!repeatedOptions.has(name) && count > 1) {
+      invalid(`--${name} may be supplied only once.`)
+    }
+  }
+
+  const result: ParsedOptions = {
+    flags: new Set(),
+    positionals: parsed.positionals,
+    values: new Map(),
+  }
+  for (const name of flagOptions) {
+    if (parsed.values[name] === true) {
+      result.flags.add(name)
+    }
+  }
+  for (const name of valueOptions) {
+    const raw = parsed.values[name]
+    if (raw !== undefined) {
+      const values = (Array.isArray(raw) ? raw : [raw]).filter((value): value is string => typeof value === 'string')
+      const rawCount = Array.isArray(raw) ? raw.length : 1
+      if (values.length !== rawCount || values.some(value => value.length === 0)) {
+        invalid(`--${name} requires a value.`)
+      }
+      result.values.set(name, values)
+    }
+  }
+  return result
 }
 
 const one = (options: ParsedOptions, name: string) => options.values.get(name)?.[0]
@@ -156,13 +191,19 @@ const parsePayload = (value: string) => {
 const rootInput = (root: string | undefined): { root?: string } => (root === undefined ? {} : { root })
 
 const dispatch = (arguments_: string[]): CommandResult => {
-  if (arguments_.includes('--help') || arguments_.includes('-h')) {
-    return { value: HELP }
+  if (arguments_.length === 1 && (arguments_[0] === '--help' || arguments_[0] === '-h')) {
+    return { format: 'text', value: HELP }
   }
-  if (arguments_.includes('--version') || arguments_.includes('-v')) {
-    return { value: `${VERSION}\n` }
+  if (arguments_.length === 1 && (arguments_[0] === '--version' || arguments_[0] === '-v')) {
+    return { format: 'text', value: `${VERSION}\n` }
   }
   const extracted = extractRoot(arguments_)
+  if (extracted.remaining.length === 1 && (extracted.remaining[0] === '--help' || extracted.remaining[0] === '-h')) {
+    return { format: 'text', value: HELP }
+  }
+  if (extracted.remaining.length === 1 && (extracted.remaining[0] === '--version' || extracted.remaining[0] === '-v')) {
+    return { format: 'text', value: `${VERSION}\n` }
+  }
   const [command, ...commandArguments] = extracted.remaining
   if (command === undefined) {
     invalid('A command is required. Use --help for usage.')
@@ -326,13 +367,7 @@ const writeJson = (stream: NodeJS.WriteStream, value: unknown) => {
 export const runCli = (arguments_: string[] = process.argv.slice(2)) => {
   try {
     const result = dispatch(arguments_)
-    if (
-      typeof result.value === 'string' &&
-      (arguments_.includes('--help') ||
-        arguments_.includes('-h') ||
-        arguments_.includes('--version') ||
-        arguments_.includes('-v'))
-    ) {
+    if (result.format === 'text' && typeof result.value === 'string') {
       process.stdout.write(result.value)
     } else {
       writeJson(process.stdout, result.value)

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2,10 +2,12 @@ import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { afterEach, describe, test } from 'node:test'
+import { afterEach, before, describe, test } from 'node:test'
 import { createTestRepository, removeTestRepository } from '../test/helpers.ts'
 
 const roots: string[] = []
+const projectRoot = join(import.meta.dirname, '..')
+const cliPath = join(projectRoot, 'dist', 'cli.mjs')
 
 const createRoot = () => {
   const root = createTestRepository()
@@ -17,18 +19,28 @@ afterEach(() => {
   roots.splice(0).forEach(removeTestRepository)
 })
 
+before(() => {
+  const result = spawnSync('bun', ['run', 'build'], {
+    cwd: projectRoot,
+    encoding: 'utf8',
+  })
+  assert.equal(result.status, 0, result.stderr)
+})
+
 const run = (root: string, arguments_: string[]) =>
-  spawnSync(process.execPath, [join(import.meta.dirname, '..', 'src', 'cli.ts'), ...arguments_], {
+  spawnSync(process.execPath, [cliPath, ...arguments_], {
     cwd: root,
     encoding: 'utf8',
   })
+
+const outputJson = (result: ReturnType<typeof run>) => JSON.parse(result.stdout) as unknown
+const errorJson = (result: ReturnType<typeof run>) => JSON.parse(result.stderr) as { error: { message: string } }
 
 describe('command-line interface', () => {
   test('emits exactly one JSON value for successful commands', () => {
     const root = createRoot()
     const added = run(root, [
-      '--root',
-      root,
+      `--root=${root}`,
       'add',
       '--id',
       'cli-decision',
@@ -45,16 +57,16 @@ describe('command-line interface', () => {
     ])
     assert.equal(added.status, 0)
     assert.equal(added.stderr, '')
-    assert.equal(JSON.parse(added.stdout).id, 'cli-decision')
+    assert.equal((outputJson(added) as { id?: unknown }).id, 'cli-decision')
     assert.equal(added.stdout.endsWith('\n'), true)
 
     const shown = run(root, ['show', '--root', root, '--id', 'missing'])
     assert.equal(shown.status, 0)
-    assert.equal(JSON.parse(shown.stdout), null)
+    assert.equal(outputJson(shown), null)
 
     const searched = run(root, ['search', '--root', root, 'nothing matches'])
     assert.equal(searched.status, 0)
-    assert.deepEqual(JSON.parse(searched.stdout), [])
+    assert.deepEqual(outputJson(searched), [])
   })
 
   test('emits expected failures as structured stderr JSON with exit status 2', () => {
@@ -62,7 +74,7 @@ describe('command-line interface', () => {
     const result = run(root, ['add', '--root', root, '--kind', 'decision'])
     assert.equal(result.status, 2)
     assert.equal(result.stdout, '')
-    assert.deepEqual(JSON.parse(result.stderr), {
+    assert.deepEqual(errorJson(result), {
       error: {
         code: 'INVALID_ARGUMENT',
         details: {},
@@ -80,7 +92,7 @@ describe('command-line interface', () => {
     const result = run(root, ['validate', '--root', root])
     assert.equal(result.status, 2)
     assert.equal(result.stderr, '')
-    assert.equal(JSON.parse(result.stdout).valid, false)
+    assert.equal((outputJson(result) as { valid?: unknown }).valid, false)
   })
 
   test('supports help and version without JSON framing', () => {
@@ -91,5 +103,159 @@ describe('command-line interface', () => {
     const version = run(root, ['--version'])
     assert.equal(version.status, 0)
     assert.equal(version.stdout, '0.1.0\n')
+  })
+
+  test('parses terminators, hyphen-leading queries, and repeated options predictably', () => {
+    const root = createRoot()
+    const first = run(root, [
+      '--root',
+      root,
+      'add',
+      '--id',
+      'help-query',
+      '--kind',
+      'decision',
+      '--subject',
+      'cli.help-query',
+      '--source',
+      'agent',
+      '--data',
+      '{"summary":"Help query"}',
+      '--text',
+      'help version alpha beta',
+    ])
+    assert.equal(first.status, 0)
+
+    const repeatOne = run(root, [
+      'add',
+      '--root',
+      root,
+      '--id',
+      'repeat-one',
+      '--kind',
+      'decision',
+      '--subject',
+      'cli.repeated',
+      '--source',
+      'agent',
+      '--data',
+      '{"summary":"Repeat one"}',
+    ])
+    assert.equal(repeatOne.status, 0)
+    const repeatTwo = run(root, [
+      'add',
+      '--root',
+      root,
+      '--id',
+      'repeat-two',
+      '--kind',
+      'decision',
+      '--subject',
+      'cli.repeated',
+      '--source',
+      'agent',
+      '--data',
+      '{"summary":"Repeat two"}',
+      '--supersedes',
+      'repeat-one',
+    ])
+    assert.equal(repeatTwo.status, 0)
+    mkdirSync(join(root, 'encephalon', '_artifacts', 'decision', 'with-repeated-options'), { recursive: true })
+    writeFileSync(join(root, 'encephalon', '_artifacts', 'decision', 'with-repeated-options', 'first.txt'), 'first')
+    writeFileSync(join(root, 'encephalon', '_artifacts', 'decision', 'with-repeated-options', 'second.txt'), 'second')
+    const repeated = run(root, [
+      'add',
+      '--root',
+      root,
+      '--id',
+      'with-repeated-options',
+      '--kind',
+      'decision',
+      '--subject',
+      'cli.repeated',
+      '--source',
+      'agent',
+      '--data',
+      '{"summary":"Repeated options"}',
+      '--supersedes',
+      'repeat-two',
+      '--supersedes',
+      'repeat-one',
+      '--artifact',
+      '_artifacts/decision/with-repeated-options/first.txt',
+      '--artifact',
+      '_artifacts/decision/with-repeated-options/second.txt',
+    ])
+    assert.equal(repeated.status, 0)
+    const repeatedRecord = outputJson(repeated) as { artifacts?: string[]; supersedes?: string[] }
+    assert.deepEqual(repeatedRecord.supersedes, ['repeat-two', 'repeat-one'])
+    assert.deepEqual(repeatedRecord.artifacts, [
+      '_artifacts/decision/with-repeated-options/first.txt',
+      '_artifacts/decision/with-repeated-options/second.txt',
+    ])
+
+    const helpQuery = run(root, ['search', '--root', root, '--', '--help'])
+    assert.equal(helpQuery.status, 0)
+    assert.deepEqual(
+      (outputJson(helpQuery) as Array<{ id?: unknown }>).map(record => record.id),
+      ['help-query'],
+    )
+
+    const versionQuery = run(root, ['search', '--root', root, '--', '--version'])
+    assert.equal(versionQuery.status, 0)
+    assert.deepEqual(
+      (outputJson(versionQuery) as Array<{ id?: unknown }>).map(record => record.id),
+      ['help-query'],
+    )
+
+    const gathered = run(root, [
+      'gather',
+      '--root',
+      root,
+      '--search',
+      'alpha',
+      '--search=beta',
+      '--show',
+      'missing-a',
+      '--show',
+      'missing-b',
+    ])
+    assert.equal(gathered.status, 0)
+    const payload = outputJson(gathered) as {
+      records: Array<{ id: string }>
+      searches: Array<{ query: string }>
+    }
+    assert.deepEqual(
+      payload.searches.map(search => search.query),
+      ['alpha', 'beta'],
+    )
+    assert.deepEqual(
+      payload.records.map(record => record.id),
+      ['missing-a', 'missing-b'],
+    )
+  })
+
+  test('rejects invalid option forms with stable messages', () => {
+    const root = createRoot()
+    const cases = [
+      { arguments_: ['list', '--root', root, '--unknown'], message: 'Unknown option --unknown.' },
+      {
+        arguments_: ['list', '--root', root, '--kind', 'decision', '--kind', 'context'],
+        message: '--kind may be supplied only once.',
+      },
+      { arguments_: ['list', '--root', root, '--kind='], message: '--kind requires a value.' },
+      {
+        arguments_: ['list', '--root', root, '--include-superseded=true'],
+        message: '--include-superseded does not take a value.',
+      },
+      { arguments_: ['show', '--root', root, '--id', '--missing'], message: '--id requires a value.' },
+      { arguments_: ['list', '--root', root, '--limit=-1'], message: '--limit must be an integer between 1 and 1000.' },
+    ]
+
+    for (const entry of cases) {
+      const result = run(root, entry.arguments_)
+      assert.equal(result.status, 2, entry.message)
+      assert.equal(errorJson(result).error.message, entry.message)
+    }
   })
 })

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -375,7 +375,19 @@ describe('command-line interface', () => {
         message: '--limit requires a value.',
       },
       {
-        arguments_: ['add', '--root', root, '--kind', 'decision', '--subject', '-draft', '--source', 'agent', '--data', '{}'],
+        arguments_: [
+          'add',
+          '--root',
+          root,
+          '--kind',
+          'decision',
+          '--subject',
+          '-draft',
+          '--source',
+          'agent',
+          '--data',
+          '{}',
+        ],
         message: '--subject requires a value.',
       },
     ]


### PR DESCRIPTION
## Human summary

The CLI now uses Node's argument parser, handles `--` correctly, and is tested through the built and packed binary.

## Summary

- Replace the bespoke command parser with a thin `node:util` `parseArgs` layer for command-specific options.
- Preserve `--root` before or after commands while respecting `--` so hyphen-leading search queries remain positional text.
- Scope help/version output to global usage only, so `--help` and `--version` after `--` can be searched normally.
- Add stable validation for unknown options, duplicate singleton options, empty option values, flag values, and ambiguous option values.
- Expand help output to include supported limits, subject filters, gather options, repeated add options, and defaults.
- Run the CLI unit suite against `dist/cli.mjs` instead of source TypeScript.
- Extend the packed tarball check so the installed Node CLI exercises help, version, init, validate, add, prepare, hydrate, list, show, search, and gather.
