### PR TITLE
[MAR-2541] Deflake instruction replacement identity checks

### DIFF
--- a/encephalon/workflow/12e39f12-151a-4fa9-b6c5-afb5b285b591.json
+++ b/encephalon/workflow/12e39f12-151a-4fa9-b6c5-afb5b285b591.json
@@ -1,0 +1,18 @@
+{
+  "createdAt": "2026-08-08T23:58:40.865Z",
+  "id": "12e39f12-151a-4fa9-b6c5-afb5b285b591",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Regression tests that simulate old and new identity shapes must preserve the runtime type shape they are exercising.",
+    "lessons": [
+      "When a review notes that a test passes on the old implementation for the wrong reason, adjust the test so it preserves the old runtime shape as well as the new one.",
+      "For deterministic simulations of filesystem identity collisions, fake only the file-key fields under test and preserve all other identity fields field-by-field or via a clearly typed full-shape helper.",
+      "Do not let TypeScript casts hide runtime type asymmetries in tests that are meant to prove red-green behaviour."
+    ],
+    "verification": [
+      "Before replying to review feedback about a regression test, rerun the focused test and ensure the code explains why the simulated shape matches the intended failure mode."
+    ]
+  },
+  "source": "agent",
+  "subject": "review.runtime-shape-regressions"
+}

--- a/encephalon/workflow/6d42b754-55d7-49b5-8fe0-9c4ba63434a8.json
+++ b/encephalon/workflow/6d42b754-55d7-49b5-8fe0-9c4ba63434a8.json
@@ -1,0 +1,19 @@
+{
+  "createdAt": "2026-08-08T23:49:18.840Z",
+  "id": "6d42b754-55d7-49b5-8fe0-9c4ba63434a8",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Instruction-file replacement checks must not rely only on dev/inode plus bytes because CI filesystems can immediately reuse inode identities for byte-identical replacements.",
+    "lessons": [
+      "For safety checks that must distinguish a planned file from a later replacement, capture nanosecond stat metadata in addition to dev and ino.",
+      "Separate pre-rename identity checks from post-rename quarantine checks: ctime can change during a legitimate rename, so post-rename comparisons should use only rename-stable identity fields plus bytes.",
+      "When a flake reports a missing expected REPOSITORY_CHANGED exception, add a deterministic regression that simulates the filesystem collision rather than relying on the local filesystem to reproduce it."
+    ],
+    "verification": [
+      "Before committing identity-related flake fixes, run the affected node --test name pattern and the full init test file.",
+      "Verify Encephalon state after adding the learning record."
+    ]
+  },
+  "source": "agent",
+  "subject": "review.inode-reuse-file-identity"
+}

--- a/encephalon/workflow/9f1cd11c-1505-4803-a6e1-1bc3891914aa.json
+++ b/encephalon/workflow/9f1cd11c-1505-4803-a6e1-1bc3891914aa.json
@@ -1,0 +1,21 @@
+{
+  "createdAt": "2026-08-09T00:19:56.450Z",
+  "id": "9f1cd11c-1505-4803-a6e1-1bc3891914aa",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Regression tests that simulate filesystem identity collisions should preserve runtime identity shape and make metadata differences deterministic.",
+    "lessons": [
+      "When a review notes that a test passes on the old implementation for the wrong reason, adjust the test so it preserves the old runtime shape as well as the new one.",
+      "When preserving old and new identity runtime shapes in one test, explicitly model both shapes and mutate only the fields that simulate the collision.",
+      "Set file timestamps before planning and after replacement when timestamp metadata is part of the expected rejection path, so the test does not depend on filesystem timing or write granularity.",
+      "Use byte assertions for byte-identical replacement tests to avoid accidental text transcoding in the test itself."
+    ],
+    "verification": [
+      "Before replying to review feedback about a regression test, rerun the focused test and ensure the code explains why the simulated shape matches the intended failure mode.",
+      "Run the focused regression test after deterministic timestamp setup and before committing the review response."
+    ]
+  },
+  "source": "agent",
+  "subject": "review.runtime-shape-regressions",
+  "supersedes": ["12e39f12-151a-4fa9-b6c5-afb5b285b591"]
+}

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import type { Stats } from 'node:fs'
+import type { BigIntStats } from 'node:fs'
 import {
   chmodSync,
   closeSync,
@@ -43,9 +43,15 @@ type FilePlan = {
 }
 
 type FileIdentity = {
-  dev: number
-  ino: number
+  birthtimeNs: string
+  ctimeNs: string
+  dev: string
+  ino: string
+  mtimeNs: string
+  size: string
 }
+
+type StableFileIdentity = Omit<FileIdentity, 'ctimeNs'>
 
 const ALLOWED_SEPARATORS = new Set(['', '\n', '\n\n', '\r\n', '\r\n\r\n'])
 const MODE_BITS = 0o7777
@@ -54,13 +60,19 @@ const noFollowFlag = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFO
 const directoryFlag = typeof constants.O_DIRECTORY === 'number' ? constants.O_DIRECTORY : 0
 const utf8Decoder = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true })
 
