### PR TITLE
[MAR-2567] Run pull-request checks across supported Node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,36 +8,39 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, reopened, synchronize, edited]
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   verify:
-    name: Verify (${{ matrix.label }})
+    name: verify (${{ matrix.context }})
     strategy:
       fail-fast: false
       matrix:
         include:
-          - label: Ubuntu / Node 24.15.0
+          - context: ubuntu-latest
             os: ubuntu-latest
             node: 24.15.0
-          - label: macOS / Node 24.15.0
+          - context: macos-latest
             os: macos-latest
             node: 24.15.0
-          - label: Windows / Node 24.15.0
+          - context: windows-latest
             os: windows-latest
             node: 24.15.0
-          - label: Ubuntu / Node 26
+          - context: ubuntu-current
             os: ubuntu-latest
             node: 26
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
@@ -59,6 +62,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v7
         with:
           node-version: 24.15.0
@@ -73,6 +78,8 @@ jobs:
         run: |
           mkdir -p package-artifacts
           npm pack --dry-run=false --ignore-scripts --json --pack-destination package-artifacts > package-artifacts/npm-pack.json
+      - name: Check npm publish dry run
+        run: bun run check:publish
       - name: Upload release-equivalent package artifact
         uses: actions/upload-artifact@v4
         with:
@@ -80,5 +87,3 @@ jobs:
           path: package-artifacts/*
           if-no-files-found: error
           retention-days: 7
-      - name: Check npm publish dry run
-        run: bun run check:publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,25 +2,45 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
+      - release/**
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify:
+    name: Verify (${{ matrix.label }})
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+        include:
+          - label: Ubuntu / Node 24.15.0
+            os: ubuntu-latest
+            node: 24.15.0
+          - label: macOS / Node 24.15.0
+            os: macos-latest
+            node: 24.15.0
+          - label: Windows / Node 24.15.0
+            os: windows-latest
+            node: 24.15.0
+          - label: Ubuntu / Node 26
+            os: ubuntu-latest
+            node: 26
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: 24.15.0
+          node-version: ${{ matrix.node }}
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.1
@@ -31,19 +51,34 @@ jobs:
       - run: bun run benchmark:check
       - run: bun run build
       - run: bun run check:package
+
+  release:
+    name: Release-equivalent package gate
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.15.0
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.1
+      - run: bun install --frozen-lockfile
+      - run: bun run build
+      - run: bun run check:package
       - name: Create release-equivalent package artifact
-        if: matrix.os == 'ubuntu-latest'
         shell: bash
         run: |
           mkdir -p package-artifacts
           npm pack --dry-run=false --ignore-scripts --json --pack-destination package-artifacts > package-artifacts/npm-pack.json
       - name: Upload release-equivalent package artifact
-        if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
           name: encephalon-npm-package
           path: package-artifacts/*
           if-no-files-found: error
+          retention-days: 7
       - name: Check npm publish dry run
-        if: matrix.os == 'ubuntu-latest'
         run: bun run check:publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - release/**
   pull_request:
     branches:
       - main
@@ -14,7 +13,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ bun run benchmark:check
 
 See [docs/performance.md](./docs/performance.md) for benchmark profiles, budgets, baseline results, and scale guidance.
 
-`check:package` inspects the npm tarball, installs it with lifecycle scripts disabled, imports the public API, and runs the bundled CLI using Node. `check:publish` exercises npm's publish-time manifest normalisation without uploading anything. The Ubuntu CI job is the release-equivalent package gate: it runs both checks and uploads the generated `npm pack` tarball for inspection.
+`check:package` inspects the npm tarball, installs it with lifecycle scripts disabled, imports the public API, and runs the bundled CLI using Node. `check:publish` exercises npm's publish-time manifest normalisation without uploading anything. CI runs four verification lanes: Node 24.15.0 on Ubuntu, macOS, and Windows, plus Node 26 on Ubuntu. Only trusted pushes to `main` run the separate release-equivalent package gate, which validates the publish dry run before uploading the generated `npm pack` tarball for inspection.
 
 ## Licence
 

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -145,7 +145,7 @@ jobs:
 `,
     )
     assert.match(verificationRunner, /^ {4}runs-on: \$\{\{ matrix\.os \}\}\n$/)
-    assert.doesNotMatch(verificationHeader, /^\s{4}(?:if|continue-on-error):/m)
+    assert.doesNotMatch(verificationJob, /^ {4}(?:if|continue-on-error):/m)
     assert.match(verificationSteps, /uses: actions\/checkout@\S+\n\s+with:\n\s+persist-credentials: false/)
     assert.match(
       verificationSteps,

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -69,18 +69,44 @@ describe('package contract', () => {
     assert.doesNotMatch(skill, /node \.\/node_modules\/encephalon\/dist\/cli\.mjs/)
   })
 
-  test('runs package and publish-contract checks in CI without publishing', () => {
+  test('runs pull-request and current-Node package checks with a trusted release gate', () => {
     const workflow = readFileSync(resolve(root, '.github', 'workflows', 'ci.yml'), 'utf8')
     const publishCheck = readFileSync(resolve(root, 'scripts', 'check-publish.ts'), 'utf8')
     const packageJson = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as {
       scripts?: Record<string, unknown>
     }
     const publishScript = String(packageJson.scripts?.['check:publish'])
+    const [verificationJob = ''] = workflow.split('\n  release:\n', 1)
 
-    assert.equal(workflow.includes('bun run check:package'), true)
-    assert.equal(workflow.includes('bun run check:publish'), true)
-    assert.equal(workflow.includes("matrix.os == 'ubuntu-latest'"), true)
-    assert.equal(workflow.includes('actions/upload-artifact'), true)
+    assert.match(workflow, /push:\n\s+branches:\n\s+- main\n\s+- release\/\*\*/)
+    assert.match(workflow, /pull_request:\n\s+branches:\n\s+- main/)
+    assert.match(workflow, /permissions:\n\s+contents: read/)
+    assert.match(
+      workflow,
+      /group: \$\{\{ github\.workflow \}\}-\$\{\{ github\.event\.pull_request\.number \|\| github\.ref \}\}/,
+    )
+    assert.equal(workflow.includes('cancel-in-progress: true'), true)
+    assert.match(verificationJob, /label: Ubuntu \/ Node 24\.15\.0\n\s+os: ubuntu-latest\n\s+node: 24\.15\.0/)
+    assert.match(verificationJob, /label: macOS \/ Node 24\.15\.0\n\s+os: macos-latest\n\s+node: 24\.15\.0/)
+    assert.match(verificationJob, /label: Windows \/ Node 24\.15\.0\n\s+os: windows-latest\n\s+node: 24\.15\.0/)
+    assert.match(verificationJob, /label: Ubuntu \/ Node 26\n\s+os: ubuntu-latest\n\s+node: 26/)
+    assert.equal(
+      [
+        'bun install --frozen-lockfile',
+        'bun run typecheck',
+        'bun run test',
+        'bun run lint',
+        'bun run benchmark:check',
+        'bun run build',
+        'bun run check:package',
+      ].every(command => verificationJob.includes(command)),
+      true,
+    )
+    assert.equal(workflow.match(/bun run check:package/g)?.length, 2)
+    assert.equal(workflow.match(/bun run check:publish/g)?.length, 1)
+    assert.equal(workflow.match(/actions\/upload-artifact/g)?.length, 1)
+    assert.match(workflow, /if: github\.event_name == 'push' && github\.ref == 'refs\/heads\/main'/)
+    assert.match(workflow, /retention-days: 7/)
     assert.equal(publishScript, 'bun run scripts/check-publish.ts')
     assert.equal(publishCheck.includes("'--dry-run'"), true)
     assert.equal(publishCheck.includes("'--ignore-scripts'"), true)

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -88,6 +88,8 @@ describe('package contract', () => {
     const runnerStart = verificationJob.indexOf('    runs-on:', matrixStart)
     const matrixBlock = verificationJob.slice(matrixStart, runnerStart)
     const verificationStepsStart = verificationJob.indexOf('    steps:\n')
+    const verificationHeader = verificationJob.slice(0, matrixStart)
+    const verificationRunner = verificationJob.slice(runnerStart, verificationStepsStart)
     const verificationSteps = verificationJob.slice(verificationStepsStart)
     const releaseStepsStart = releaseJob.indexOf('    steps:\n')
     const releaseHeader = releaseJob.slice(0, releaseStepsStart)
@@ -115,6 +117,16 @@ describe('package contract', () => {
     )
 
     assert.equal(
+      verificationHeader,
+      `
+jobs:
+  verify:
+    name: verify (\${{ matrix.context }})
+    strategy:
+      fail-fast: false
+`,
+    )
+    assert.equal(
       matrixBlock,
       `      matrix:
         include:
@@ -132,8 +144,8 @@ describe('package contract', () => {
             node: 26
 `,
     )
-    assert.match(verificationJob, /name: verify \(\$\{\{ matrix\.context \}\}\)/)
-    assert.match(verificationJob, /runs-on: \$\{\{ matrix\.os \}\}/)
+    assert.match(verificationRunner, /^ {4}runs-on: \$\{\{ matrix\.os \}\}\n$/)
+    assert.doesNotMatch(verificationHeader, /^\s{4}(?:if|continue-on-error):/m)
     assert.match(verificationSteps, /uses: actions\/checkout@\S+\n\s+with:\n\s+persist-credentials: false/)
     assert.match(
       verificationSteps,

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -77,19 +77,27 @@ describe('package contract', () => {
       scripts?: Record<string, unknown>
     }
     const publishScript = String(packageJson.scripts?.['check:publish'])
+    const eventsStart = workflow.indexOf('\non:\n') + 1
+    const permissionsStart = workflow.indexOf('\npermissions:\n', eventsStart)
     const jobsStart = workflow.indexOf('\njobs:\n')
     const releaseStart = workflow.indexOf('\n  release:\n', jobsStart)
     const workflowConfiguration = workflow.slice(0, jobsStart)
     const verificationJob = workflow.slice(jobsStart, releaseStart)
     const releaseJob = workflow.slice(releaseStart)
+    const matrixStart = verificationJob.indexOf('      matrix:\n')
+    const runnerStart = verificationJob.indexOf('    runs-on:', matrixStart)
+    const matrixBlock = verificationJob.slice(matrixStart, runnerStart)
+    const verificationStepsStart = verificationJob.indexOf('    steps:\n')
+    const verificationSteps = verificationJob.slice(verificationStepsStart)
+    const releaseStepsStart = releaseJob.indexOf('    steps:\n')
+    const releaseHeader = releaseJob.slice(0, releaseStepsStart)
+    const releaseSteps = releaseJob.slice(releaseStepsStart)
     const uploadStart = releaseJob.indexOf('      - name: Upload release-equivalent package artifact\n')
     const uploadStep = releaseJob.slice(uploadStart)
 
     assert.equal(
-      workflowConfiguration,
-      `name: CI
-
-on:
+      workflow.slice(eventsStart, permissionsStart),
+      `on:
   push:
     branches:
       - main
@@ -97,24 +105,18 @@ on:
     branches:
       - main
     types: [opened, reopened, synchronize, edited]
-
-permissions:
-  contents: read
-
-concurrency:
-  group: \${{ github.workflow }}-\${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 `,
     )
+    assert.doesNotMatch(workflow.slice(eventsStart, permissionsStart), /paths|ignore|workflow_dispatch|schedule/)
+    assert.match(workflowConfiguration, /permissions:\n\s+contents: read/)
+    assert.match(
+      workflowConfiguration,
+      /concurrency:\n\s+group: \$\{\{ github\.workflow \}\}-\$\{\{ github\.event\.pull_request\.number \|\| github\.ref \}\}\n\s+cancel-in-progress: true/,
+    )
+
     assert.equal(
-      verificationJob,
-      `
-jobs:
-  verify:
-    name: verify (\${{ matrix.context }})
-    strategy:
-      fail-fast: false
-      matrix:
+      matrixBlock,
+      `      matrix:
         include:
           - context: ubuntu-latest
             os: ubuntu-latest
@@ -128,47 +130,63 @@ jobs:
           - context: ubuntu-current
             os: ubuntu-latest
             node: 26
-    runs-on: \${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-      - uses: actions/setup-node@v7
-        with:
-          node-version: \${{ matrix.node }}
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.1
-      - run: bun install --frozen-lockfile
-      - run: bun run typecheck
-      - run: bun run test
-      - run: bun run lint
-      - run: bun run benchmark:check
-      - run: bun run build
-      - run: bun run check:package
 `,
     )
+    assert.match(verificationJob, /name: verify \(\$\{\{ matrix\.context \}\}\)/)
+    assert.match(verificationJob, /runs-on: \$\{\{ matrix\.os \}\}/)
+    assert.match(verificationSteps, /uses: actions\/checkout@\S+\n\s+with:\n\s+persist-credentials: false/)
+    assert.match(
+      verificationSteps,
+      /uses: actions\/setup-node@\S+\n\s+with:\n\s+node-version: \$\{\{ matrix\.node \}\}/,
+    )
+    assert.deepEqual(
+      [...verificationSteps.matchAll(/^\s+(?:- )?run: (.+)$/gm)].map(match => match[1]),
+      [
+        'bun install --frozen-lockfile',
+        'bun run typecheck',
+        'bun run test',
+        'bun run lint',
+        'bun run benchmark:check',
+        'bun run build',
+        'bun run check:package',
+      ],
+    )
+    assert.equal(verificationSteps.match(/^\s+(?:- )?run:/gm)?.length, 7)
+    assert.doesNotMatch(verificationSteps, /^\s{8}(?:if|continue-on-error):/m)
 
+    assert.equal(
+      releaseHeader,
+      `
+  release:
+    name: Release-equivalent package gate
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: verify
+    runs-on: ubuntu-latest
+`,
+    )
+    assert.match(releaseSteps, /uses: actions\/checkout@\S+\n\s+with:\n\s+persist-credentials: false/)
+    assert.match(releaseSteps, /uses: actions\/setup-node@\S+\n\s+with:\n\s+node-version: 24\.15\.0/)
+    assert.deepEqual(
+      [...releaseSteps.matchAll(/^\s{6}- run: (.+)$/gm)].map(match => match[1]),
+      ['bun install --frozen-lockfile', 'bun run build', 'bun run check:package'],
+    )
+    assert.equal(releaseSteps.match(/^\s+(?:- )?run:/gm)?.length, 5)
+    assert.doesNotMatch(releaseSteps, /^\s{8}(?:if|continue-on-error):/m)
     assert.match(
       releaseJob,
-      /release:\n\s+name: Release-equivalent package gate\n\s+if: github\.event_name == 'push' && github\.ref == 'refs\/heads\/main'\n\s+needs: verify/,
+      /- name: Create release-equivalent package artifact\n\s+shell: bash\n\s+run: \|\n\s+mkdir -p package-artifacts\n\s+npm pack --dry-run=false --ignore-scripts --json --pack-destination package-artifacts > package-artifacts\/npm-pack\.json/,
     )
-    assert.match(releaseJob, /uses: actions\/checkout@v7\n\s+with:\n\s+persist-credentials: false/)
-    assert.equal(
-      ['bun install --frozen-lockfile', 'bun run build', 'bun run check:package'].every(command =>
-        releaseJob.includes(`- run: ${command}`),
-      ),
-      true,
-    )
-    assert.match(releaseJob, /npm pack --dry-run=false --ignore-scripts --json --pack-destination package-artifacts/)
+    assert.equal(releaseJob.match(/npm pack --dry-run=false/g)?.length, 1)
     assert.match(releaseJob, /- name: Check npm publish dry run\n\s+run: bun run check:publish/)
     assert.equal(releaseJob.match(/bun run check:publish/g)?.length, 1)
     assert.equal(releaseJob.match(/actions\/upload-artifact/g)?.length, 1)
     assert.equal(
-      uploadStep,
-      `      - name: Upload release-equivalent package artifact
-        uses: actions/upload-artifact@v4
-        with:
+      uploadStep
+        .split('\n')
+        .filter(line => !line.includes('uses: actions/upload-artifact@'))
+        .slice(1)
+        .join('\n'),
+      `        with:
           name: encephalon-npm-package
           path: package-artifacts/*
           if-no-files-found: error
@@ -176,8 +194,12 @@ jobs:
 `,
     )
     assert.equal(
-      releaseJob.indexOf('npm pack') < releaseJob.indexOf('bun run check:publish') &&
-        releaseJob.indexOf('bun run check:publish') < releaseJob.indexOf('actions/upload-artifact'),
+      ['bun run build', 'bun run check:package', 'npm pack', 'bun run check:publish', 'actions/upload-artifact']
+        .map(step => releaseJob.indexOf(step))
+        .every(
+          (position, index, positions) =>
+            position >= 0 && (index === 0 || position > (positions[index - 1] ?? Number.POSITIVE_INFINITY)),
+        ),
       true,
     )
     assert.match(readme, /four verification lanes/)

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -71,42 +71,82 @@ describe('package contract', () => {
 
   test('runs pull-request and current-Node package checks with a trusted release gate', () => {
     const workflow = readFileSync(resolve(root, '.github', 'workflows', 'ci.yml'), 'utf8')
+    const readme = readFileSync(resolve(root, 'README.md'), 'utf8')
     const publishCheck = readFileSync(resolve(root, 'scripts', 'check-publish.ts'), 'utf8')
     const packageJson = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as {
       scripts?: Record<string, unknown>
     }
     const publishScript = String(packageJson.scripts?.['check:publish'])
-    const [verificationJob = ''] = workflow.split('\n  release:\n', 1)
+    const jobsStart = workflow.indexOf('\njobs:\n')
+    const releaseStart = workflow.indexOf('\n  release:\n', jobsStart)
+    const workflowConfiguration = workflow.slice(0, jobsStart)
+    const verificationJob = workflow.slice(jobsStart, releaseStart)
+    const releaseJob = workflow.slice(releaseStart)
 
-    assert.match(workflow, /push:\n\s+branches:\n\s+- main\n\s+- release\/\*\*/)
-    assert.match(workflow, /pull_request:\n\s+branches:\n\s+- main/)
-    assert.match(workflow, /permissions:\n\s+contents: read/)
+    assert.match(workflowConfiguration, /push:\n\s+branches:\n\s+- main\n\s+- release\/\*\*/)
     assert.match(
-      workflow,
-      /group: \$\{\{ github\.workflow \}\}-\$\{\{ github\.event\.pull_request\.number \|\| github\.ref \}\}/,
+      workflowConfiguration,
+      /pull_request:\n\s+branches:\n\s+- main\n\s+types: \[opened, reopened, synchronize, edited\]/,
     )
-    assert.equal(workflow.includes('cancel-in-progress: true'), true)
-    assert.match(verificationJob, /label: Ubuntu \/ Node 24\.15\.0\n\s+os: ubuntu-latest\n\s+node: 24\.15\.0/)
-    assert.match(verificationJob, /label: macOS \/ Node 24\.15\.0\n\s+os: macos-latest\n\s+node: 24\.15\.0/)
-    assert.match(verificationJob, /label: Windows \/ Node 24\.15\.0\n\s+os: windows-latest\n\s+node: 24\.15\.0/)
-    assert.match(verificationJob, /label: Ubuntu \/ Node 26\n\s+os: ubuntu-latest\n\s+node: 26/)
+    assert.match(workflowConfiguration, /permissions:\n\s+contents: read/)
+    assert.match(
+      workflowConfiguration,
+      /group: \$\{\{ github\.workflow \}\}-\$\{\{ github\.event\.pull_request\.head\.repo\.full_name \|\| github\.repository \}\}-\$\{\{ github\.head_ref \|\| github\.ref_name \}\}/,
+    )
+    assert.equal(workflowConfiguration.includes('cancel-in-progress: true'), true)
+
+    assert.match(verificationJob, /name: verify \(\$\{\{ matrix\.context \}\}\)/)
+    assert.equal(verificationJob.match(/\n\s+- context:/g)?.length, 4)
+    assert.match(verificationJob, /context: ubuntu-latest\n\s+os: ubuntu-latest\n\s+node: 24\.15\.0/)
+    assert.match(verificationJob, /context: macos-latest\n\s+os: macos-latest\n\s+node: 24\.15\.0/)
+    assert.match(verificationJob, /context: windows-latest\n\s+os: windows-latest\n\s+node: 24\.15\.0/)
+    assert.match(verificationJob, /context: ubuntu-current\n\s+os: ubuntu-latest\n\s+node: 26/)
+    assert.match(verificationJob, /runs-on: \$\{\{ matrix\.os \}\}/)
+    assert.match(verificationJob, /node-version: \$\{\{ matrix\.node \}\}/)
+    assert.match(verificationJob, /uses: actions\/checkout@v7\n\s+with:\n\s+persist-credentials: false/)
+    const verificationCommands = [
+      'bun install --frozen-lockfile',
+      'bun run typecheck',
+      'bun run test',
+      'bun run lint',
+      'bun run benchmark:check',
+      'bun run build',
+      'bun run check:package',
+    ]
     assert.equal(
-      [
-        'bun install --frozen-lockfile',
-        'bun run typecheck',
-        'bun run test',
-        'bun run lint',
-        'bun run benchmark:check',
-        'bun run build',
-        'bun run check:package',
-      ].every(command => verificationJob.includes(command)),
+      verificationCommands.every(command => verificationJob.includes(`- run: ${command}`)),
       true,
     )
-    assert.equal(workflow.match(/bun run check:package/g)?.length, 2)
-    assert.equal(workflow.match(/bun run check:publish/g)?.length, 1)
-    assert.equal(workflow.match(/actions\/upload-artifact/g)?.length, 1)
-    assert.match(workflow, /if: github\.event_name == 'push' && github\.ref == 'refs\/heads\/main'/)
-    assert.match(workflow, /retention-days: 7/)
+    assert.equal(verificationJob.includes('actions/upload-artifact'), false)
+    assert.equal(verificationJob.includes('bun run check:publish'), false)
+
+    assert.match(
+      releaseJob,
+      /release:\n\s+name: Release-equivalent package gate\n\s+if: github\.event_name == 'push' && github\.ref == 'refs\/heads\/main'\n\s+needs: verify/,
+    )
+    assert.match(releaseJob, /uses: actions\/checkout@v7\n\s+with:\n\s+persist-credentials: false/)
+    assert.equal(
+      ['bun install --frozen-lockfile', 'bun run build', 'bun run check:package'].every(command =>
+        releaseJob.includes(`- run: ${command}`),
+      ),
+      true,
+    )
+    assert.match(releaseJob, /npm pack --dry-run=false --ignore-scripts --json --pack-destination package-artifacts/)
+    assert.match(releaseJob, /- name: Check npm publish dry run\n\s+run: bun run check:publish/)
+    assert.equal(releaseJob.match(/bun run check:publish/g)?.length, 1)
+    assert.equal(releaseJob.match(/actions\/upload-artifact/g)?.length, 1)
+    assert.match(
+      releaseJob,
+      /uses: actions\/upload-artifact@v4\n\s+with:\n\s+name: encephalon-npm-package\n\s+path: package-artifacts\/\*\n\s+if-no-files-found: error\n\s+retention-days: 7/,
+    )
+    assert.equal(
+      releaseJob.indexOf('npm pack') < releaseJob.indexOf('bun run check:publish') &&
+        releaseJob.indexOf('bun run check:publish') < releaseJob.indexOf('actions/upload-artifact'),
+      true,
+    )
+    assert.match(readme, /four verification lanes/)
+    assert.match(readme, /trusted pushes to `main`/)
+    assert.match(readme, /release-equivalent package gate/)
     assert.equal(publishScript, 'bun run scripts/check-publish.ts')
     assert.equal(publishCheck.includes("'--dry-run'"), true)
     assert.equal(publishCheck.includes("'--ignore-scripts'"), true)

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -82,43 +82,72 @@ describe('package contract', () => {
     const workflowConfiguration = workflow.slice(0, jobsStart)
     const verificationJob = workflow.slice(jobsStart, releaseStart)
     const releaseJob = workflow.slice(releaseStart)
+    const uploadStart = releaseJob.indexOf('      - name: Upload release-equivalent package artifact\n')
+    const uploadStep = releaseJob.slice(uploadStart)
 
-    assert.match(workflowConfiguration, /push:\n\s+branches:\n\s+- main\n\s+- release\/\*\*/)
-    assert.match(
-      workflowConfiguration,
-      /pull_request:\n\s+branches:\n\s+- main\n\s+types: \[opened, reopened, synchronize, edited\]/,
-    )
-    assert.match(workflowConfiguration, /permissions:\n\s+contents: read/)
-    assert.match(
-      workflowConfiguration,
-      /group: \$\{\{ github\.workflow \}\}-\$\{\{ github\.event\.pull_request\.head\.repo\.full_name \|\| github\.repository \}\}-\$\{\{ github\.head_ref \|\| github\.ref_name \}\}/,
-    )
-    assert.equal(workflowConfiguration.includes('cancel-in-progress: true'), true)
-
-    assert.match(verificationJob, /name: verify \(\$\{\{ matrix\.context \}\}\)/)
-    assert.equal(verificationJob.match(/\n\s+- context:/g)?.length, 4)
-    assert.match(verificationJob, /context: ubuntu-latest\n\s+os: ubuntu-latest\n\s+node: 24\.15\.0/)
-    assert.match(verificationJob, /context: macos-latest\n\s+os: macos-latest\n\s+node: 24\.15\.0/)
-    assert.match(verificationJob, /context: windows-latest\n\s+os: windows-latest\n\s+node: 24\.15\.0/)
-    assert.match(verificationJob, /context: ubuntu-current\n\s+os: ubuntu-latest\n\s+node: 26/)
-    assert.match(verificationJob, /runs-on: \$\{\{ matrix\.os \}\}/)
-    assert.match(verificationJob, /node-version: \$\{\{ matrix\.node \}\}/)
-    assert.match(verificationJob, /uses: actions\/checkout@v7\n\s+with:\n\s+persist-credentials: false/)
-    const verificationCommands = [
-      'bun install --frozen-lockfile',
-      'bun run typecheck',
-      'bun run test',
-      'bun run lint',
-      'bun run benchmark:check',
-      'bun run build',
-      'bun run check:package',
-    ]
     assert.equal(
-      verificationCommands.every(command => verificationJob.includes(`- run: ${command}`)),
-      true,
+      workflowConfiguration,
+      `name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: \${{ github.workflow }}-\${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+`,
     )
-    assert.equal(verificationJob.includes('actions/upload-artifact'), false)
-    assert.equal(verificationJob.includes('bun run check:publish'), false)
+    assert.equal(
+      verificationJob,
+      `
+jobs:
+  verify:
+    name: verify (\${{ matrix.context }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - context: ubuntu-latest
+            os: ubuntu-latest
+            node: 24.15.0
+          - context: macos-latest
+            os: macos-latest
+            node: 24.15.0
+          - context: windows-latest
+            os: windows-latest
+            node: 24.15.0
+          - context: ubuntu-current
+            os: ubuntu-latest
+            node: 26
+    runs-on: \${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version: \${{ matrix.node }}
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.1
+      - run: bun install --frozen-lockfile
+      - run: bun run typecheck
+      - run: bun run test
+      - run: bun run lint
+      - run: bun run benchmark:check
+      - run: bun run build
+      - run: bun run check:package
+`,
+    )
 
     assert.match(
       releaseJob,
@@ -135,9 +164,16 @@ describe('package contract', () => {
     assert.match(releaseJob, /- name: Check npm publish dry run\n\s+run: bun run check:publish/)
     assert.equal(releaseJob.match(/bun run check:publish/g)?.length, 1)
     assert.equal(releaseJob.match(/actions\/upload-artifact/g)?.length, 1)
-    assert.match(
-      releaseJob,
-      /uses: actions\/upload-artifact@v4\n\s+with:\n\s+name: encephalon-npm-package\n\s+path: package-artifacts\/\*\n\s+if-no-files-found: error\n\s+retention-days: 7/,
+    assert.equal(
+      uploadStep,
+      `      - name: Upload release-equivalent package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: encephalon-npm-package
+          path: package-artifacts/*
+          if-no-files-found: error
+          retention-days: 7
+`,
     )
     assert.equal(
       releaseJob.indexOf('npm pack') < releaseJob.indexOf('bun run check:publish') &&


### PR DESCRIPTION
## Human summary

Pull requests now run the full safe CI suite across the minimum and current Node versions, while release packaging remains restricted to trusted pushes to `main`.

## Summary

- run CI for pull requests targeting `main` and cancel superseded runs
- preserve the existing Linux, macOS, and Windows required checks on Node 24.15.0
- add an Ubuntu check on Node 26 that exercises the packed package and CLI contract
- prevent checkout credentials from persisting into untrusted verification steps
- run the release-equivalent package gate once on trusted `main` pushes, with bounded artifact retention
- document the verification and release lanes and add focused workflow contract coverage

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run test` (159 tests)
- `bun run benchmark:check`
- `bun run build`
- `bun run check:package`
- `bun run check:publish`
- `actionlint .github/workflows/ci.yml`
- `git diff --check origin/main...HEAD`

Linear: [MAR-2567](https://linear.app/marcoappio/issue/MAR-2567/ci-run-pull-request-checks-and-cover-the-current-node-major)
