### PR TITLE
[MAR-2528] Sort directory entries before applying scan caps

### DIFF
--- a/src/baseline.ts
+++ b/src/baseline.ts
@@ -195,23 +195,37 @@ const readPackageFacts = (root: string): PackageFacts => {
   return { scriptKeys: [], workspacePatterns: [] }
 }
 
-const readBoundedDirectoryEntries = (directory: string) => {
-  const accepted = readdirSync(directory, { withFileTypes: true })
-    .filter(entry => {
-      const excludedDirectory = entry.isDirectory() && EXCLUDED_DIRECTORIES.has(entry.name.toLowerCase())
-      return (
-        safeName(entry.name) &&
-        !entry.isSymbolicLink() &&
-        !EXCLUDED_FILES.has(entry.name.toLowerCase()) &&
-        !excludedDirectory
-      )
-    })
-    .sort((first, second) => first.name.localeCompare(second.name))
+const compareEntryNames = (first: string, second: string) => {
+  if (first < second) {
+    return -1
+  }
+  if (first > second) {
+    return 1
+  }
+  return 0
+}
+
+export const selectBoundedDirectoryEntries = <T extends { name: string }>(
+  entries: readonly T[],
+  isAccepted: (entry: T) => boolean,
+) => {
+  const accepted = entries.filter(isAccepted).sort((first, second) => compareEntryNames(first.name, second.name))
   return {
     entries: accepted.slice(0, MAX_DIRECTORY_ENTRIES),
     truncated: accepted.length > MAX_DIRECTORY_ENTRIES,
   }
 }
+
+const readBoundedDirectoryEntries = (directory: string) =>
+  selectBoundedDirectoryEntries(readdirSync(directory, { withFileTypes: true }), entry => {
+    const excludedDirectory = entry.isDirectory() && EXCLUDED_DIRECTORIES.has(entry.name.toLowerCase())
+    return (
+      safeName(entry.name) &&
+      !entry.isSymbolicLink() &&
+      !EXCLUDED_FILES.has(entry.name.toLowerCase()) &&
+      !excludedDirectory
+    )
+  })
 
 const scanLanguages = (root: string) => {
   const initial: ScanState = {

--- a/src/baseline.ts
+++ b/src/baseline.ts
@@ -1,14 +1,4 @@
-import {
-  closeSync,
-  constants,
-  type Dirent,
-  fstatSync,
-  lstatSync,
-  opendirSync,
-  openSync,
-  readdirSync,
-  readFileSync,
-} from 'node:fs'
+import { closeSync, constants, fstatSync, lstatSync, openSync, readdirSync, readFileSync } from 'node:fs'
 import { extname, resolve } from 'node:path'
 import type { AddRecordInput, JsonValue } from './types.ts'
 
@@ -206,32 +196,20 @@ const readPackageFacts = (root: string): PackageFacts => {
 }
 
 const readBoundedDirectoryEntries = (directory: string) => {
-  const retained: Dirent[] = []
-  let truncated = false
-  const handle = opendirSync(directory)
-  try {
-    for (let entry = handle.readSync(); entry !== null; entry = handle.readSync()) {
+  const accepted = readdirSync(directory, { withFileTypes: true })
+    .filter(entry => {
       const excludedDirectory = entry.isDirectory() && EXCLUDED_DIRECTORIES.has(entry.name.toLowerCase())
-      const acceptable =
+      return (
         safeName(entry.name) &&
         !entry.isSymbolicLink() &&
         !EXCLUDED_FILES.has(entry.name.toLowerCase()) &&
         !excludedDirectory
-      if (acceptable) {
-        if (retained.length < MAX_DIRECTORY_ENTRIES) {
-          retained.push(entry)
-        } else {
-          truncated = true
-          break
-        }
-      }
-    }
-  } finally {
-    handle.closeSync()
-  }
+      )
+    })
+    .sort((first, second) => first.name.localeCompare(second.name))
   return {
-    entries: retained.sort((first, second) => first.name.localeCompare(second.name)),
-    truncated,
+    entries: accepted.slice(0, MAX_DIRECTORY_ENTRIES),
+    truncated: accepted.length > MAX_DIRECTORY_ENTRIES,
   }
 }
 

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -17,6 +17,7 @@ import {
 } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { afterEach, describe, test } from 'node:test'
+import { selectBoundedDirectoryEntries } from '../src/baseline.ts'
 import * as api from '../src/index.ts'
 import { applyInstructionChanges, planInstructionChanges } from '../src/instructions.ts'
 import type { BrainRecord, BrainRecordFile } from '../src/types.ts'
@@ -461,27 +462,22 @@ describe('initialisation', () => {
     ])
   })
 
-  test('applies directory entry caps after sorting so truncation is deterministic', () => {
-    const root = createRoot()
-    for (let index = 0; index < 300; index += 1) {
-      writeFileSync(join(root, `z-${String(index).padStart(3, '0')}.py`), 'pass\n')
-      writeFileSync(join(root, `a-${String(index).padStart(3, '0')}.ts`), 'export {}\n')
-    }
+  test('selects directory entry caps from sorted names regardless of input order', () => {
+    const reverseGroupOrder = [
+      ...Array.from({ length: 300 }, (_, index) => ({ name: `z-${String(index).padStart(3, '0')}.py` })),
+      ...Array.from({ length: 300 }, (_, index) => ({ name: `a-${String(index).padStart(3, '0')}.ts` })),
+    ]
+    const { entries, truncated } = selectBoundedDirectoryEntries(reverseGroupOrder, () => true)
 
-    api.initEncephalon({ root })
-    const overview = generatedRecord(root, 'encephalon:init/repository-overview')
-    const payload = overview.payload as {
-      languageCounts?: Array<{ files: number; language: string }>
-      scannedRegularFiles?: unknown
-      scanTruncationReasons?: unknown
-    }
-
-    assert.equal(payload.scannedRegularFiles, 512)
-    assert.deepEqual(payload.scanTruncationReasons, ['directory-entry-limit'])
-    assert.deepEqual(payload.languageCounts, [
-      { files: 212, language: 'Python' },
-      { files: 300, language: 'TypeScript' },
-    ])
+    assert.equal(truncated, true)
+    assert.equal(entries.length, 512)
+    assert.deepEqual(
+      entries.map(entry => entry.name),
+      [
+        ...Array.from({ length: 300 }, (_, index) => `a-${String(index).padStart(3, '0')}.ts`),
+        ...Array.from({ length: 212 }, (_, index) => `z-${String(index).padStart(3, '0')}.py`),
+      ],
+    )
   })
 
   test('bounds baseline scanner depth without following deep chains forever', () => {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -461,6 +461,29 @@ describe('initialisation', () => {
     ])
   })
 
+  test('applies directory entry caps after sorting so truncation is deterministic', () => {
+    const root = createRoot()
+    for (let index = 0; index < 300; index += 1) {
+      writeFileSync(join(root, `z-${String(index).padStart(3, '0')}.py`), 'pass\n')
+      writeFileSync(join(root, `a-${String(index).padStart(3, '0')}.ts`), 'export {}\n')
+    }
+
+    api.initEncephalon({ root })
+    const overview = generatedRecord(root, 'encephalon:init/repository-overview')
+    const payload = overview.payload as {
+      languageCounts?: Array<{ files: number; language: string }>
+      scannedRegularFiles?: unknown
+      scanTruncationReasons?: unknown
+    }
+
+    assert.equal(payload.scannedRegularFiles, 512)
+    assert.deepEqual(payload.scanTruncationReasons, ['directory-entry-limit'])
+    assert.deepEqual(payload.languageCounts, [
+      { files: 212, language: 'Python' },
+      { files: 300, language: 'TypeScript' },
+    ])
+  })
+
   test('bounds baseline scanner depth without following deep chains forever', () => {
     const root = createRoot()
     let current = root


### PR DESCRIPTION
## Summary
- Fixes the follow-up Pullfrog finding on #25: directory entry caps are applied after sorting accepted names, so truncation under `MAX_DIRECTORY_ENTRIES` is deterministic across filesystems.
- Adds a regression that mixes lexicographically early TypeScript files with late Python files and asserts stable `languageCounts` after truncation.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test`
- [x] `bun run build`
- [x] `bun run check:package`