### PR TITLE
[MAR-2539] Correct README privacy and asset claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ npm install --save-dev encephalon
 npx --no-install encephalon init
 ```
 
-`init` safely scans derived repository metadata, creates up to three baseline records, builds the local cache, and adds a reversible managed block to root `AGENTS.md` and `CLAUDE.md`. It never reads source bodies, instruction-file text, README content, environment files, registry configuration, Git history, Git remotes, or CI workflow contents.
+`init` safely derives bounded repository metadata, creates up to three baseline records, builds the local cache, and adds a reversible managed block to root `AGENTS.md` and `CLAUDE.md`. For baseline records, it reads only bounded `package.json` fields such as package name, package manager, workspace globs, and script keys. It enumerates safe top-level names, recognised package/config filenames, source file extensions for language counts, and workflow YAML filenames.
+
+`init` reads root `AGENTS.md` and `CLAUDE.md` byte-for-byte only to preserve, replace, or remove the managed Encephalon block safely. Unrelated instruction text is not semantically scanned, stored in generated records, indexed for search, printed to stdout, or included in error details. `init` does not read source bodies, README content, environment files, registry configuration, Git history, Git remotes, or CI workflow contents.
 
 The result includes a `nextAction` asking an agent to read the installed skill and optionally enrich the baseline semantically.
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "files": [
     "dist",
     "skills",
+    "assets/encephalon.png",
     "README.md",
     "LICENSE"
   ],

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -36,6 +36,24 @@ const collectFiles = (directory: string): string[] =>
     return entry.isDirectory() ? collectFiles(path) : [path]
   })
 
+const readmeReferences = (content: string) => {
+  const pattern = /(?:!?\[[^\]]*]\(([^)]+)\)|<img\b[^>]*\bsrc=["']([^"']+)["'])/gi
+  return [...content.matchAll(pattern)]
+    .map(match => match[1] ?? match[2] ?? '')
+    .map(reference => reference.trim())
+    .filter(
+      reference =>
+        reference.length > 0 &&
+        !reference.startsWith('#') &&
+        !reference.startsWith('/') &&
+        !/^[a-z][a-z0-9+.-]*:/i.test(reference),
+    )
+    .map(reference => {
+      const [path = ''] = reference.split(/[?#]/u, 1)
+      return path.startsWith('./') ? path.slice(2) : path
+    })
+}
+
 const packedMode = (tarball: string, expectedPath: string) => {
   const archive = gunzipSync(readFileSync(tarball))
   const field = (fieldOffset: number, fieldLength: number) =>
@@ -86,7 +104,8 @@ try {
       JSON.stringify({
         '.': { import: './dist/index.mjs', types: './dist/index.d.ts' },
       }) ||
-    JSON.stringify(packageJson.files) !== JSON.stringify(['dist', 'skills', 'README.md', 'LICENSE']) ||
+    JSON.stringify(packageJson.files) !==
+      JSON.stringify(['dist', 'skills', 'assets/encephalon.png', 'README.md', 'LICENSE']) ||
     packageJson.dependencies !== undefined
   ) {
     throw new Error('Package identity, exports, engine, files, or zero-runtime-dependency contract is invalid.')
@@ -101,6 +120,7 @@ try {
     'dist/index.mjs',
     'dist/index.d.ts',
     'skills/encephalon/SKILL.md',
+    'assets/encephalon.png',
     'README.md',
     'LICENSE',
   ]
@@ -146,12 +166,19 @@ try {
   if (pack === undefined) {
     throw new Error('npm pack did not return package metadata.')
   }
-  const allowedRootFiles = new Set(['LICENSE', 'README.md', 'package.json'])
+  const allowedFiles = new Set(['LICENSE', 'README.md', 'assets/encephalon.png', 'package.json'])
   const unexpected = pack.files
     .map(file => file.path)
-    .filter(path => !(allowedRootFiles.has(path) || path.startsWith('dist/') || path.startsWith('skills/')))
+    .filter(path => !(allowedFiles.has(path) || path.startsWith('dist/') || path.startsWith('skills/')))
   if (unexpected.length > 0) {
     throw new Error(`The tarball contains unexpected files: ${unexpected.join(', ')}`)
+  }
+  const packedPaths = new Set(pack.files.map(file => file.path))
+  const missingReadmeReferences = readmeReferences(readFileSync(resolve(root, 'README.md'), 'utf8')).filter(
+    path => !packedPaths.has(path),
+  )
+  if (missingReadmeReferences.length > 0) {
+    throw new Error(`The packed README references missing files: ${missingReadmeReferences.join(', ')}`)
   }
   const tarball = resolve(temporaryDirectory, pack.filename)
   const packedCli = pack.files.find(file => file.path === 'dist/cli.mjs')

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
 import {
   chmodSync,
   closeSync,
@@ -26,6 +27,12 @@ const createRoot = () => {
   roots.push(root)
   return root
 }
+
+const runCli = (root: string, arguments_: string[]) =>
+  spawnSync(process.execPath, [join(import.meta.dirname, '..', 'src', 'cli.ts'), ...arguments_], {
+    cwd: root,
+    encoding: 'utf8',
+  })
 
 afterEach(() => {
   roots.splice(0).forEach(removeTestRepository)
@@ -93,6 +100,29 @@ describe('initialisation', () => {
       records.every(record => existsSync(join(root, record.path))),
       true,
     )
+  })
+
+  test('does not persist or print unrelated instruction-file content', () => {
+    const root = createRoot()
+    const sentinel = 'PRIVATE_INSTRUCTION_SENTINEL_do_not_store'
+    writeFileSync(join(root, 'AGENTS.md'), `# Agent notes\n${sentinel}\n`)
+    writeFileSync(join(root, 'CLAUDE.md'), `# Claude notes\n${sentinel}\n`)
+
+    const initialized = runCli(root, ['--root', root, 'init'])
+    assert.equal(initialized.status, 0)
+    assert.equal(initialized.stderr, '')
+    assert.doesNotMatch(initialized.stdout, new RegExp(sentinel))
+
+    const records = api.listRecords({ includeSuperseded: true, limit: 20, root })
+    assert.doesNotMatch(JSON.stringify(records), new RegExp(sentinel))
+    assert.deepEqual(api.searchRecords({ query: sentinel, root }), [])
+
+    writeFileSync(join(root, 'AGENTS.md'), `${sentinel}\n<!-- encephalon:managed-instructions:start invalid -->\n`)
+    const failed = runCli(root, ['--root', root, 'init'])
+    assert.equal(failed.status, 2)
+    assert.equal(failed.stdout, '')
+    assert.doesNotMatch(failed.stderr, new RegExp(sentinel))
+    assert.equal(JSON.parse(failed.stderr).error.code, 'VALIDATION_FAILED')
   })
 
   test('is idempotent and refreshes only changed generated facts by superseding the active head', () => {


### PR DESCRIPTION
## Human summary

Corrects the README privacy and image packaging claims so users can trust what `init` reads and the packaged README renders its local image.

## Summary

- Replaces the inaccurate README privacy sentence with the implemented boundary for baseline scanning and managed instruction-file reads.
- Includes `assets/encephalon.png` in the npm tarball whitelist so the packaged README image resolves locally.
- Extends `check:package` to assert repository-relative README references resolve inside the packed tarball.
- Adds an init fixture proving unrelated instruction-file content is not stored in generated records, indexed for search, printed to stdout, or leaked in structured error details.

Verification:
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`
- `bun run check:package`
