### PR TITLE
[MAR-2537] Align declarations with minimum Node runtime

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,7 @@
       "name": "encephalon",
       "devDependencies": {
         "@biomejs/biome": "2.5.6",
-        "@types/bun": "1.3.14",
-        "@types/node": "26.1.2",
+        "@types/node": "24.13.3",
         "typescript": "7.0.2",
         "ultracite": "7.10.1",
       },
@@ -35,9 +34,7 @@
 
     "@clack/prompts": ["@clack/prompts@1.7.0", "", { "dependencies": { "@clack/core": "1.4.3", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A=="],
 
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
-
-    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+    "@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
@@ -82,8 +79,6 @@
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
-
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "citty": ["citty@0.2.2", "", {}, "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w=="],
 
@@ -131,7 +126,7 @@
 
     "ultracite": ["ultracite@7.10.1", "", { "dependencies": { "@clack/prompts": "^1.5.1", "commander": "^15.0.0", "cross-spawn": "^7.0.6", "deepmerge": "^4.3.1", "glob": "^13.0.6", "jsonc-parser": "^3.3.1", "nypm": "^0.6.6", "yaml": "^2.9.0", "zod": "^4.4.3" }, "peerDependencies": { "oxfmt": ">=0.1.0", "oxlint": "^1.0.0" }, "optionalPeers": ["oxfmt", "oxlint"], "bin": { "ultracite": "dist/index.js" } }, "sha512-2WbhHS9+rNsPIfV5kHnuHsvFscvMwLIVsUgvEUnTUP3tFRUBpwWN1wmt2K+A6uecjE3Qv7iUOR6gszXBkrv/qg=="],
 
-    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/package.json
+++ b/package.json
@@ -51,12 +51,11 @@
     "lint": "ultracite check",
     "prepack": "bun run build && bun run check:package",
     "test": "node --test test/*.test.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --project tsconfig.src.json --noEmit && tsc --project tsconfig.scripts.json --noEmit && tsc --project tsconfig.test.json --noEmit && tsc --project tsconfig.runtime-guard.json --noEmit"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.6",
-    "@types/bun": "1.3.14",
-    "@types/node": "26.1.2",
+    "@types/node": "24.13.3",
     "typescript": "7.0.2",
     "ultracite": "7.10.1"
   }

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,7 +1,8 @@
 import { chmodSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const root = resolve(import.meta.dir, '..')
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const outputDirectory = resolve(root, 'dist')
 
 rmSync(outputDirectory, { force: true, recursive: true })

--- a/scripts/bun-runtime.d.ts
+++ b/scripts/bun-runtime.d.ts
@@ -1,0 +1,20 @@
+declare const Bun: {
+  build: (input: {
+    entrypoints: string[]
+    format: 'esm'
+    minify: boolean
+    naming: string
+    outdir: string
+    sourcemap: 'none'
+    splitting: boolean
+    target: 'node'
+  }) => Promise<{
+    logs: unknown[]
+    success: boolean
+  }>
+  spawnSync: (input: { cmd: string[]; cwd: string; stderr: 'inherit' | 'pipe'; stdout: 'inherit' | 'pipe' }) => {
+    exitCode: number | null
+    stderr: Buffer
+    stdout: Buffer
+  }
+}

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -9,10 +9,11 @@ import {
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { gunzipSync } from 'node:zlib'
 
-const root = resolve(import.meta.dir, '..')
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const temporaryDirectory = mkdtempSync(join(tmpdir(), 'encephalon-package-check-'))
 
 const run = (command: string[], cwd = root) => {

--- a/scripts/check-publish.ts
+++ b/scripts/check-publish.ts
@@ -1,6 +1,7 @@
-import { resolve } from 'node:path'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const root = resolve(import.meta.dir, '..')
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const command = ['npm', 'publish', '--dry-run', '--ignore-scripts', '--access', 'public', '--json']
 
 const result = Bun.spawnSync({

--- a/test/types/runtime-node24.guard.ts
+++ b/test/types/runtime-node24.guard.ts
@@ -1,0 +1,4 @@
+// @ts-expect-error Node 26-only modules must not be available to runtime source typechecking.
+import type { dlopen } from 'node:ffi'
+
+export type Node26OnlyRuntimeApi = typeof dlopen

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "exactOptionalPropertyTypes": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2024"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "strict": true,
+    "target": "ES2024"
+  }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
-	"extends": "./tsconfig.json",
+	"extends": "./tsconfig.src.json",
 	"compilerOptions": {
 		"declaration": true,
 		"declarationDir": "./dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,9 @@
 {
-	"compilerOptions": {
-		"allowImportingTsExtensions": true,
-		"declaration": true,
-		"declarationDir": "dist",
-		"emitDeclarationOnly": true,
-		"exactOptionalPropertyTypes": true,
-		"forceConsistentCasingInFileNames": true,
-		"lib": ["ES2024"],
-		"module": "NodeNext",
-		"moduleResolution": "NodeNext",
-		"noEmit": true,
-		"noFallthroughCasesInSwitch": true,
-		"noImplicitOverride": true,
-		"noUncheckedIndexedAccess": true,
-		"strict": true,
-		"target": "ES2024",
-		"types": ["bun", "node"]
-	},
-	"include": ["scripts/**/*.ts", "src/**/*.ts", "test/**/*.ts"]
+	"files": [],
+	"references": [
+		{ "path": "./tsconfig.src.json" },
+		{ "path": "./tsconfig.scripts.json" },
+		{ "path": "./tsconfig.test.json" },
+		{ "path": "./tsconfig.runtime-guard.json" }
+	]
 }

--- a/tsconfig.runtime-guard.json
+++ b/tsconfig.runtime-guard.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.src.json",
+  "include": ["test/types/runtime-node24.guard.ts"]
+}

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["scripts/**/*.d.ts", "scripts/**/*.ts"]
+}

--- a/tsconfig.src.json
+++ b/tsconfig.src.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["test/**/*.ts"]
+}


### PR DESCRIPTION
## Human summary

Keeps TypeScript checking aligned with the supported Node 24 runtime so the library cannot accidentally rely on newer Node-only declarations.

## Summary

- Pins `@types/node` to the Node 24 declaration line and removes ambient Bun types from project-wide typechecking.
- Splits typechecking into source, scripts, tests, and a runtime guard so runtime code only sees Node declarations while build scripts keep a narrow local Bun surface.
- Replaces script-only `import.meta.dir` usage with Node URL/path helpers.
- Adds a guard that fails if Node 26-only declarations, such as `node:ffi`, become visible to runtime source typechecking.