-const identityFor = (metadata: Stats): FileIdentity => ({
-  dev: metadata.dev,
-  ino: metadata.ino,
+const identityFor = (metadata: BigIntStats): FileIdentity => ({
+  birthtimeNs: metadata.birthtimeNs.toString(),
+  ctimeNs: metadata.ctimeNs.toString(),
+  dev: metadata.dev.toString(),
+  ino: metadata.ino.toString(),
+  mtimeNs: metadata.mtimeNs.toString(),
+  size: metadata.size.toString(),
 })
 
-const sameIdentity = (left: FileIdentity | undefined, right: FileIdentity) =>
-  left !== undefined && left.dev === right.dev && left.ino === right.ino
+const stableIdentity = ({ ctimeNs: _ctimeNs, ...identity }: FileIdentity): StableFileIdentity => identity
+
+const sameIdentity = <Identity extends Record<string, string>>(left: Identity | undefined, right: Identity) =>
+  left !== undefined && Object.entries(right).every(([key, value]) => left[key] === value)
 
 const lstatIfExists = (path: string) => {
   try {
@@ -71,6 +83,33 @@ const lstatIfExists = (path: string) => {
     }
     throw error
   }
+}
+
+const lstatIdentityIfExists = (path: string) => {
+  try {
+    return lstatSync(path, { bigint: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return
+    }
+    throw error
+  }
+}
+
+const identityForPath = (path: string) => {
+  const metadata = lstatIdentityIfExists(path)
+  if (metadata === undefined) {
+    return
+  }
+  return identityFor(metadata)
+}
+
+const requiredIdentityForPath = (path: string, filename: (typeof FILENAMES)[number]) => {
+  const identity = identityForPath(path)
+  if (identity === undefined) {
+    return fail('REPOSITORY_CHANGED', `${filename} changed after it was preflighted.`)
+  }
+  return identity
 }
 
 const encodeMetadata = (metadata: BlockMetadata) => Buffer.from(JSON.stringify(metadata), 'utf8').toString('base64url')
@@ -230,7 +269,7 @@ const additionPlan = (root: string, filename: (typeof FILENAMES)[number]): FileP
       originalBytes,
       originalContent: content,
       originalFileExisted: existed,
-      ...(existingMetadata === undefined ? {} : { originalIdentity: identityFor(existingMetadata) }),
+      ...(existingMetadata === undefined ? {} : { originalIdentity: requiredIdentityForPath(path, filename) }),
     }
   }
   const lineEnding = lineEndingFor(content)
@@ -252,7 +291,7 @@ const additionPlan = (root: string, filename: (typeof FILENAMES)[number]): FileP
     contentBytes: nextBytes,
     filename,
     originalBytes,
-    ...(existingMetadata === undefined ? {} : { originalIdentity: identityFor(existingMetadata) }),
+    ...(existingMetadata === undefined ? {} : { originalIdentity: requiredIdentityForPath(path, filename) }),
     originalContent: content,
     originalFileExisted: existed,
   }
@@ -283,7 +322,7 @@ const removalPlan = (root: string, filename: (typeof FILENAMES)[number]): FilePl
       originalBytes,
       originalContent: content,
       originalFileExisted: true,
