### PR TITLE
[MAR-2542] v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to Encephalon are documented here.
+
+## [0.2.0] - 2026-08-09
+
+### Added
+
+- Added bounded baseline scanning with deterministic directory ordering and symlink-safe traversal.
+- Added package-manager evidence to baseline records instead of inferring npm from incomplete repository metadata.
+- Added explicit request, response, corpus, cache, and performance budgets.
+- Added package and publish-contract checks to CI, including inspection of the packed package.
+- Added a replacement CLI parser and aligned generated TypeScript declarations with the supported Node.js runtime.
+
+### Changed
+
+- Made canonical record staging, publication, instruction-file writes, and post-commit recovery safer across filesystem failures.
+- Made cache hydration and gather reads transactional, snapshot-consistent, and resilient to malformed disposable state.
+- Made compact search avoid materialising full record JSON and removed persistent-style copying from hot scans.
+- Centralised the package version and separated cache schema compatibility from diagnostic package metadata.
+- Improved validation of record graphs, kind directories, artifact paths, Windows filename portability, and locale-independent ordering.
+
+### Fixed
+
+- Classified expected filesystem and SQLite environment failures separately from internal defects.
+- Made committed add failures report the affected post-commit recovery phase explicitly.
+- Made generated baseline refreshes converge on one canonical snapshot.
+- Deflaked instruction replacement identity checks across supported platforms.
+
+### Documentation
+
+- Corrected README privacy and packaged-asset claims.
+- Resolved implementation-plan drift and removed obsolete documentation surface.
+- Added performance baselines and CI budgets for prepare, hydrate, search, and cache-size behaviour.
+
+## [0.1.0]
+
+- Initial release of the repository-local durable knowledge package.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Encephalon is general-purpose. It does not include hosted services, accounts, te
 
 Bun is used to build and test Encephalon itself. Installed projects run the bundled ESM distribution with Node and do not need Bun. The package has zero runtime dependencies and no installation lifecycle scripts.
 
-Yarn Plug'n'Play is not supported in v0.1.0.
+Yarn Plug'n'Play is not supported in v0.2.0.
 
 ## Install
 

--- a/encephalon/workflow/269cceb6-d5e2-47a6-be66-91e309b4e059.json
+++ b/encephalon/workflow/269cceb6-d5e2-47a6-be66-91e309b4e059.json
@@ -1,0 +1,19 @@
+{
+  "createdAt": "2026-08-09T01:40:26.397Z",
+  "id": "269cceb6-d5e2-47a6-be66-91e309b4e059",
+  "kind": "workflow",
+  "payload": {
+    "summary": "Prepare releases as reviewable metadata-only pull requests before manual publication.",
+    "lessons": [
+      "Update package.json and regenerate src/generated/version.ts together so the bundled CLI and package checks agree on the release version.",
+      "Populate a top-level CHANGELOG.md from the merged history since the previous release.",
+      "Run release-equivalent checks without publishing, and leave the release pull request open for maintainer inspection."
+    ],
+    "verification": [
+      "Run typecheck, tests, lint, build, check:package, and check:publish before confirming or pushing the release PR."
+    ]
+  },
+  "searchText": "release preparation changelog manual publication version metadata package checks",
+  "source": "agent",
+  "subject": "workflow.release-prepare"
+}

--- a/encephalon/workflow/269cceb6-d5e2-47a6-be66-91e309b4e059.json
+++ b/encephalon/workflow/269cceb6-d5e2-47a6-be66-91e309b4e059.json
@@ -10,10 +10,10 @@
       "Run release-equivalent checks without publishing, and leave the release pull request open for maintainer inspection."
     ],
     "verification": [
-      "Run typecheck, tests, lint, build, check:package, and check:publish before confirming or pushing the release PR."
+      "Run typecheck, tests, lint, benchmark:check, build, check:package, check:publish, and encephalon validate before confirming or pushing the release PR."
     ]
   },
-  "searchText": "release preparation changelog manual publication version metadata package checks",
+  "searchText": "release preparation changelog manual publication version metadata package checks benchmark validate",
   "source": "agent",
   "subject": "workflow.release-prepare"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "encephalon",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Repository-local, durable knowledge for coding agents",
   "keywords": [
     "agents",

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -1,2 +1,2 @@
 // Generated from package.json by scripts/build.ts.
-export const PACKAGE_VERSION = "0.1.0"
+export const PACKAGE_VERSION = "0.2.0"


### PR DESCRIPTION
## Human summary

Prepare Encephalon 0.2.0 for manual publication by updating its version metadata and documenting the changes since 0.1.0.

## Summary

This PR:

- Updates `package.json` and the generated runtime metadata to `0.2.0`.
- Adds a top-level `CHANGELOG.md` covering the material changes delivered since 0.1.0.
- Records the release preparation workflow in Encephalon state so future release work follows the same manual-publication and verification gates.

The package remains unpublished and this PR is intentionally left open for maintainer inspection.

## Validation

All checks passed with Node.js 24.15.0 and Bun 1.3.1:

- `bun run typecheck`
- `bun run test` (159 tests passed)
- `bun run lint`
- `bun run benchmark:check`
- `bun run build`
- `bun run check:package`
- `bun run check:publish` (npm dry run only; no upload)
- `encephalon validate` (38 records checked, no errors)

The PR does not publish a package or merge into `main`.