-      originalIdentity: identityFor(fileMetadata),
+      originalIdentity: requiredIdentityForPath(path, filename),
     }
   }
   const contentWithoutBlock = `${content.slice(0, installed.start - installed.separator.length)}${content.slice(installed.end)}`
@@ -294,7 +333,7 @@ const removalPlan = (root: string, filename: (typeof FILENAMES)[number]): FilePl
       originalBytes,
       originalContent: content,
       originalFileExisted: true,
-      originalIdentity: identityFor(fileMetadata),
+      originalIdentity: requiredIdentityForPath(path, filename),
     }
   }
   const nextBytes = Buffer.from(contentWithoutBlock, 'utf8')
@@ -306,7 +345,7 @@ const removalPlan = (root: string, filename: (typeof FILENAMES)[number]): FilePl
     originalBytes,
     originalContent: content,
     originalFileExisted: true,
-    originalIdentity: identityFor(fileMetadata),
+    originalIdentity: requiredIdentityForPath(path, filename),
   }
 }
 
@@ -440,12 +479,26 @@ const restoreQuarantinedFile = (path: string, quarantinePath: string, hooks: Ato
   }
 }
 
-const assertQuarantinedDeleteTarget = (quarantinePath: string, plan: FilePlan) => {
-  const metadata = lstatIfExists(quarantinePath)
+const assertOriginalDeleteTarget = (path: string, plan: FilePlan) => {
+  const metadata = lstatIdentityIfExists(path)
   if (metadata === undefined || metadata.isSymbolicLink() || !metadata.isFile()) {
     return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
   }
   if (!sameIdentity(plan.originalIdentity, identityFor(metadata))) {
+    return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
+  }
+  if (!readRegularFileBytes(path, plan.filename).equals(plan.originalBytes)) {
+    return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
+  }
+}
+
+const assertQuarantinedDeleteTarget = (quarantinePath: string, plan: FilePlan) => {
+  const metadata = lstatIdentityIfExists(quarantinePath)
+  if (metadata === undefined || metadata.isSymbolicLink() || !metadata.isFile()) {
+    return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
+  }
+  const originalIdentity = plan.originalIdentity === undefined ? undefined : stableIdentity(plan.originalIdentity)
+  if (!sameIdentity(originalIdentity, stableIdentity(identityFor(metadata)))) {
     return fail('REPOSITORY_CHANGED', `${plan.filename} changed after it was preflighted.`)
   }
   if (!readRegularFileBytes(quarantinePath, plan.filename).equals(plan.originalBytes)) {
@@ -458,7 +511,7 @@ const deletePlan = (path: string, plan: FilePlan, hooks: AtomicWriteHooks | unde
   let quarantined = false
   try {
     fault(hooks, 'before-deletion')
-    assertQuarantinedDeleteTarget(path, plan)
+    assertOriginalDeleteTarget(path, plan)
     renameSync(path, quarantinePath)
     quarantined = true
     fault(hooks, 'after-delete-quarantine')

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -1061,6 +1061,26 @@ describe('initialisation', () => {
     })
   }
 
+  test('detects byte-identical instruction replacement when inode identity is reused', () => {
+    const root = createRoot()
+    const path = join(root, 'AGENTS.md')
+    const agentsPlan = createDeletePlan(root)
+    const plannedIdentity = (agentsPlan as { originalIdentity?: { dev: string; ino: string } }).originalIdentity
+    assert.ok(plannedIdentity)
+    const replacement = readFileSync(path, 'utf8')
+    rmSync(path)
+    writeFileSync(path, replacement)
+    const replacementMetadata = statSync(path, { bigint: true })
+    ;(agentsPlan as { originalIdentity?: { dev: string; ino: string } }).originalIdentity = {
+      ...plannedIdentity,
+      dev: replacementMetadata.dev.toString(),
+      ino: replacementMetadata.ino.toString(),
+    }
+
+    assertErrorCode(() => applyInstructionChanges(root, [agentsPlan]), 'REPOSITORY_CHANGED')
+    assert.equal(readFileSync(path, 'utf8'), replacement)
+  })
+
   test('does not delete a replacement created after deletion quarantine', () => {
     const root = createRoot()
     const path = join(root, 'AGENTS.md')

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -13,6 +13,7 @@ import {
   rmSync,
   statSync,
   symlinkSync,
+  utimesSync,
   writeFileSync,
   writeSync,
 } from 'node:fs'
@@ -1064,21 +1065,51 @@ describe('initialisation', () => {
   test('detects byte-identical instruction replacement when inode identity is reused', () => {
     const root = createRoot()
     const path = join(root, 'AGENTS.md')
-    const agentsPlan = createDeletePlan(root)
-    const plannedIdentity = (agentsPlan as { originalIdentity?: { dev: string; ino: string } }).originalIdentity
+    const originalTime = new Date('2000-01-01T00:00:00.000Z')
+    const replacementTime = new Date('2001-01-01T00:00:00.000Z')
+    api.initEncephalon({ root })
+    utimesSync(path, originalTime, originalTime)
+    const [agentsPlan] = planInstructionChanges(root, true)
+    assert.equal(agentsPlan?.action, 'delete')
+    type LegacyInstructionIdentity = { dev: number; ino: number }
+    type StrengthenedInstructionIdentity = {
+      birthtimeNs: string
+      ctimeNs: string
+      dev: string
+      ino: string
+      mtimeNs: string
+      size: string
+    }
+    type TestInstructionIdentity = LegacyInstructionIdentity | StrengthenedInstructionIdentity
+    const isStrengthenedIdentity = (identity: TestInstructionIdentity): identity is StrengthenedInstructionIdentity =>
+      typeof identity.dev === 'string'
+    const mutablePlan = agentsPlan as { originalIdentity?: TestInstructionIdentity }
+    const plannedIdentity = mutablePlan.originalIdentity
     assert.ok(plannedIdentity)
-    const replacement = readFileSync(path, 'utf8')
+    const replacement = readFileSync(path)
     rmSync(path)
     writeFileSync(path, replacement)
-    const replacementMetadata = statSync(path, { bigint: true })
-    ;(agentsPlan as { originalIdentity?: { dev: string; ino: string } }).originalIdentity = {
-      ...plannedIdentity,
-      dev: replacementMetadata.dev.toString(),
-      ino: replacementMetadata.ino.toString(),
+    utimesSync(path, replacementTime, replacementTime)
+    if (isStrengthenedIdentity(plannedIdentity)) {
+      const replacementMetadata = statSync(path, { bigint: true })
+      mutablePlan.originalIdentity = {
+        birthtimeNs: plannedIdentity.birthtimeNs,
+        ctimeNs: plannedIdentity.ctimeNs,
+        dev: replacementMetadata.dev.toString(),
+        ino: replacementMetadata.ino.toString(),
+        mtimeNs: plannedIdentity.mtimeNs,
+        size: plannedIdentity.size,
+      }
+    } else {
+      const replacementMetadata = statSync(path)
+      mutablePlan.originalIdentity = {
+        dev: replacementMetadata.dev,
+        ino: replacementMetadata.ino,
+      }
     }
 
     assertErrorCode(() => applyInstructionChanges(root, [agentsPlan]), 'REPOSITORY_CHANGED')
-    assert.equal(readFileSync(path, 'utf8'), replacement)
+    assert.deepEqual(readFileSync(path), replacement)
   })
 
   test('does not delete a replacement created after deletion quarantine', () => {


### PR DESCRIPTION
## Human summary

Instruction-file deletion now recognises byte-identical file replacements on CI, so the flaky Ubuntu test no longer depends on filesystem timing.

## Summary

- Strengthens instruction-file identity from dev/inode to nanosecond stat metadata captured as strings.
- Splits deletion verification into a full original-path identity check before rename and a rename-stable quarantine check after rename.
- Adds a deterministic regression that simulates inode reuse for a byte-identical replacement.
- Saves the CI flake learning in Encephalon as `review.inode-reuse-file-identity`.

Verification run locally:

- `node --test --test-name-pattern "byte-identical instruction replacement|different file containing identical bytes" test/init.test.ts` repeated 50 times
- `node --test test/init.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`
- `bun run check:package`
- `node ./node_modules/encephalon/dist/cli.mjs validate`