### PR TITLE
[MAR-2562] Confine cache filesystem access

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The v0.x canonical corpus may contain at most 1,000 records, 8 MiB of aggregate 
 
 Payload values are validated without invoking accessors. They may contain at most 64 nested levels and 10,000 JSON nodes, counting the root value, arrays, objects, and primitive values.
 
-The disposable cache lives at `node_modules/.cache/encephalon/brain.sqlite` and should not be committed. It uses SQLite WAL mode, FTS5, a repository-scoped operation lock, manifest-based freshness, and transactional table rebuilds. Canonical records remain the source of truth.
+The disposable cache lives at `node_modules/.cache/encephalon/brain.sqlite` and should not be committed. Encephalon verifies that its cache ancestors, SQLite files, sidecars, and operation-lock entries are real contained entries before use and identity-specific cleanup. It uses SQLite WAL mode, FTS5, a repository-scoped operation lock, manifest-based freshness, and transactional table rebuilds. Canonical records remain the source of truth.
 
 Artifacts must be regular, non-symlink files beneath `_artifacts/<kind>/<id>/`. Record IDs and artifact paths are checked for traversal, platform portability, Windows-reserved names, case collisions, size limits, and containment.
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-12 for audited snapshot `d9b5282e9f6454ba68192c35fad402b1e3e7c399`.
+Last reviewed: 2026-08-12 for audited snapshot `abbdcfb0daf267e4308559b7af3cfe88c9a43564`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-12 for audited snapshot `e43ad30b6af6dadbdb78e1ffff5dbb3905a21995`.
+Last reviewed: 2026-08-12 for audited snapshot `376455d16577f12efb4ef484bb8a12303e7d29b0`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-08 for audited snapshot `514f444fdaf428c2e41124020b40b7568af66b6b`.
+Last reviewed: 2026-08-12 for audited snapshot `fd8eb6025fe85556ea6177e0497d51d51bdce261`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -31,9 +31,12 @@ This document is the concise contract maintainers should update when public beha
 ## Cache Compatibility
 
 - SQLite is disposable derived state under `node_modules/.cache/encephalon`.
+- The repository, cache ancestors, SQLite databases and sidecars, operation-lock metadata, recovery entries, and quarantine entries must be real contained filesystem entries verified by type, native realpath, and stable identity. Static symlinks, junction redirects, unexpected types, and replacements at validation boundaries fail closed.
+- Missing cache ancestors are created individually. New primary databases use exclusive no-follow descriptor creation before SQLite opens the verified pathname, and destructive recovery removes only the exact identity moved to a verified sibling quarantine.
 - Every `list`, `show`, `search`, and `gather` operation prepares the cache before reading.
 - Cache rebuilds are transactional and repository-scoped. Corrupt or incompatible cache state is removed and rebuilt rather than treated as canonical data.
 - Freshness is determined from explicit cache metadata and a manifest of canonical records plus referenced artifacts.
+- Node's pathname-only SQLite API leaves a narrow replacement race inside SQLite's open after the surrounding identity checks. Defending against arbitrary same-user mutation between those boundaries is not a supported security boundary.
 
 ## Package and Release Gates
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-12 for audited snapshot `fd8eb6025fe85556ea6177e0497d51d51bdce261`.
+Last reviewed: 2026-08-12 for audited snapshot `2fdb424d7ebeb5c5184ed88058c34c70e13fe88f`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-12 for audited snapshot `376455d16577f12efb4ef484bb8a12303e7d29b0`.
+Last reviewed: 2026-08-12 for audited snapshot `37e0a52e29bbacfe05b8a7999394d6374a5285a1`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-12 for audited snapshot `2fdb424d7ebeb5c5184ed88058c34c70e13fe88f`.
+Last reviewed: 2026-08-12 for audited snapshot `e43ad30b6af6dadbdb78e1ffff5dbb3905a21995`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-12 for audited snapshot `37e0a52e29bbacfe05b8a7999394d6374a5285a1`.
+Last reviewed: 2026-08-12 for audited snapshot `d9b5282e9f6454ba68192c35fad402b1e3e7c399`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 

--- a/src/cache-location.ts
+++ b/src/cache-location.ts
@@ -1,0 +1,429 @@
+import { randomUUID } from 'node:crypto'
+import {
+  type BigIntStats,
+  closeSync,
+  constants,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readSync,
+  realpathSync,
+  renameSync,
+  rmdirSync,
+  unlinkSync,
+  writeSync,
+} from 'node:fs'
+import { isAbsolute, relative, resolve } from 'node:path'
+import { fail } from './errors.ts'
+
+const CACHE_COMPONENTS = ['node_modules', '.cache', 'encephalon'] as const
+const DATABASE_SIDECAR_SUFFIXES = ['-wal', '-shm', '-journal'] as const
+const NO_FOLLOW = constants.O_NOFOLLOW ?? 0
+
+export type CacheEntryIdentity = {
+  dev: bigint
+  ino: bigint
+}
+
+type CacheDirectoryEntry = CacheEntryIdentity & {
+  path: string
+  relativePath: string
+}
+
+export type CacheLocation = {
+  directory: string
+  entries: readonly [CacheDirectoryEntry, CacheDirectoryEntry, CacheDirectoryEntry, CacheDirectoryEntry]
+  repository: string
+}
+
+export type CacheDatabase = CacheEntryIdentity & {
+  name: CacheDatabaseName
+  path: string
+}
+
+export type CacheDatabaseName = 'brain.sqlite' | 'operation-lock.sqlite'
+
+export type CacheOwnedDirectory = CacheEntryIdentity & {
+  name: string
+  path: string
+}
+
+type CacheLocationTestHooks = {
+  afterQuarantineRename?: ((path: string) => void) | undefined
+  beforeQuarantineRename?: ((path: string) => void) | undefined
+}
+
+export const cacheLocationTestHooks: CacheLocationTestHooks = {}
+
+export const sameCacheEntryIdentity = (first: CacheEntryIdentity, second: CacheEntryIdentity) =>
+  first.dev === second.dev && first.ino === second.ino
+
+const identityFrom = (metadata: BigIntStats): CacheEntryIdentity => ({
+  dev: metadata.dev,
+  ino: metadata.ino,
+})
+
+const missingPath = (error: unknown) => (error as NodeJS.ErrnoException).code === 'ENOENT'
+
+const existingPath = (error: unknown) => (error as NodeJS.ErrnoException).code === 'EEXIST'
+
+const comparablePath = (path: string) => {
+  const normalized = path.replaceAll('\\', '/')
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized
+}
+
+const samePath = (first: string, second: string) => comparablePath(first) === comparablePath(second)
+
+const invalidLayout = (relativePath: string, invariant: string): never =>
+  fail('VALIDATION_FAILED', 'The Encephalon cache layout is unsafe.', {
+    entry: relativePath,
+    invariant,
+  })
+
+const changedLayout = (relativePath: string, invariant: string): never =>
+  fail('REPOSITORY_CHANGED', 'The Encephalon cache layout changed during the operation.', {
+    entry: relativePath,
+    invariant,
+  })
+
+const inspectDirectory = (
+  path: string,
+  relativePath: string,
+  expectedRealpath: string,
+  create: boolean,
+): CacheDirectoryEntry => {
+  if (create) {
+    try {
+      mkdirSync(path)
+    } catch (error) {
+      if (!existingPath(error)) {
+        throw error
+      }
+    }
+  }
+  let metadata: BigIntStats
+  try {
+    metadata = lstatSync(path, { bigint: true })
+  } catch (error) {
+    if (missingPath(error)) {
+      return invalidLayout(relativePath, 'directory-present')
+    }
+    throw error
+  }
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+    return invalidLayout(relativePath, 'real-directory')
+  }
+  const actualRealpath = realpathSync.native(path)
+  if (!samePath(actualRealpath, expectedRealpath)) {
+    return invalidLayout(relativePath, 'expected-realpath')
+  }
+  return { ...identityFrom(metadata), path, relativePath }
+}
+
+const assertDirectoryEntry = (entry: CacheDirectoryEntry) => {
+  let metadata: BigIntStats
+  try {
+    metadata = lstatSync(entry.path, { bigint: true })
+  } catch (error) {
+    if (missingPath(error)) {
+      return changedLayout(entry.relativePath, 'directory-present')
+    }
+    throw error
+  }
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+    return changedLayout(entry.relativePath, 'real-directory')
+  }
+  if (!sameCacheEntryIdentity(entry, identityFrom(metadata))) {
+    return changedLayout(entry.relativePath, 'stable-identity')
+  }
+  if (!samePath(realpathSync.native(entry.path), entry.path)) {
+    return changedLayout(entry.relativePath, 'expected-realpath')
+  }
+}
+
+const assertContained = (repository: string, directory: string) => {
+  const cacheRelative = relative(repository, directory)
+  if (
+    cacheRelative.length === 0 ||
+    cacheRelative === '..' ||
+    cacheRelative.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`) ||
+    isAbsolute(cacheRelative)
+  ) {
+    return invalidLayout('node_modules/.cache/encephalon', 'repository-contained')
+  }
+}
+
+export const inspectCacheLocation = (root: string): CacheLocation => {
+  const repository = realpathSync.native(resolve(root))
+  const repositoryEntry = inspectDirectory(repository, '.', repository, false)
+  const entries = CACHE_COMPONENTS.reduce<CacheDirectoryEntry[]>(
+    (result, component) => {
+      const parent = result.at(-1) ?? repositoryEntry
+      const path = resolve(parent.path, component)
+      const relativePath = parent.relativePath === '.' ? component : `${parent.relativePath}/${component}`
+      return [...result, inspectDirectory(path, relativePath, path, true)]
+    },
+    [repositoryEntry],
+  )
+  const [capturedRepository, nodeModules, cache, directory] = entries
+  if (capturedRepository === undefined || nodeModules === undefined || cache === undefined || directory === undefined) {
+    return fail('INTERNAL_ERROR', 'The Encephalon cache location could not be captured.')
+  }
+  assertContained(repository, directory.path)
+  return {
+    directory: directory.path,
+    entries: [capturedRepository, nodeModules, cache, directory],
+    repository,
+  }
+}
+
+export const assertCacheLocation = (location: CacheLocation) => {
+  location.entries.forEach(assertDirectoryEntry)
+  assertContained(location.repository, location.directory)
+}
+
+const databaseRelativePath = (name: CacheDatabaseName) => `node_modules/.cache/encephalon/${name}`
+
+const inspectRegularFile = (path: string, relativePath: string): CacheEntryIdentity | undefined => {
+  let metadata: BigIntStats
+  try {
+    metadata = lstatSync(path, { bigint: true })
+  } catch (error) {
+    if (missingPath(error)) {
+      return
+    }
+    throw error
+  }
+  if (!metadata.isFile() || metadata.isSymbolicLink()) {
+    return invalidLayout(relativePath, 'regular-non-symlink-file')
+  }
+  const captured = identityFrom(metadata)
+  let descriptor: number | undefined
+  try {
+    descriptor = openSync(path, constants.O_RDONLY | NO_FOLLOW)
+    const opened = fstatSync(descriptor, { bigint: true })
+    if (!(opened.isFile() && sameCacheEntryIdentity(captured, identityFrom(opened)))) {
+      return changedLayout(relativePath, 'stable-open-identity')
+    }
+  } finally {
+    if (descriptor !== undefined) {
+      closeSync(descriptor)
+    }
+  }
+  return captured
+}
+
+const inspectSidecars = (location: CacheLocation, name: CacheDatabaseName) => {
+  for (const suffix of DATABASE_SIDECAR_SUFFIXES) {
+    inspectRegularFile(resolve(location.directory, `${name}${suffix}`), `${databaseRelativePath(name)}${suffix}`)
+  }
+}
+
+const bootstrapPrimary = (location: CacheLocation, name: CacheDatabaseName) => {
+  const path = resolve(location.directory, name)
+  const relativePath = databaseRelativePath(name)
+  let created = false
+  try {
+    const descriptor = openSync(path, constants.O_CREAT | constants.O_EXCL | constants.O_RDWR | NO_FOLLOW, 0o600)
+    closeSync(descriptor)
+    created = true
+  } catch (error) {
+    if (!existingPath(error)) {
+      throw error
+    }
+  }
+  const identity = inspectRegularFile(path, relativePath)
+  if (identity === undefined) {
+    return changedLayout(relativePath, created ? 'created-file-present' : 'existing-file-present')
+  }
+  return identity
+}
+
+export const prepareCacheDatabase = (location: CacheLocation, name: CacheDatabaseName): CacheDatabase => {
+  assertCacheLocation(location)
+  inspectSidecars(location, name)
+  const path = resolve(location.directory, name)
+  const existing = inspectRegularFile(path, databaseRelativePath(name))
+  const identity = existing ?? bootstrapPrimary(location, name)
+  assertCacheLocation(location)
+  inspectSidecars(location, name)
+  return { ...identity, name, path }
+}
+
+export const inspectCacheDatabase = (location: CacheLocation, name: CacheDatabaseName): CacheDatabase | undefined => {
+  assertCacheLocation(location)
+  inspectSidecars(location, name)
+  const path = resolve(location.directory, name)
+  const identity = inspectRegularFile(path, databaseRelativePath(name))
+  return identity === undefined ? undefined : { ...identity, name, path }
+}
+
+export const assertCacheDatabase = (location: CacheLocation, database: CacheDatabase) => {
+  assertCacheLocation(location)
+  const identity = inspectRegularFile(database.path, databaseRelativePath(database.name))
+  if (identity === undefined || !sameCacheEntryIdentity(database, identity)) {
+    return changedLayout(databaseRelativePath(database.name), 'stable-identity')
+  }
+  inspectSidecars(location, database.name)
+}
+
+const quarantineFile = (location: CacheLocation, path: string, relativePath: string) => {
+  const captured = inspectRegularFile(path, relativePath)
+  if (captured !== undefined) {
+    assertCacheLocation(location)
+    cacheLocationTestHooks.beforeQuarantineRename?.(path)
+    assertCacheLocation(location)
+    const current = inspectRegularFile(path, relativePath)
+    if (current === undefined || !sameCacheEntryIdentity(captured, current)) {
+      return changedLayout(relativePath, 'stable-quarantine-source')
+    }
+    const quarantineName = `.${relativePath.split('/').at(-1)}.${randomUUID()}.quarantine`
+    const quarantinePath = resolve(location.directory, quarantineName)
+    renameSync(path, quarantinePath)
+    assertCacheLocation(location)
+    cacheLocationTestHooks.afterQuarantineRename?.(quarantinePath)
+    assertCacheLocation(location)
+    const quarantined = inspectRegularFile(quarantinePath, `node_modules/.cache/encephalon/${quarantineName}`)
+    if (quarantined === undefined || !sameCacheEntryIdentity(captured, quarantined)) {
+      return changedLayout(relativePath, 'stable-quarantine-identity')
+    }
+    unlinkSync(quarantinePath)
+    assertCacheLocation(location)
+  }
+}
+
+export const quarantineCacheDatabase = (location: CacheLocation, name: CacheDatabaseName) => {
+  assertCacheLocation(location)
+  for (const suffix of [...DATABASE_SIDECAR_SUFFIXES, ''] as const) {
+    const candidateName = `${name}${suffix}`
+    quarantineFile(
+      location,
+      resolve(location.directory, candidateName),
+      `node_modules/.cache/encephalon/${candidateName}`,
+    )
+  }
+}
+
+const safeOwnedDirectoryName = (name: string) =>
+  name === 'operation.lock' || name === 'operation-lock.recovery' || /^operation\.lock\.[0-9a-f-]{36}$/u.test(name)
+
+const ownedDirectoryRelativePath = (name: string) => `node_modules/.cache/encephalon/${name}`
+
+const inspectOwnedDirectoryPath = (location: CacheLocation, name: string): CacheOwnedDirectory | undefined => {
+  if (!safeOwnedDirectoryName(name)) {
+    return fail('INTERNAL_ERROR', 'An unsupported cache directory name was requested.')
+  }
+  const path = resolve(location.directory, name)
+  let metadata: BigIntStats
+  try {
+    metadata = lstatSync(path, { bigint: true })
+  } catch (error) {
+    if (missingPath(error)) {
+      return
+    }
+    throw error
+  }
+  if (!metadata.isDirectory() || metadata.isSymbolicLink() || !samePath(realpathSync.native(path), path)) {
+    return invalidLayout(ownedDirectoryRelativePath(name), 'real-directory')
+  }
+  return { ...identityFrom(metadata), name, path }
+}
+
+export const inspectCacheOwnedDirectory = (location: CacheLocation, name: string) => {
+  assertCacheLocation(location)
+  return inspectOwnedDirectoryPath(location, name)
+}
+
+export const assertCacheOwnedEntries = (location: CacheLocation) => {
+  assertCacheLocation(location)
+  readdirSync(location.directory)
+    .filter(name => /^operation\.lock\.[0-9a-f-]{36}$/u.test(name))
+    .map(name => inspectOwnedDirectoryPath(location, name))
+}
+
+export const createCacheOwnedDirectory = (location: CacheLocation, name: string) => {
+  assertCacheLocation(location)
+  if (!safeOwnedDirectoryName(name)) {
+    return fail('INTERNAL_ERROR', 'An unsupported cache directory name was requested.')
+  }
+  mkdirSync(resolve(location.directory, name))
+  const directory = inspectOwnedDirectoryPath(location, name)
+  if (directory === undefined) {
+    return changedLayout(ownedDirectoryRelativePath(name), 'created-directory-present')
+  }
+  return directory
+}
+
+const assertOwnedDirectory = (location: CacheLocation, directory: CacheOwnedDirectory) => {
+  assertCacheLocation(location)
+  const current = inspectOwnedDirectoryPath(location, directory.name)
+  if (current === undefined || !sameCacheEntryIdentity(directory, current)) {
+    return changedLayout(ownedDirectoryRelativePath(directory.name), 'stable-identity')
+  }
+}
+
+export const writeCacheOwner = (location: CacheLocation, directory: CacheOwnedDirectory, contents: string) => {
+  assertOwnedDirectory(location, directory)
+  const path = resolve(directory.path, 'owner.json')
+  const descriptor = openSync(path, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | NO_FOLLOW, 0o600)
+  try {
+    const bytes = Buffer.from(contents)
+    let offset = 0
+    while (offset < bytes.length) {
+      offset += writeSync(descriptor, bytes, offset)
+    }
+  } finally {
+    closeSync(descriptor)
+  }
+  assertOwnedDirectory(location, directory)
+  inspectRegularFile(path, `${ownedDirectoryRelativePath(directory.name)}/owner.json`)
+}
+
+export const readCacheOwner = (location: CacheLocation, directory: CacheOwnedDirectory, maximumBytes: number) => {
+  assertOwnedDirectory(location, directory)
+  const path = resolve(directory.path, 'owner.json')
+  const captured = inspectRegularFile(path, `${ownedDirectoryRelativePath(directory.name)}/owner.json`)
+  if (captured === undefined) {
+    return
+  }
+  const descriptor = openSync(path, constants.O_RDONLY | NO_FOLLOW)
+  try {
+    const metadata = fstatSync(descriptor, { bigint: true })
+    if (!sameCacheEntryIdentity(captured, identityFrom(metadata)) || metadata.size > BigInt(maximumBytes)) {
+      return invalidLayout(`${ownedDirectoryRelativePath(directory.name)}/owner.json`, 'bounded-stable-owner-file')
+    }
+    const bytes = Buffer.alloc(Number(metadata.size))
+    const read = readSync(descriptor, bytes, 0, bytes.length, 0)
+    if (read !== bytes.length) {
+      return changedLayout(`${ownedDirectoryRelativePath(directory.name)}/owner.json`, 'complete-owner-read')
+    }
+    return bytes.toString('utf8')
+  } finally {
+    closeSync(descriptor)
+  }
+}
+
+export const quarantineCacheOwnedDirectory = (location: CacheLocation, directory: CacheOwnedDirectory) => {
+  assertOwnedDirectory(location, directory)
+  cacheLocationTestHooks.beforeQuarantineRename?.(directory.path)
+  assertOwnedDirectory(location, directory)
+  const quarantineName = `.${directory.name}.${randomUUID()}.quarantine`
+  const quarantinePath = resolve(location.directory, quarantineName)
+  renameSync(directory.path, quarantinePath)
+  assertCacheLocation(location)
+  cacheLocationTestHooks.afterQuarantineRename?.(quarantinePath)
+  assertCacheLocation(location)
+  const metadata = lstatSync(quarantinePath, { bigint: true })
+  if (!(metadata.isDirectory() && sameCacheEntryIdentity(directory, identityFrom(metadata)))) {
+    return changedLayout(ownedDirectoryRelativePath(directory.name), 'stable-quarantine-identity')
+  }
+  const ownerPath = resolve(quarantinePath, 'owner.json')
+  const owner = inspectRegularFile(ownerPath, `${ownedDirectoryRelativePath(directory.name)}/owner.json`)
+  if (owner !== undefined) {
+    unlinkSync(ownerPath)
+  }
+  rmdirSync(quarantinePath)
+  assertCacheLocation(location)
+}

--- a/src/cache-location.ts
+++ b/src/cache-location.ts
@@ -73,6 +73,7 @@ type VerifiedCacheDatabaseOptions<Database> = {
     readOnly?: boolean
     timeout?: number
   }
+  preserveDatabaseLocksAfterInitialisation?: boolean
 }
 
 export type CacheOwnedDirectory = CacheEntryIdentity & {
@@ -114,6 +115,7 @@ type CacheLocationTestHooks = {
   afterQuarantineRename?: ((path: string) => void) | undefined
   beforeDatabaseOpen?: ((database: CacheDatabase) => void) | undefined
   beforeLocationInspection?: (() => void) | undefined
+  beforeOwnedDirectoryFinalIdentity?: ((path: string) => void) | undefined
   beforeQuarantineRename?: ((path: string) => void) | undefined
   duringOwnedDirectoryInspection?: ((path: string) => void) | undefined
 }
@@ -386,6 +388,56 @@ export const assertCacheDatabase = (location: CacheLocation, database: CacheData
   return { ...database, sidecars: reconcileSidecars(location, database) }
 }
 
+const assertCacheDatabaseMetadata = (location: CacheLocation, database: CacheDatabase) => {
+  // Closing another descriptor for this file can release process-scoped POSIX
+  // locks, so the operation gate uses metadata continuity after BEGIN.
+  assertCacheLocation(location)
+  let initialMetadata: BigIntStats
+  try {
+    initialMetadata = lstatSync(database.path, { bigint: true })
+  } catch (error) {
+    if (missingPath(error)) {
+      return changedLayout(databaseRelativePath(database.name), 'stable-identity')
+    }
+    throw error
+  }
+  if (!initialMetadata.isFile() || initialMetadata.isSymbolicLink()) {
+    return invalidLayout(databaseRelativePath(database.name), 'regular-non-symlink-file')
+  }
+  const captured = identityFrom(initialMetadata)
+  let actualRealpath: string
+  try {
+    actualRealpath = realpathSync.native(database.path)
+  } catch (error) {
+    if (missingPath(error)) {
+      return changedLayout(databaseRelativePath(database.name), 'stable-identity')
+    }
+    throw error
+  }
+  if (!samePath(actualRealpath, database.path)) {
+    return invalidLayout(databaseRelativePath(database.name), 'expected-realpath')
+  }
+  let finalMetadata: BigIntStats
+  try {
+    finalMetadata = lstatSync(database.path, { bigint: true })
+  } catch (error) {
+    if (missingPath(error)) {
+      return changedLayout(databaseRelativePath(database.name), 'stable-identity')
+    }
+    throw error
+  }
+  if (
+    !finalMetadata.isFile() ||
+    finalMetadata.isSymbolicLink() ||
+    !sameCacheEntryIdentity(database, captured) ||
+    !sameCacheEntryIdentity(captured, identityFrom(finalMetadata))
+  ) {
+    return changedLayout(databaseRelativePath(database.name), 'stable-identity')
+  }
+  assertCacheLocation(location)
+  return { ...database, sidecars: reconcileSidecars(location, database) }
+}
+
 export const openVerifiedCacheDatabase = <Database extends { close: () => void }>(
   options: VerifiedCacheDatabaseOptions<Database>,
 ) => {
@@ -424,7 +476,9 @@ export const openVerifiedCacheDatabase = <Database extends { close: () => void }
       cacheLocationTestHooks.afterDatabaseOpen?.(snapshot)
       snapshot = assertCacheDatabase(options.location, snapshot)
       options.afterVerifiedOpen?.(database)
-      snapshot = assertCacheDatabase(options.location, snapshot)
+      snapshot = options.preserveDatabaseLocksAfterInitialisation
+        ? assertCacheDatabaseMetadata(options.location, snapshot)
+        : assertCacheDatabase(options.location, snapshot)
       return { database, snapshot }
     } catch (error) {
       if (error instanceof CacheDatabaseSidecarChanged) {
@@ -505,7 +559,12 @@ const safeOwnedDirectoryName = (name: string) =>
 
 const ownedDirectoryRelativePath = (name: string) => `node_modules/.cache/encephalon/${name}`
 
-const inspectOwnedDirectoryPath = (location: CacheLocation, name: string): CacheOwnedDirectory | undefined => {
+type CacheOwnedDirectoryObservation =
+  | { kind: 'changed' }
+  | { kind: 'missing' }
+  | { directory: CacheOwnedDirectory; kind: 'stable' }
+
+const observeOwnedDirectoryPath = (location: CacheLocation, name: string): CacheOwnedDirectoryObservation => {
   if (!safeOwnedDirectoryName(name)) {
     return fail('INTERNAL_ERROR', 'An unsupported cache directory name was requested.')
   }
@@ -515,7 +574,19 @@ const inspectOwnedDirectoryPath = (location: CacheLocation, name: string): Cache
     initialMetadata = lstatSync(path, { bigint: true })
   } catch (error) {
     if (missingPath(error)) {
-      return
+      cacheLocationTestHooks.duringOwnedDirectoryInspection?.(path)
+      try {
+        const replacement = lstatSync(path, { bigint: true })
+        if (!replacement.isDirectory() || replacement.isSymbolicLink()) {
+          return invalidLayout(ownedDirectoryRelativePath(name), 'real-directory')
+        }
+        return { kind: 'changed' }
+      } catch (candidate) {
+        if (missingPath(candidate)) {
+          return { kind: 'missing' }
+        }
+        throw candidate
+      }
     }
     throw error
   }
@@ -529,19 +600,20 @@ const inspectOwnedDirectoryPath = (location: CacheLocation, name: string): Cache
     actualRealpath = realpathSync.native(path)
   } catch (error) {
     if (missingPath(error)) {
-      return
+      return { kind: 'changed' }
     }
     throw error
   }
   if (!samePath(actualRealpath, path)) {
     return invalidLayout(ownedDirectoryRelativePath(name), 'real-directory')
   }
+  cacheLocationTestHooks.beforeOwnedDirectoryFinalIdentity?.(path)
   let finalMetadata: BigIntStats
   try {
     finalMetadata = lstatSync(path, { bigint: true })
   } catch (error) {
     if (missingPath(error)) {
-      return
+      return { kind: 'changed' }
     }
     throw error
   }
@@ -549,14 +621,24 @@ const inspectOwnedDirectoryPath = (location: CacheLocation, name: string): Cache
     return invalidLayout(ownedDirectoryRelativePath(name), 'real-directory')
   }
   if (!sameCacheEntryIdentity(captured, identityFrom(finalMetadata))) {
-    return
+    return { kind: 'changed' }
   }
-  return { ...captured, name, path }
+  return { directory: { ...captured, name, path }, kind: 'stable' }
+}
+
+export const observeCacheOwnedDirectory = (location: CacheLocation, name: string) => {
+  assertCacheLocation(location)
+  const observation = observeOwnedDirectoryPath(location, name)
+  assertCacheLocation(location)
+  return observation
 }
 
 export const inspectCacheOwnedDirectory = (location: CacheLocation, name: string) => {
-  assertCacheLocation(location)
-  return inspectOwnedDirectoryPath(location, name)
+  const observation = observeCacheOwnedDirectory(location, name)
+  if (observation.kind === 'changed') {
+    return changedLayout(ownedDirectoryRelativePath(name), 'stable-identity')
+  }
+  return observation.kind === 'stable' ? observation.directory : undefined
 }
 
 export const assertCacheLockCandidates = (location: CacheLocation) => {
@@ -564,7 +646,7 @@ export const assertCacheLockCandidates = (location: CacheLocation) => {
   const candidates = readdirSync(location.directory).filter(name => /^operation\.lock\.[0-9a-f-]{36}$/u.test(name))
   // biome-ignore lint/complexity/noForEach: validation intentionally visits every candidate entry.
   candidates.forEach(name => {
-    inspectOwnedDirectoryPath(location, name)
+    observeCacheOwnedDirectory(location, name)
   })
 }
 
@@ -574,25 +656,23 @@ export const createCacheOwnedDirectory = (location: CacheLocation, name: string)
     return fail('INTERNAL_ERROR', 'An unsupported cache directory name was requested.')
   }
   mkdirSync(resolve(location.directory, name))
-  const directory = inspectOwnedDirectoryPath(location, name)
-  if (directory === undefined) {
+  const observation = observeCacheOwnedDirectory(location, name)
+  if (observation.kind !== 'stable') {
     return changedLayout(ownedDirectoryRelativePath(name), 'created-directory-present')
   }
-  return directory
+  return observation.directory
 }
 
 const assertOwnedDirectory = (location: CacheLocation, directory: CacheOwnedDirectory) => {
-  assertCacheLocation(location)
-  const current = inspectOwnedDirectoryPath(location, directory.name)
-  if (current === undefined || !sameCacheEntryIdentity(directory, current)) {
+  const observation = observeCacheOwnedDirectory(location, directory.name)
+  if (observation.kind !== 'stable' || !sameCacheEntryIdentity(directory, observation.directory)) {
     return changedLayout(ownedDirectoryRelativePath(directory.name), 'stable-identity')
   }
 }
 
 export const cacheOwnedDirectoryIsCurrent = (location: CacheLocation, directory: CacheOwnedDirectory) => {
-  assertCacheLocation(location)
-  const current = inspectOwnedDirectoryPath(location, directory.name)
-  return current !== undefined && sameCacheEntryIdentity(directory, current)
+  const observation = observeCacheOwnedDirectory(location, directory.name)
+  return observation.kind === 'stable' && sameCacheEntryIdentity(directory, observation.directory)
 }
 
 export const cacheOwnedDirectoryMtimeMilliseconds = (location: CacheLocation, directory: CacheOwnedDirectory) => {
@@ -610,18 +690,18 @@ export const promoteCacheOwnedDirectory = (
   targetName: 'operation.lock',
 ) => {
   assertOwnedDirectory(location, directory)
-  const existingTarget = inspectOwnedDirectoryPath(location, targetName)
-  if (existingTarget !== undefined) {
+  const targetObservation = observeCacheOwnedDirectory(location, targetName)
+  if (targetObservation.kind !== 'missing') {
     return changedLayout(ownedDirectoryRelativePath(targetName), 'promotion-target-missing')
   }
   const targetPath = resolve(location.directory, targetName)
   renameSync(directory.path, targetPath)
   assertCacheLocation(location)
-  const promoted = inspectOwnedDirectoryPath(location, targetName)
-  if (promoted === undefined || !sameCacheEntryIdentity(directory, promoted)) {
+  const promoted = observeCacheOwnedDirectory(location, targetName)
+  if (promoted.kind !== 'stable' || !sameCacheEntryIdentity(directory, promoted.directory)) {
     return changedLayout(ownedDirectoryRelativePath(targetName), 'stable-promoted-identity')
   }
-  return promoted
+  return promoted.directory
 }
 
 export const writeCacheOwner = (location: CacheLocation, directory: CacheOwnedDirectory, contents: string) => {

--- a/src/cache-location.ts
+++ b/src/cache-location.ts
@@ -21,7 +21,7 @@ import { EncephalonError, fail } from './errors.ts'
 const CACHE_COMPONENTS = ['node_modules', '.cache', 'encephalon'] as const
 const DATABASE_SIDECAR_SUFFIXES = ['-wal', '-shm', '-journal'] as const
 const OPTIONAL_FILE_OBSERVATION_ATTEMPTS = 3
-export const MAX_CACHE_DATABASE_OPEN_ATTEMPTS = 3
+const MAX_CACHE_DATABASE_OPEN_ATTEMPTS = 3
 const NO_FOLLOW = constants.O_NOFOLLOW ?? 0
 
 export type CacheEntryIdentity = {
@@ -54,6 +54,27 @@ export type CacheDatabase = CacheFile & {
 
 export type CacheDatabaseName = 'brain.sqlite' | 'operation-lock.sqlite'
 
+type CacheDatabaseConstructor<Database> = new (
+  path: string,
+  options?: {
+    readOnly?: boolean
+    timeout?: number
+  },
+) => Database
+
+type VerifiedCacheDatabaseOptions<Database> = {
+  afterVerifiedOpen?: ((database: Database) => void) | undefined
+  create: boolean
+  DatabaseConstructor: CacheDatabaseConstructor<Database>
+  location: CacheLocation
+  missing?: (() => never) | undefined
+  name: CacheDatabaseName
+  openOptions?: {
+    readOnly?: boolean
+    timeout?: number
+  }
+}
+
 export type CacheOwnedDirectory = CacheEntryIdentity & {
   name: string
   path: string
@@ -71,7 +92,7 @@ export class CacheDatabaseFailure extends Error {
   }
 }
 
-export class CacheDatabaseSidecarChanged extends EncephalonError {
+class CacheDatabaseSidecarChanged extends EncephalonError {
   readonly database: CacheDatabase
 
   constructor(database: CacheDatabase, relativePath: string) {
@@ -94,6 +115,7 @@ type CacheLocationTestHooks = {
   beforeDatabaseOpen?: ((database: CacheDatabase) => void) | undefined
   beforeLocationInspection?: (() => void) | undefined
   beforeQuarantineRename?: ((path: string) => void) | undefined
+  duringOwnedDirectoryInspection?: ((path: string) => void) | undefined
 }
 
 export const cacheLocationTestHooks: CacheLocationTestHooks = {}
@@ -337,7 +359,7 @@ const bootstrapPrimary = (location: CacheLocation, name: CacheDatabaseName) => {
   return identity
 }
 
-export const prepareCacheDatabase = (location: CacheLocation, name: CacheDatabaseName): CacheDatabase => {
+const prepareCacheDatabase = (location: CacheLocation, name: CacheDatabaseName): CacheDatabase => {
   assertCacheLocation(location)
   const sidecars = inspectSidecars(location, name)
   const path = resolve(location.directory, name)
@@ -364,21 +386,72 @@ export const assertCacheDatabase = (location: CacheLocation, database: CacheData
   return { ...database, sidecars: reconcileSidecars(location, database) }
 }
 
-export const refreshCacheDatabase = (location: CacheLocation, database: CacheDatabase) => {
-  assertCacheLocation(location)
-  const identity = inspectRegularFile(database.path, database.relativePath)
-  if (identity === undefined || !sameCacheEntryIdentity(database, identity)) {
-    return changedLayout(database.relativePath, 'stable-identity')
+export const openVerifiedCacheDatabase = <Database extends { close: () => void }>(
+  options: VerifiedCacheDatabaseOptions<Database>,
+) => {
+  const initial = options.create
+    ? prepareCacheDatabase(options.location, options.name)
+    : inspectCacheDatabase(options.location, options.name)
+  if (initial === undefined) {
+    if (options.missing !== undefined) {
+      return options.missing()
+    }
+    return fail('INTERNAL_ERROR', 'The requested Encephalon cache database is missing.')
   }
-  return { ...database, sidecars: reconcileSidecars(location, database) }
-}
-
-export const cacheDatabaseWillOpen = (database: CacheDatabase) => {
-  cacheLocationTestHooks.beforeDatabaseOpen?.(database)
-}
-
-export const cacheDatabaseDidOpen = (database: CacheDatabase) => {
-  cacheLocationTestHooks.afterDatabaseOpen?.(database)
+  let snapshot = initial
+  const attempts = Array.from({ length: MAX_CACHE_DATABASE_OPEN_ATTEMPTS }, (_, index) => index)
+  for (const attempt of attempts) {
+    try {
+      cacheLocationTestHooks.beforeDatabaseOpen?.(snapshot)
+      snapshot = assertCacheDatabase(options.location, snapshot)
+    } catch (error) {
+      if (error instanceof CacheDatabaseSidecarChanged) {
+        snapshot = error.database
+        if (attempt === MAX_CACHE_DATABASE_OPEN_ATTEMPTS - 1) {
+          throw error
+        }
+        continue
+      }
+      throw error
+    }
+    let database: Database
+    try {
+      database = new options.DatabaseConstructor(snapshot.path, options.openOptions)
+    } catch (error) {
+      return failCacheDatabase(error, snapshot)
+    }
+    try {
+      cacheLocationTestHooks.afterDatabaseOpen?.(snapshot)
+      snapshot = assertCacheDatabase(options.location, snapshot)
+      options.afterVerifiedOpen?.(database)
+      snapshot = assertCacheDatabase(options.location, snapshot)
+      return { database, snapshot }
+    } catch (error) {
+      if (error instanceof CacheDatabaseSidecarChanged) {
+        database.close()
+        snapshot = error.database
+        if (attempt === MAX_CACHE_DATABASE_OPEN_ATTEMPTS - 1) {
+          throw error
+        }
+      } else {
+        let validationError: unknown
+        try {
+          snapshot = assertCacheDatabase(options.location, snapshot)
+        } catch (candidate) {
+          validationError = candidate
+        }
+        database.close()
+        if (validationError !== undefined) {
+          throw validationError
+        }
+        if (error instanceof EncephalonError) {
+          throw error
+        }
+        return failCacheDatabase(error, snapshot)
+      }
+    }
+  }
+  return fail('INTERNAL_ERROR', 'The verified Encephalon cache database open ended unexpectedly.')
 }
 
 const quarantineFile = (location: CacheLocation, expected: CacheFile, required: boolean) => {
@@ -437,19 +510,48 @@ const inspectOwnedDirectoryPath = (location: CacheLocation, name: string): Cache
     return fail('INTERNAL_ERROR', 'An unsupported cache directory name was requested.')
   }
   const path = resolve(location.directory, name)
-  let metadata: BigIntStats
+  let initialMetadata: BigIntStats
   try {
-    metadata = lstatSync(path, { bigint: true })
+    initialMetadata = lstatSync(path, { bigint: true })
   } catch (error) {
     if (missingPath(error)) {
       return
     }
     throw error
   }
-  if (!metadata.isDirectory() || metadata.isSymbolicLink() || !samePath(realpathSync.native(path), path)) {
+  if (!initialMetadata.isDirectory() || initialMetadata.isSymbolicLink()) {
     return invalidLayout(ownedDirectoryRelativePath(name), 'real-directory')
   }
-  return { ...identityFrom(metadata), name, path }
+  const captured = identityFrom(initialMetadata)
+  cacheLocationTestHooks.duringOwnedDirectoryInspection?.(path)
+  let actualRealpath: string
+  try {
+    actualRealpath = realpathSync.native(path)
+  } catch (error) {
+    if (missingPath(error)) {
+      return
+    }
+    throw error
+  }
+  if (!samePath(actualRealpath, path)) {
+    return invalidLayout(ownedDirectoryRelativePath(name), 'real-directory')
+  }
+  let finalMetadata: BigIntStats
+  try {
+    finalMetadata = lstatSync(path, { bigint: true })
+  } catch (error) {
+    if (missingPath(error)) {
+      return
+    }
+    throw error
+  }
+  if (!finalMetadata.isDirectory() || finalMetadata.isSymbolicLink()) {
+    return invalidLayout(ownedDirectoryRelativePath(name), 'real-directory')
+  }
+  if (!sameCacheEntryIdentity(captured, identityFrom(finalMetadata))) {
+    return
+  }
+  return { ...captured, name, path }
 }
 
 export const inspectCacheOwnedDirectory = (location: CacheLocation, name: string) => {

--- a/src/cache-location.ts
+++ b/src/cache-location.ts
@@ -29,6 +29,14 @@ export type CacheEntryIdentity = {
   ino: bigint
 }
 
+type CacheEntryIncarnation = CacheEntryIdentity & {
+  birthtimeNs: bigint
+  ctimeNs: bigint
+  mode: bigint
+  mtimeNs: bigint
+  size: bigint
+}
+
 type CacheDirectoryEntry = CacheEntryIdentity & {
   path: string
   relativePath: string
@@ -131,6 +139,23 @@ const identityFrom = (metadata: BigIntStats): CacheEntryIdentity => ({
   ino: metadata.ino,
 })
 
+const incarnationFrom = (metadata: BigIntStats): CacheEntryIncarnation => ({
+  ...identityFrom(metadata),
+  birthtimeNs: metadata.birthtimeNs,
+  ctimeNs: metadata.ctimeNs,
+  mode: metadata.mode,
+  mtimeNs: metadata.mtimeNs,
+  size: metadata.size,
+})
+
+const sameCacheEntryIncarnation = (first: CacheEntryIncarnation, second: CacheEntryIncarnation) =>
+  sameCacheEntryIdentity(first, second) &&
+  first.birthtimeNs === second.birthtimeNs &&
+  first.ctimeNs === second.ctimeNs &&
+  first.mode === second.mode &&
+  first.mtimeNs === second.mtimeNs &&
+  first.size === second.size
+
 const missingPath = (error: unknown) => (error as NodeJS.ErrnoException).code === 'ENOENT'
 
 const existingPath = (error: unknown) => (error as NodeJS.ErrnoException).code === 'EEXIST'
@@ -153,6 +178,17 @@ const changedLayout = (relativePath: string, invariant: string): never =>
     entry: relativePath,
     invariant,
   })
+
+const quarantineMetadata = (path: string, relativePath: string) => {
+  try {
+    return lstatSync(path, { bigint: true })
+  } catch (error) {
+    if (missingPath(error)) {
+      return changedLayout(relativePath, 'stable-quarantine-identity')
+    }
+    throw error
+  }
+}
 
 const inspectDirectory = (
   path: string,
@@ -579,10 +615,19 @@ const quarantineFile = (location: CacheLocation, expected: CacheFile, required: 
     const quarantinePath = resolve(location.directory, quarantineName)
     renameSync(expected.path, quarantinePath)
     assertCacheLocation(location)
+    const movedMetadata = quarantineMetadata(quarantinePath, expected.relativePath)
+    if (!(movedMetadata.isFile() && sameCacheEntryIdentity(expected, identityFrom(movedMetadata)))) {
+      return changedLayout(expected.relativePath, 'stable-quarantine-identity')
+    }
+    const movedIncarnation = incarnationFrom(movedMetadata)
     cacheLocationTestHooks.afterQuarantineRename?.(quarantinePath)
     assertCacheLocation(location)
-    const quarantined = inspectRegularFile(quarantinePath, `node_modules/.cache/encephalon/${quarantineName}`)
-    if (quarantined === undefined || !sameCacheEntryIdentity(expected, quarantined)) {
+    const quarantinedMetadata = quarantineMetadata(quarantinePath, expected.relativePath)
+    if (
+      !quarantinedMetadata.isFile() ||
+      quarantinedMetadata.isSymbolicLink() ||
+      !sameCacheEntryIncarnation(movedIncarnation, incarnationFrom(quarantinedMetadata))
+    ) {
       return changedLayout(expected.relativePath, 'stable-quarantine-identity')
     }
     unlinkSync(quarantinePath)
@@ -800,10 +845,15 @@ export const quarantineCacheOwnedDirectory = (location: CacheLocation, directory
   const quarantinePath = resolve(location.directory, quarantineName)
   renameSync(directory.path, quarantinePath)
   assertCacheLocation(location)
+  const movedMetadata = quarantineMetadata(quarantinePath, ownedDirectoryRelativePath(directory.name))
+  if (!(movedMetadata.isDirectory() && sameCacheEntryIdentity(directory, identityFrom(movedMetadata)))) {
+    return changedLayout(ownedDirectoryRelativePath(directory.name), 'stable-quarantine-identity')
+  }
+  const movedIncarnation = incarnationFrom(movedMetadata)
   cacheLocationTestHooks.afterQuarantineRename?.(quarantinePath)
   assertCacheLocation(location)
-  const metadata = lstatSync(quarantinePath, { bigint: true })
-  if (!(metadata.isDirectory() && sameCacheEntryIdentity(directory, identityFrom(metadata)))) {
+  const metadata = quarantineMetadata(quarantinePath, ownedDirectoryRelativePath(directory.name))
+  if (!(metadata.isDirectory() && sameCacheEntryIncarnation(movedIncarnation, incarnationFrom(metadata)))) {
     return changedLayout(ownedDirectoryRelativePath(directory.name), 'stable-quarantine-identity')
   }
   const ownerPath = resolve(quarantinePath, 'owner.json')

--- a/src/cache-location.ts
+++ b/src/cache-location.ts
@@ -16,11 +16,12 @@ import {
   writeSync,
 } from 'node:fs'
 import { isAbsolute, relative, resolve } from 'node:path'
-import { fail } from './errors.ts'
+import { EncephalonError, fail } from './errors.ts'
 
 const CACHE_COMPONENTS = ['node_modules', '.cache', 'encephalon'] as const
 const DATABASE_SIDECAR_SUFFIXES = ['-wal', '-shm', '-journal'] as const
 const OPTIONAL_FILE_OBSERVATION_ATTEMPTS = 3
+export const MAX_CACHE_DATABASE_OPEN_ATTEMPTS = 3
 const NO_FOLLOW = constants.O_NOFOLLOW ?? 0
 
 export type CacheEntryIdentity = {
@@ -70,13 +71,28 @@ export class CacheDatabaseFailure extends Error {
   }
 }
 
+export class CacheDatabaseSidecarChanged extends EncephalonError {
+  readonly database: CacheDatabase
+
+  constructor(database: CacheDatabase, relativePath: string) {
+    super('REPOSITORY_CHANGED', 'The Encephalon cache layout changed during the operation.', {
+      entry: relativePath,
+      invariant: 'stable-identity',
+    })
+    this.name = 'CacheDatabaseSidecarChanged'
+    this.database = database
+  }
+}
+
 export const failCacheDatabase = (failure: unknown, database: CacheDatabase): never => {
   throw new CacheDatabaseFailure(failure, database, { cause: failure })
 }
 
 type CacheLocationTestHooks = {
+  afterDatabaseOpen?: ((database: CacheDatabase) => void) | undefined
   afterQuarantineRename?: ((path: string) => void) | undefined
   beforeDatabaseOpen?: ((database: CacheDatabase) => void) | undefined
+  beforeLocationInspection?: (() => void) | undefined
   beforeQuarantineRename?: ((path: string) => void) | undefined
 }
 
@@ -181,6 +197,7 @@ const assertContained = (repository: string, directory: string) => {
 }
 
 export const inspectCacheLocation = (root: string): CacheLocation => {
+  cacheLocationTestHooks.beforeLocationInspection?.()
   const repository = realpathSync.native(resolve(root))
   const repositoryEntry = inspectDirectory(repository, '.', repository, false)
   const entries = CACHE_COMPONENTS.reduce<CacheDirectoryEntry[]>(
@@ -285,13 +302,16 @@ const inspectSidecars = (location: CacheLocation, name: CacheDatabaseName) =>
     return file === undefined ? sidecars : { ...sidecars, [suffix]: file }
   }, {})
 
-const assertSidecars = (location: CacheLocation, database: CacheDatabase) => {
+const reconcileSidecars = (location: CacheLocation, database: CacheDatabase) => {
   const observed = inspectSidecars(location, database.name)
   for (const suffix of DATABASE_SIDECAR_SUFFIXES) {
     const expected = database.sidecars[suffix]
     const current = observed[suffix]
-    if (expected !== undefined && (current === undefined || !sameCacheEntryIdentity(expected, current))) {
-      return changedLayout(`${databaseRelativePath(database.name)}${suffix}`, 'stable-identity')
+    if (expected !== undefined && current !== undefined && !sameCacheEntryIdentity(expected, current)) {
+      throw new CacheDatabaseSidecarChanged(
+        { ...database, sidecars: observed },
+        `${databaseRelativePath(database.name)}${suffix}`,
+      )
     }
   }
   return observed
@@ -341,7 +361,7 @@ export const assertCacheDatabase = (location: CacheLocation, database: CacheData
   if (identity === undefined || !sameCacheEntryIdentity(database, identity)) {
     return changedLayout(databaseRelativePath(database.name), 'stable-identity')
   }
-  return { ...database, sidecars: { ...database.sidecars, ...assertSidecars(location, database) } }
+  return { ...database, sidecars: reconcileSidecars(location, database) }
 }
 
 export const refreshCacheDatabase = (location: CacheLocation, database: CacheDatabase) => {
@@ -350,11 +370,15 @@ export const refreshCacheDatabase = (location: CacheLocation, database: CacheDat
   if (identity === undefined || !sameCacheEntryIdentity(database, identity)) {
     return changedLayout(database.relativePath, 'stable-identity')
   }
-  return { ...database, sidecars: inspectSidecars(location, database.name) }
+  return { ...database, sidecars: reconcileSidecars(location, database) }
 }
 
 export const cacheDatabaseWillOpen = (database: CacheDatabase) => {
   cacheLocationTestHooks.beforeDatabaseOpen?.(database)
+}
+
+export const cacheDatabaseDidOpen = (database: CacheDatabase) => {
+  cacheLocationTestHooks.afterDatabaseOpen?.(database)
 }
 
 const quarantineFile = (location: CacheLocation, expected: CacheFile, required: boolean) => {

--- a/src/cache-location.ts
+++ b/src/cache-location.ts
@@ -111,6 +111,7 @@ export const failCacheDatabase = (failure: unknown, database: CacheDatabase): ne
 }
 
 type CacheLocationTestHooks = {
+  afterDatabaseLockInitialisation?: ((database: CacheDatabase) => void) | undefined
   afterDatabaseOpen?: ((database: CacheDatabase) => void) | undefined
   afterQuarantineRename?: ((path: string) => void) | undefined
   beforeDatabaseOpen?: ((database: CacheDatabase) => void) | undefined
@@ -316,6 +317,65 @@ const inspectRegularFile = (path: string, relativePath: string, optional = false
   return changedLayout(relativePath, 'stable-open-identity')
 }
 
+const inspectRegularFileMetadataOnce = (path: string, relativePath: string): RegularFileInspection => {
+  let initialMetadata: BigIntStats
+  try {
+    initialMetadata = lstatSync(path, { bigint: true })
+  } catch (error) {
+    if (missingPath(error)) {
+      return { kind: 'missing' }
+    }
+    throw error
+  }
+  if (!initialMetadata.isFile() || initialMetadata.isSymbolicLink()) {
+    return invalidLayout(relativePath, 'regular-non-symlink-file')
+  }
+  const captured = identityFrom(initialMetadata)
+  let actualRealpath: string
+  try {
+    actualRealpath = realpathSync.native(path)
+  } catch (error) {
+    if (missingPath(error)) {
+      return { kind: 'changed' }
+    }
+    throw error
+  }
+  if (!samePath(actualRealpath, path)) {
+    return invalidLayout(relativePath, 'expected-realpath')
+  }
+  let finalMetadata: BigIntStats
+  try {
+    finalMetadata = lstatSync(path, { bigint: true })
+  } catch (error) {
+    if (missingPath(error)) {
+      return { kind: 'changed' }
+    }
+    throw error
+  }
+  if (
+    !finalMetadata.isFile() ||
+    finalMetadata.isSymbolicLink() ||
+    !sameCacheEntryIdentity(captured, identityFrom(finalMetadata))
+  ) {
+    return { kind: 'changed' }
+  }
+  return { file: { ...captured, path, relativePath }, kind: 'stable' }
+}
+
+const inspectRegularFileMetadata = (path: string, relativePath: string, optional = false): CacheFile | undefined => {
+  const attempts = optional ? OPTIONAL_FILE_OBSERVATION_ATTEMPTS : 1
+  for (const attempt of Array.from({ length: attempts }, (_, index) => index)) {
+    const inspection = inspectRegularFileMetadataOnce(path, relativePath)
+    if (inspection.kind === 'stable') {
+      return inspection.file
+    }
+    if (inspection.kind === 'missing' && (!optional || attempt === attempts - 1)) {
+      return
+    }
+  }
+  return changedLayout(relativePath, 'stable-metadata-identity')
+}
+
 const inspectSidecars = (location: CacheLocation, name: CacheDatabaseName) =>
   DATABASE_SIDECAR_SUFFIXES.reduce<Partial<Record<CacheDatabaseSidecarSuffix, CacheFile>>>((sidecars, suffix) => {
     const file = inspectRegularFile(
@@ -326,8 +386,20 @@ const inspectSidecars = (location: CacheLocation, name: CacheDatabaseName) =>
     return file === undefined ? sidecars : { ...sidecars, [suffix]: file }
   }, {})
 
-const reconcileSidecars = (location: CacheLocation, database: CacheDatabase) => {
-  const observed = inspectSidecars(location, database.name)
+const inspectSidecarMetadata = (location: CacheLocation, name: CacheDatabaseName) =>
+  DATABASE_SIDECAR_SUFFIXES.reduce<Partial<Record<CacheDatabaseSidecarSuffix, CacheFile>>>((sidecars, suffix) => {
+    const file = inspectRegularFileMetadata(
+      resolve(location.directory, `${name}${suffix}`),
+      `${databaseRelativePath(name)}${suffix}`,
+      true,
+    )
+    return file === undefined ? sidecars : { ...sidecars, [suffix]: file }
+  }, {})
+
+const reconcileSidecarSnapshots = (
+  database: CacheDatabase,
+  observed: Partial<Record<CacheDatabaseSidecarSuffix, CacheFile>>,
+) => {
   for (const suffix of DATABASE_SIDECAR_SUFFIXES) {
     const expected = database.sidecars[suffix]
     const current = observed[suffix]
@@ -340,6 +412,12 @@ const reconcileSidecars = (location: CacheLocation, database: CacheDatabase) => 
   }
   return observed
 }
+
+const reconcileSidecars = (location: CacheLocation, database: CacheDatabase) =>
+  reconcileSidecarSnapshots(database, inspectSidecars(location, database.name))
+
+const reconcileSidecarMetadata = (location: CacheLocation, database: CacheDatabase) =>
+  reconcileSidecarSnapshots(database, inspectSidecarMetadata(location, database.name))
 
 const bootstrapPrimary = (location: CacheLocation, name: CacheDatabaseName) => {
   const path = resolve(location.directory, name)
@@ -389,53 +467,17 @@ export const assertCacheDatabase = (location: CacheLocation, database: CacheData
 }
 
 const assertCacheDatabaseMetadata = (location: CacheLocation, database: CacheDatabase) => {
-  // Closing another descriptor for this file can release process-scoped POSIX
-  // locks, so the operation gate uses metadata continuity after BEGIN.
+  // Opening and closing any sibling file descriptor after BEGIN can release
+  // process-scoped SQLite locks on POSIX, so this boundary observes metadata only.
   assertCacheLocation(location)
-  let initialMetadata: BigIntStats
-  try {
-    initialMetadata = lstatSync(database.path, { bigint: true })
-  } catch (error) {
-    if (missingPath(error)) {
-      return changedLayout(databaseRelativePath(database.name), 'stable-identity')
-    }
-    throw error
-  }
-  if (!initialMetadata.isFile() || initialMetadata.isSymbolicLink()) {
-    return invalidLayout(databaseRelativePath(database.name), 'regular-non-symlink-file')
-  }
-  const captured = identityFrom(initialMetadata)
-  let actualRealpath: string
-  try {
-    actualRealpath = realpathSync.native(database.path)
-  } catch (error) {
-    if (missingPath(error)) {
-      return changedLayout(databaseRelativePath(database.name), 'stable-identity')
-    }
-    throw error
-  }
-  if (!samePath(actualRealpath, database.path)) {
-    return invalidLayout(databaseRelativePath(database.name), 'expected-realpath')
-  }
-  let finalMetadata: BigIntStats
-  try {
-    finalMetadata = lstatSync(database.path, { bigint: true })
-  } catch (error) {
-    if (missingPath(error)) {
-      return changedLayout(databaseRelativePath(database.name), 'stable-identity')
-    }
-    throw error
-  }
-  if (
-    !finalMetadata.isFile() ||
-    finalMetadata.isSymbolicLink() ||
-    !sameCacheEntryIdentity(database, captured) ||
-    !sameCacheEntryIdentity(captured, identityFrom(finalMetadata))
-  ) {
+  const identity = inspectRegularFileMetadata(database.path, databaseRelativePath(database.name))
+  if (identity === undefined || !sameCacheEntryIdentity(database, identity)) {
     return changedLayout(databaseRelativePath(database.name), 'stable-identity')
   }
   assertCacheLocation(location)
-  return { ...database, sidecars: reconcileSidecars(location, database) }
+  const sidecars = reconcileSidecarMetadata(location, database)
+  assertCacheLocation(location)
+  return { ...database, sidecars }
 }
 
 export const openVerifiedCacheDatabase = <Database extends { close: () => void }>(
@@ -476,10 +518,13 @@ export const openVerifiedCacheDatabase = <Database extends { close: () => void }
       cacheLocationTestHooks.afterDatabaseOpen?.(snapshot)
       snapshot = assertCacheDatabase(options.location, snapshot)
       options.afterVerifiedOpen?.(database)
+      if (options.preserveDatabaseLocksAfterInitialisation) {
+        cacheLocationTestHooks.afterDatabaseLockInitialisation?.(snapshot)
+      }
       snapshot = options.preserveDatabaseLocksAfterInitialisation
         ? assertCacheDatabaseMetadata(options.location, snapshot)
         : assertCacheDatabase(options.location, snapshot)
-      return { database, snapshot }
+      return database
     } catch (error) {
       if (error instanceof CacheDatabaseSidecarChanged) {
         database.close()
@@ -490,7 +535,9 @@ export const openVerifiedCacheDatabase = <Database extends { close: () => void }
       } else {
         let validationError: unknown
         try {
-          snapshot = assertCacheDatabase(options.location, snapshot)
+          snapshot = options.preserveDatabaseLocksAfterInitialisation
+            ? assertCacheDatabaseMetadata(options.location, snapshot)
+            : assertCacheDatabase(options.location, snapshot)
         } catch (candidate) {
           validationError = candidate
         }

--- a/src/cache-location.ts
+++ b/src/cache-location.ts
@@ -20,6 +20,7 @@ import { fail } from './errors.ts'
 
 const CACHE_COMPONENTS = ['node_modules', '.cache', 'encephalon'] as const
 const DATABASE_SIDECAR_SUFFIXES = ['-wal', '-shm', '-journal'] as const
+const OPTIONAL_FILE_OBSERVATION_ATTEMPTS = 3
 const NO_FOLLOW = constants.O_NOFOLLOW ?? 0
 
 export type CacheEntryIdentity = {
@@ -38,9 +39,16 @@ export type CacheLocation = {
   repository: string
 }
 
-export type CacheDatabase = CacheEntryIdentity & {
-  name: CacheDatabaseName
+type CacheFile = CacheEntryIdentity & {
   path: string
+  relativePath: string
+}
+
+type CacheDatabaseSidecarSuffix = (typeof DATABASE_SIDECAR_SUFFIXES)[number]
+
+export type CacheDatabase = CacheFile & {
+  name: CacheDatabaseName
+  sidecars: Partial<Record<CacheDatabaseSidecarSuffix, CacheFile>>
 }
 
 export type CacheDatabaseName = 'brain.sqlite' | 'operation-lock.sqlite'
@@ -50,8 +58,25 @@ export type CacheOwnedDirectory = CacheEntryIdentity & {
   path: string
 }
 
+export class CacheDatabaseFailure extends Error {
+  readonly database: CacheDatabase
+  readonly failure: unknown
+
+  constructor(failure: unknown, database: CacheDatabase, options: ErrorOptions) {
+    super(failure instanceof Error ? failure.message : 'The SQLite cache operation failed.', options)
+    this.name = 'CacheDatabaseFailure'
+    this.database = database
+    this.failure = failure
+  }
+}
+
+export const failCacheDatabase = (failure: unknown, database: CacheDatabase): never => {
+  throw new CacheDatabaseFailure(failure, database, { cause: failure })
+}
+
 type CacheLocationTestHooks = {
   afterQuarantineRename?: ((path: string) => void) | undefined
+  beforeDatabaseOpen?: ((database: CacheDatabase) => void) | undefined
   beforeQuarantineRename?: ((path: string) => void) | undefined
 }
 
@@ -186,13 +211,15 @@ export const assertCacheLocation = (location: CacheLocation) => {
 
 const databaseRelativePath = (name: CacheDatabaseName) => `node_modules/.cache/encephalon/${name}`
 
-const inspectRegularFile = (path: string, relativePath: string): CacheEntryIdentity | undefined => {
+type RegularFileInspection = { kind: 'changed' } | { kind: 'missing' } | { file: CacheFile; kind: 'stable' }
+
+const inspectRegularFileOnce = (path: string, relativePath: string): RegularFileInspection => {
   let metadata: BigIntStats
   try {
     metadata = lstatSync(path, { bigint: true })
   } catch (error) {
     if (missingPath(error)) {
-      return
+      return { kind: 'missing' }
     }
     throw error
   }
@@ -200,25 +227,74 @@ const inspectRegularFile = (path: string, relativePath: string): CacheEntryIdent
     return invalidLayout(relativePath, 'regular-non-symlink-file')
   }
   const captured = identityFrom(metadata)
+  let actualRealpath: string
+  try {
+    actualRealpath = realpathSync.native(path)
+  } catch (error) {
+    if (missingPath(error)) {
+      return { kind: 'changed' }
+    }
+    throw error
+  }
+  if (!samePath(actualRealpath, path)) {
+    return invalidLayout(relativePath, 'expected-realpath')
+  }
   let descriptor: number | undefined
   try {
-    descriptor = openSync(path, constants.O_RDONLY | NO_FOLLOW)
+    try {
+      descriptor = openSync(path, constants.O_RDONLY | NO_FOLLOW)
+    } catch (error) {
+      if (missingPath(error)) {
+        return { kind: 'changed' }
+      }
+      throw error
+    }
     const opened = fstatSync(descriptor, { bigint: true })
     if (!(opened.isFile() && sameCacheEntryIdentity(captured, identityFrom(opened)))) {
-      return changedLayout(relativePath, 'stable-open-identity')
+      return { kind: 'changed' }
     }
   } finally {
     if (descriptor !== undefined) {
       closeSync(descriptor)
     }
   }
-  return captured
+  return { file: { ...captured, path, relativePath }, kind: 'stable' }
 }
 
-const inspectSidecars = (location: CacheLocation, name: CacheDatabaseName) => {
-  for (const suffix of DATABASE_SIDECAR_SUFFIXES) {
-    inspectRegularFile(resolve(location.directory, `${name}${suffix}`), `${databaseRelativePath(name)}${suffix}`)
+const inspectRegularFile = (path: string, relativePath: string, optional = false): CacheFile | undefined => {
+  const attempts = optional ? OPTIONAL_FILE_OBSERVATION_ATTEMPTS : 1
+  for (const attempt of Array.from({ length: attempts }, (_, index) => index)) {
+    const inspection = inspectRegularFileOnce(path, relativePath)
+    if (inspection.kind === 'stable') {
+      return inspection.file
+    }
+    if (inspection.kind === 'missing' && (!optional || attempt === attempts - 1)) {
+      return
+    }
   }
+  return changedLayout(relativePath, 'stable-open-identity')
+}
+
+const inspectSidecars = (location: CacheLocation, name: CacheDatabaseName) =>
+  DATABASE_SIDECAR_SUFFIXES.reduce<Partial<Record<CacheDatabaseSidecarSuffix, CacheFile>>>((sidecars, suffix) => {
+    const file = inspectRegularFile(
+      resolve(location.directory, `${name}${suffix}`),
+      `${databaseRelativePath(name)}${suffix}`,
+      true,
+    )
+    return file === undefined ? sidecars : { ...sidecars, [suffix]: file }
+  }, {})
+
+const assertSidecars = (location: CacheLocation, database: CacheDatabase) => {
+  const observed = inspectSidecars(location, database.name)
+  for (const suffix of DATABASE_SIDECAR_SUFFIXES) {
+    const expected = database.sidecars[suffix]
+    const current = observed[suffix]
+    if (expected !== undefined && (current === undefined || !sameCacheEntryIdentity(expected, current))) {
+      return changedLayout(`${databaseRelativePath(database.name)}${suffix}`, 'stable-identity')
+    }
+  }
+  return observed
 }
 
 const bootstrapPrimary = (location: CacheLocation, name: CacheDatabaseName) => {
@@ -243,21 +319,20 @@ const bootstrapPrimary = (location: CacheLocation, name: CacheDatabaseName) => {
 
 export const prepareCacheDatabase = (location: CacheLocation, name: CacheDatabaseName): CacheDatabase => {
   assertCacheLocation(location)
-  inspectSidecars(location, name)
+  const sidecars = inspectSidecars(location, name)
   const path = resolve(location.directory, name)
   const existing = inspectRegularFile(path, databaseRelativePath(name))
   const identity = existing ?? bootstrapPrimary(location, name)
   assertCacheLocation(location)
-  inspectSidecars(location, name)
-  return { ...identity, name, path }
+  return { ...identity, name, sidecars: { ...sidecars, ...inspectSidecars(location, name) } }
 }
 
 export const inspectCacheDatabase = (location: CacheLocation, name: CacheDatabaseName): CacheDatabase | undefined => {
   assertCacheLocation(location)
-  inspectSidecars(location, name)
+  const sidecars = inspectSidecars(location, name)
   const path = resolve(location.directory, name)
   const identity = inspectRegularFile(path, databaseRelativePath(name))
-  return identity === undefined ? undefined : { ...identity, name, path }
+  return identity === undefined ? undefined : { ...identity, name, sidecars }
 }
 
 export const assertCacheDatabase = (location: CacheLocation, database: CacheDatabase) => {
@@ -266,44 +341,66 @@ export const assertCacheDatabase = (location: CacheLocation, database: CacheData
   if (identity === undefined || !sameCacheEntryIdentity(database, identity)) {
     return changedLayout(databaseRelativePath(database.name), 'stable-identity')
   }
-  inspectSidecars(location, database.name)
+  return { ...database, sidecars: { ...database.sidecars, ...assertSidecars(location, database) } }
 }
 
-const quarantineFile = (location: CacheLocation, path: string, relativePath: string) => {
-  const captured = inspectRegularFile(path, relativePath)
-  if (captured !== undefined) {
-    assertCacheLocation(location)
-    cacheLocationTestHooks.beforeQuarantineRename?.(path)
-    assertCacheLocation(location)
-    const current = inspectRegularFile(path, relativePath)
-    if (current === undefined || !sameCacheEntryIdentity(captured, current)) {
-      return changedLayout(relativePath, 'stable-quarantine-source')
+export const refreshCacheDatabase = (location: CacheLocation, database: CacheDatabase) => {
+  assertCacheLocation(location)
+  const identity = inspectRegularFile(database.path, database.relativePath)
+  if (identity === undefined || !sameCacheEntryIdentity(database, identity)) {
+    return changedLayout(database.relativePath, 'stable-identity')
+  }
+  return { ...database, sidecars: inspectSidecars(location, database.name) }
+}
+
+export const cacheDatabaseWillOpen = (database: CacheDatabase) => {
+  cacheLocationTestHooks.beforeDatabaseOpen?.(database)
+}
+
+const quarantineFile = (location: CacheLocation, expected: CacheFile, required: boolean) => {
+  const current = inspectRegularFile(expected.path, expected.relativePath, !required)
+  if (current === undefined) {
+    if (required) {
+      return changedLayout(expected.relativePath, 'stable-quarantine-source')
     }
-    const quarantineName = `.${relativePath.split('/').at(-1)}.${randomUUID()}.quarantine`
+  } else {
+    if (!sameCacheEntryIdentity(expected, current)) {
+      return changedLayout(expected.relativePath, 'stable-quarantine-source')
+    }
+    assertCacheLocation(location)
+    cacheLocationTestHooks.beforeQuarantineRename?.(expected.path)
+    assertCacheLocation(location)
+    const verified = inspectRegularFile(expected.path, expected.relativePath, !required)
+    if (verified === undefined) {
+      return changedLayout(expected.relativePath, 'stable-quarantine-source')
+    }
+    if (!sameCacheEntryIdentity(expected, verified)) {
+      return changedLayout(expected.relativePath, 'stable-quarantine-source')
+    }
+    const quarantineName = `.${expected.relativePath.split('/').at(-1)}.${randomUUID()}.quarantine`
     const quarantinePath = resolve(location.directory, quarantineName)
-    renameSync(path, quarantinePath)
+    renameSync(expected.path, quarantinePath)
     assertCacheLocation(location)
     cacheLocationTestHooks.afterQuarantineRename?.(quarantinePath)
     assertCacheLocation(location)
     const quarantined = inspectRegularFile(quarantinePath, `node_modules/.cache/encephalon/${quarantineName}`)
-    if (quarantined === undefined || !sameCacheEntryIdentity(captured, quarantined)) {
-      return changedLayout(relativePath, 'stable-quarantine-identity')
+    if (quarantined === undefined || !sameCacheEntryIdentity(expected, quarantined)) {
+      return changedLayout(expected.relativePath, 'stable-quarantine-identity')
     }
     unlinkSync(quarantinePath)
     assertCacheLocation(location)
   }
 }
 
-export const quarantineCacheDatabase = (location: CacheLocation, name: CacheDatabaseName) => {
+export const quarantineCacheDatabase = (location: CacheLocation, database: CacheDatabase) => {
   assertCacheLocation(location)
-  for (const suffix of [...DATABASE_SIDECAR_SUFFIXES, ''] as const) {
-    const candidateName = `${name}${suffix}`
-    quarantineFile(
-      location,
-      resolve(location.directory, candidateName),
-      `node_modules/.cache/encephalon/${candidateName}`,
-    )
+  for (const suffix of DATABASE_SIDECAR_SUFFIXES) {
+    const sidecar = database.sidecars[suffix]
+    if (sidecar !== undefined) {
+      quarantineFile(location, sidecar, false)
+    }
   }
+  quarantineFile(location, database, true)
 }
 
 const safeOwnedDirectoryName = (name: string) =>
@@ -336,11 +433,13 @@ export const inspectCacheOwnedDirectory = (location: CacheLocation, name: string
   return inspectOwnedDirectoryPath(location, name)
 }
 
-export const assertCacheOwnedEntries = (location: CacheLocation) => {
+export const assertCacheLockCandidates = (location: CacheLocation) => {
   assertCacheLocation(location)
-  readdirSync(location.directory)
-    .filter(name => /^operation\.lock\.[0-9a-f-]{36}$/u.test(name))
-    .map(name => inspectOwnedDirectoryPath(location, name))
+  const candidates = readdirSync(location.directory).filter(name => /^operation\.lock\.[0-9a-f-]{36}$/u.test(name))
+  // biome-ignore lint/complexity/noForEach: validation intentionally visits every candidate entry.
+  candidates.forEach(name => {
+    inspectOwnedDirectoryPath(location, name)
+  })
 }
 
 export const createCacheOwnedDirectory = (location: CacheLocation, name: string) => {
@@ -362,6 +461,41 @@ const assertOwnedDirectory = (location: CacheLocation, directory: CacheOwnedDire
   if (current === undefined || !sameCacheEntryIdentity(directory, current)) {
     return changedLayout(ownedDirectoryRelativePath(directory.name), 'stable-identity')
   }
+}
+
+export const cacheOwnedDirectoryIsCurrent = (location: CacheLocation, directory: CacheOwnedDirectory) => {
+  assertCacheLocation(location)
+  const current = inspectOwnedDirectoryPath(location, directory.name)
+  return current !== undefined && sameCacheEntryIdentity(directory, current)
+}
+
+export const cacheOwnedDirectoryMtimeMilliseconds = (location: CacheLocation, directory: CacheOwnedDirectory) => {
+  assertOwnedDirectory(location, directory)
+  const metadata = lstatSync(directory.path, { bigint: true })
+  if (!sameCacheEntryIdentity(directory, identityFrom(metadata))) {
+    return changedLayout(ownedDirectoryRelativePath(directory.name), 'stable-metadata-identity')
+  }
+  return Number(metadata.mtimeMs)
+}
+
+export const promoteCacheOwnedDirectory = (
+  location: CacheLocation,
+  directory: CacheOwnedDirectory,
+  targetName: 'operation.lock',
+) => {
+  assertOwnedDirectory(location, directory)
+  const existingTarget = inspectOwnedDirectoryPath(location, targetName)
+  if (existingTarget !== undefined) {
+    return changedLayout(ownedDirectoryRelativePath(targetName), 'promotion-target-missing')
+  }
+  const targetPath = resolve(location.directory, targetName)
+  renameSync(directory.path, targetPath)
+  assertCacheLocation(location)
+  const promoted = inspectOwnedDirectoryPath(location, targetName)
+  if (promoted === undefined || !sameCacheEntryIdentity(directory, promoted)) {
+    return changedLayout(ownedDirectoryRelativePath(targetName), 'stable-promoted-identity')
+  }
+  return promoted
 }
 
 export const writeCacheOwner = (location: CacheLocation, directory: CacheOwnedDirectory, contents: string) => {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -13,11 +13,14 @@ import {
 import {
   assertCacheDatabase,
   CacheDatabaseFailure,
+  CacheDatabaseSidecarChanged,
   type CacheLocation,
+  cacheDatabaseDidOpen,
   cacheDatabaseWillOpen,
   failCacheDatabase,
   inspectCacheDatabase,
   inspectCacheLocation,
+  MAX_CACHE_DATABASE_OPEN_ATTEMPTS,
   prepareCacheDatabase,
   quarantineCacheDatabase,
   refreshCacheDatabase,
@@ -254,42 +257,55 @@ const openWriterDatabase = (location: CacheLocation) => {
   const { DatabaseSync: DatabaseConstructor } = loadSQLite()
   verifySQLiteFeatures(DatabaseConstructor)
   let cacheDatabase = prepareCacheDatabase(location, 'brain.sqlite')
-  cacheDatabaseWillOpen(cacheDatabase)
-  cacheDatabase = assertCacheDatabase(location, cacheDatabase)
-  let database: DatabaseSync
-  try {
-    database = new DatabaseConstructor(cacheDatabase.path, {
-      timeout: SQLITE_BUSY_TIMEOUT_MILLISECONDS,
-    })
-  } catch (error) {
-    return failCacheDatabase(error, cacheDatabase)
-  }
-  try {
-    // Node's SQLite API accepts only pathnames, leaving a narrow replacement race
-    // between this identity check and SQLite's internal open.
+  const attempts = Array.from({ length: MAX_CACHE_DATABASE_OPEN_ATTEMPTS }, (_, index) => index)
+  for (const attempt of attempts) {
+    cacheDatabaseWillOpen(cacheDatabase)
     cacheDatabase = assertCacheDatabase(location, cacheDatabase)
-    database.exec('PRAGMA journal_mode = WAL; PRAGMA synchronous = FULL; PRAGMA foreign_keys = ON;')
-    cacheDatabase = refreshCacheDatabase(location, cacheDatabase)
-    createCacheSchema(database)
-    assertCacheSchema(database)
-    cacheDatabase = assertCacheDatabase(location, cacheDatabase)
-    return database
-  } catch (error) {
-    let validationError: unknown
+    let database: DatabaseSync
     try {
+      database = new DatabaseConstructor(cacheDatabase.path, {
+        timeout: SQLITE_BUSY_TIMEOUT_MILLISECONDS,
+      })
+    } catch (error) {
+      return failCacheDatabase(error, cacheDatabase)
+    }
+    try {
+      cacheDatabaseDidOpen(cacheDatabase)
+      // Node's SQLite API accepts only pathnames, leaving a narrow replacement race
+      // between this identity check and SQLite's internal open.
       cacheDatabase = assertCacheDatabase(location, cacheDatabase)
-    } catch (candidate) {
-      validationError = candidate
+      database.exec('PRAGMA journal_mode = WAL; PRAGMA synchronous = FULL; PRAGMA foreign_keys = ON;')
+      cacheDatabase = refreshCacheDatabase(location, cacheDatabase)
+      createCacheSchema(database)
+      assertCacheSchema(database)
+      cacheDatabase = assertCacheDatabase(location, cacheDatabase)
+      return database
+    } catch (error) {
+      if (error instanceof CacheDatabaseSidecarChanged) {
+        database.close()
+        cacheDatabase = error.database
+        if (attempt === MAX_CACHE_DATABASE_OPEN_ATTEMPTS - 1) {
+          throw error
+        }
+      } else {
+        let validationError: unknown
+        try {
+          cacheDatabase = assertCacheDatabase(location, cacheDatabase)
+        } catch (candidate) {
+          validationError = candidate
+        }
+        database.close()
+        if (validationError !== undefined) {
+          throw validationError
+        }
+        if (error instanceof EncephalonError) {
+          throw error
+        }
+        return failCacheDatabase(error, cacheDatabase)
+      }
     }
-    database.close()
-    if (validationError !== undefined) {
-      throw validationError
-    }
-    if (error instanceof EncephalonError) {
-      throw error
-    }
-    return failCacheDatabase(error, cacheDatabase)
   }
+  return fail('INTERNAL_ERROR', 'The Encephalon writer database open ended unexpectedly.')
 }
 
 const openReaderDatabase = (location: CacheLocation) => {
@@ -299,38 +315,51 @@ const openReaderDatabase = (location: CacheLocation) => {
   if (cacheDatabase === undefined) {
     throw new CacheSchemaMismatch('The cache database disappeared before it was opened.')
   }
-  cacheDatabaseWillOpen(cacheDatabase)
-  cacheDatabase = assertCacheDatabase(location, cacheDatabase)
-  let database: DatabaseSync
-  try {
-    database = new DatabaseConstructor(cacheDatabase.path, {
-      readOnly: true,
-      timeout: SQLITE_BUSY_TIMEOUT_MILLISECONDS,
-    })
-  } catch (error) {
-    return failCacheDatabase(error, cacheDatabase)
-  }
-  try {
+  const attempts = Array.from({ length: MAX_CACHE_DATABASE_OPEN_ATTEMPTS }, (_, index) => index)
+  for (const attempt of attempts) {
+    cacheDatabaseWillOpen(cacheDatabase)
     cacheDatabase = assertCacheDatabase(location, cacheDatabase)
-    assertCacheSchema(database)
-    cacheDatabase = assertCacheDatabase(location, cacheDatabase)
-    return database
-  } catch (error) {
-    let validationError: unknown
+    let database: DatabaseSync
     try {
+      database = new DatabaseConstructor(cacheDatabase.path, {
+        readOnly: true,
+        timeout: SQLITE_BUSY_TIMEOUT_MILLISECONDS,
+      })
+    } catch (error) {
+      return failCacheDatabase(error, cacheDatabase)
+    }
+    try {
+      cacheDatabaseDidOpen(cacheDatabase)
       cacheDatabase = assertCacheDatabase(location, cacheDatabase)
-    } catch (candidate) {
-      validationError = candidate
+      assertCacheSchema(database)
+      cacheDatabase = assertCacheDatabase(location, cacheDatabase)
+      return database
+    } catch (error) {
+      if (error instanceof CacheDatabaseSidecarChanged) {
+        database.close()
+        cacheDatabase = error.database
+        if (attempt === MAX_CACHE_DATABASE_OPEN_ATTEMPTS - 1) {
+          throw error
+        }
+      } else {
+        let validationError: unknown
+        try {
+          cacheDatabase = assertCacheDatabase(location, cacheDatabase)
+        } catch (candidate) {
+          validationError = candidate
+        }
+        database.close()
+        if (validationError !== undefined) {
+          throw validationError
+        }
+        if (error instanceof EncephalonError) {
+          throw error
+        }
+        return failCacheDatabase(error, cacheDatabase)
+      }
     }
-    database.close()
-    if (validationError !== undefined) {
-      throw validationError
-    }
-    if (error instanceof EncephalonError) {
-      throw error
-    }
-    return failCacheDatabase(error, cacheDatabase)
   }
+  return fail('INTERNAL_ERROR', 'The Encephalon reader database open ended unexpectedly.')
 }
 
 const posixRelative = (root: string, path: string) =>

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -11,10 +11,8 @@ import {
   parseShowRecordInput,
 } from './api-input.ts'
 import {
-  assertCacheDatabase,
   CacheDatabaseFailure,
   type CacheLocation,
-  failCacheDatabase,
   inspectCacheDatabase,
   inspectCacheLocation,
   openVerifiedCacheDatabase,
@@ -109,6 +107,7 @@ type SearchStatementInput = Pick<SearchRecordsInput, 'includeSuperseded' | 'kind
 type CacheReadTestHooks = {
   afterCompactSearchRead?: ((query: string) => void) | undefined
   afterShowRead?: ((id: string) => void) | undefined
+  duringDatabaseInitialisation?: ((mode: 'reader' | 'writer') => void) | undefined
   onCompactSearchPrepare?: ((source: string) => void) | undefined
   onShowPrepare?: ((source: string) => void) | undefined
 }
@@ -254,6 +253,9 @@ const openWriterDatabase = (location: CacheLocation) => {
   const opened = openVerifiedCacheDatabase({
     afterVerifiedOpen: database => {
       database.exec('PRAGMA journal_mode = WAL; PRAGMA synchronous = FULL; PRAGMA foreign_keys = ON;')
+      createCacheSchema(database)
+      assertCacheSchema(database)
+      cacheReadTestHooks.duringDatabaseInitialisation?.('writer')
     },
     create: true,
     DatabaseConstructor,
@@ -261,34 +263,17 @@ const openWriterDatabase = (location: CacheLocation) => {
     name: 'brain.sqlite',
     openOptions: { timeout: SQLITE_BUSY_TIMEOUT_MILLISECONDS },
   })
-  let cacheDatabase = opened.snapshot
-  try {
-    createCacheSchema(opened.database)
-    assertCacheSchema(opened.database)
-    cacheDatabase = assertCacheDatabase(location, cacheDatabase)
-    return opened.database
-  } catch (error) {
-    let validationError: unknown
-    try {
-      cacheDatabase = assertCacheDatabase(location, cacheDatabase)
-    } catch (candidate) {
-      validationError = candidate
-    }
-    opened.database.close()
-    if (validationError !== undefined) {
-      throw validationError
-    }
-    if (error instanceof EncephalonError) {
-      throw error
-    }
-    return failCacheDatabase(error, cacheDatabase)
-  }
+  return opened.database
 }
 
 const openReaderDatabase = (location: CacheLocation) => {
   const { DatabaseSync: DatabaseConstructor } = loadSQLite()
   verifySQLiteFeatures(DatabaseConstructor)
   const opened = openVerifiedCacheDatabase({
+    afterVerifiedOpen: database => {
+      assertCacheSchema(database)
+      cacheReadTestHooks.duringDatabaseInitialisation?.('reader')
+    },
     create: false,
     DatabaseConstructor,
     location,
@@ -301,27 +286,7 @@ const openReaderDatabase = (location: CacheLocation) => {
       timeout: SQLITE_BUSY_TIMEOUT_MILLISECONDS,
     },
   })
-  let cacheDatabase = opened.snapshot
-  try {
-    assertCacheSchema(opened.database)
-    cacheDatabase = assertCacheDatabase(location, cacheDatabase)
-    return opened.database
-  } catch (error) {
-    let validationError: unknown
-    try {
-      cacheDatabase = assertCacheDatabase(location, cacheDatabase)
-    } catch (candidate) {
-      validationError = candidate
-    }
-    opened.database.close()
-    if (validationError !== undefined) {
-      throw validationError
-    }
-    if (error instanceof EncephalonError) {
-      throw error
-    }
-    return failCacheDatabase(error, cacheDatabase)
-  }
+  return opened.database
 }
 
 const posixRelative = (root: string, path: string) =>

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { existsSync, lstatSync, readdirSync, realpathSync, rmSync, statSync } from 'node:fs'
+import { existsSync, lstatSync, readdirSync, realpathSync, statSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { resolve } from 'node:path'
 import type { DatabaseSync } from 'node:sqlite'
@@ -10,9 +10,17 @@ import {
   parseSearchRecordsInput,
   parseShowRecordInput,
 } from './api-input.ts'
+import {
+  assertCacheDatabase,
+  type CacheLocation,
+  inspectCacheDatabase,
+  inspectCacheLocation,
+  prepareCacheDatabase,
+  quarantineCacheDatabase,
+} from './cache-location.ts'
 import { EncephalonError, fail, failWithCause, wrapIo } from './errors.ts'
 import { PACKAGE_VERSION } from './generated/version.ts'
-import { cacheDirectory, withOperationLock } from './lock.ts'
+import { withOperationLock } from './lock.ts'
 import { ordinalStringCompare } from './order.ts'
 import { canonicalRecordPath, readRecords } from './records.ts'
 import { resolveRepository } from './repository.ts'
@@ -32,7 +40,6 @@ import type {
 
 const SCHEMA_VERSION = '1'
 const MAX_REPOSITORY_CHANGE_RETRIES = 3
-const DATABASE_FILENAME = 'brain.sqlite'
 export const MAX_QUERY_BYTES = 1024
 export const MAX_QUERY_TERMS = 32
 export const MAX_GATHER_SEARCHES = 16
@@ -133,8 +140,6 @@ const loadSQLite = () => {
   return sqliteModule
 }
 
-const databasePath = (root: string) => resolve(cacheDirectory(root), DATABASE_FILENAME)
-
 const isRecoverableCacheFailure = (error: unknown) => {
   const sqlite = error as { errcode?: unknown; message?: unknown }
   return (
@@ -158,12 +163,7 @@ const assertTableColumns = (database: DatabaseSync, table: string, expected: str
   }
 }
 
-const removeCorruptCache = (root: string) => {
-  const path = databasePath(root)
-  for (const candidate of [path, `${path}-wal`, `${path}-shm`, `${path}-journal`]) {
-    rmSync(candidate, { force: true })
-  }
-}
+const removeCorruptCache = (location: CacheLocation) => quarantineCacheDatabase(location, 'brain.sqlite')
 
 const verifySQLiteFeatures = (DatabaseConstructor: SQLiteModule['DatabaseSync']) => {
   if (sqliteFeaturesVerified) {
@@ -240,13 +240,17 @@ const createCacheSchema = (database: DatabaseSync) => {
   `)
 }
 
-const openWriterDatabase = (root: string) => {
+const openWriterDatabase = (root: string, location: CacheLocation = inspectCacheLocation(root)) => {
   const { DatabaseSync: DatabaseConstructor } = loadSQLite()
   verifySQLiteFeatures(DatabaseConstructor)
-  const database = new DatabaseConstructor(databasePath(root), {
+  const cacheDatabase = prepareCacheDatabase(location, 'brain.sqlite')
+  const database = new DatabaseConstructor(cacheDatabase.path, {
     timeout: SQLITE_BUSY_TIMEOUT_MILLISECONDS,
   })
   try {
+    // Node's SQLite API accepts only pathnames, leaving a narrow replacement race
+    // between this identity check and SQLite's internal open.
+    assertCacheDatabase(location, cacheDatabase)
     database.exec('PRAGMA journal_mode = WAL; PRAGMA synchronous = FULL; PRAGMA foreign_keys = ON;')
     createCacheSchema(database)
     assertCacheSchema(database)
@@ -257,14 +261,19 @@ const openWriterDatabase = (root: string) => {
   }
 }
 
-const openReaderDatabase = (root: string) => {
+const openReaderDatabase = (root: string, location: CacheLocation = inspectCacheLocation(root)) => {
   const { DatabaseSync: DatabaseConstructor } = loadSQLite()
   verifySQLiteFeatures(DatabaseConstructor)
-  const database = new DatabaseConstructor(databasePath(root), {
+  const cacheDatabase = inspectCacheDatabase(location, 'brain.sqlite')
+  if (cacheDatabase === undefined) {
+    throw new CacheSchemaMismatch('The cache database disappeared before it was opened.')
+  }
+  const database = new DatabaseConstructor(cacheDatabase.path, {
     readOnly: true,
     timeout: SQLITE_BUSY_TIMEOUT_MILLISECONDS,
   })
   try {
+    assertCacheDatabase(location, cacheDatabase)
     assertCacheSchema(database)
     return database
   } catch (error) {
@@ -579,8 +588,8 @@ const writeMetadata = (database: DatabaseSync, metadata: Metadata) => {
   }
 }
 
-const readFreshMetadata = (root: string): Metadata | undefined => {
-  const database = openReaderDatabase(root)
+const readFreshMetadata = (root: string, location: CacheLocation): Metadata | undefined => {
+  const database = openReaderDatabase(root, location)
   try {
     const metadata = readMetadata(database)
     return metadataIsFresh(root, database, metadata) ? metadata : undefined
@@ -589,7 +598,7 @@ const readFreshMetadata = (root: string): Metadata | undefined => {
   }
 }
 
-const rebuildCache = (root: string): PrepareResult => {
+const rebuildCache = (root: string, location: CacheLocation = inspectCacheLocation(root)): PrepareResult => {
   const attempts = Array.from({ length: MAX_REPOSITORY_CHANGE_RETRIES }, (_, index) => index)
   for (const attempt of attempts) {
     const recordManifestBefore = repositoryManifest(root, [])
@@ -618,13 +627,13 @@ const rebuildCache = (root: string): PrepareResult => {
     const superseded = new Set(records.flatMap(record => record.supersedes ?? []))
     let database: DatabaseSync
     try {
-      database = openWriterDatabase(root)
+      database = openWriterDatabase(root, location)
     } catch (error) {
       if (!isRecoverableCacheFailure(error)) {
         throw error
       }
-      removeCorruptCache(root)
-      database = openWriterDatabase(root)
+      removeCorruptCache(location)
+      database = openWriterDatabase(root, location)
     }
     try {
       let existingMetadata: Metadata | undefined
@@ -689,13 +698,18 @@ const rebuildCache = (root: string): PrepareResult => {
   return fail('INTERNAL_ERROR', 'The Encephalon cache rebuild ended unexpectedly.')
 }
 
-const prepareResolvedWithoutCorruptionRecovery = (root: string, lock = true): PrepareResult => {
-  const serialize = <Result>(operation: () => Result) => (lock ? withOperationLock(root, operation) : operation())
-  if (!existsSync(databasePath(root))) {
-    return serialize(() => {
-      if (existsSync(databasePath(root))) {
+const prepareResolvedWithoutCorruptionRecovery = (
+  root: string,
+  location: CacheLocation,
+  lock = true,
+): PrepareResult => {
+  const serialize = <Result>(operation: (captured: CacheLocation) => Result) =>
+    lock ? withOperationLock(root, operation, {}, location) : operation(location)
+  if (inspectCacheDatabase(location, 'brain.sqlite') === undefined) {
+    return serialize(captured => {
+      if (inspectCacheDatabase(captured, 'brain.sqlite') !== undefined) {
         try {
-          const metadata = readFreshMetadata(root)
+          const metadata = readFreshMetadata(root, captured)
           if (metadata !== undefined) {
             return { hydrated: false, recordsIndexed: metadata.recordsIndexed }
           }
@@ -705,16 +719,16 @@ const prepareResolvedWithoutCorruptionRecovery = (root: string, lock = true): Pr
           }
         }
       }
-      return rebuildCache(root)
+      return rebuildCache(root, captured)
     })
   }
-  const cachedMetadata = readFreshMetadata(root)
+  const cachedMetadata = readFreshMetadata(root, location)
   if (cachedMetadata !== undefined) {
     return { hydrated: false, recordsIndexed: cachedMetadata.recordsIndexed }
   }
-  return serialize(() => {
+  return serialize(captured => {
     try {
-      const metadata = readFreshMetadata(root)
+      const metadata = readFreshMetadata(root, captured)
       if (metadata !== undefined) {
         return { hydrated: false, recordsIndexed: metadata.recordsIndexed }
       }
@@ -723,25 +737,36 @@ const prepareResolvedWithoutCorruptionRecovery = (root: string, lock = true): Pr
         throw error
       }
     }
-    return rebuildCache(root)
+    return rebuildCache(root, captured)
   })
 }
 
-const prepareResolved = (root: string, lock = true): PrepareResult => {
+const prepareResolved = (
+  root: string,
+  lock = true,
+  capturedLocation: CacheLocation = inspectCacheLocation(root),
+): PrepareResult => {
   try {
-    return prepareResolvedWithoutCorruptionRecovery(root, lock)
+    return prepareResolvedWithoutCorruptionRecovery(root, capturedLocation, lock)
   } catch (error) {
     if (!isRecoverableCacheFailure(error)) {
       throw error
     }
-    return lock ? withOperationLock(root, () => rebuildCache(root)) : rebuildCache(root)
+    return lock
+      ? withOperationLock(root, location => rebuildCache(root, location), {}, capturedLocation)
+      : rebuildCache(root, capturedLocation)
   }
 }
 
-export const prepareResolvedRepository = (root: string, lock = true): PrepareResult => prepareResolved(root, lock)
+export const prepareResolvedRepository = (root: string, lock = true, location?: CacheLocation): PrepareResult =>
+  prepareResolved(root, lock, location)
 
-export const hydrateResolvedRepository = (root: string, lock = true): PrepareResult =>
-  lock ? withOperationLock(root, () => rebuildCache(root)) : rebuildCache(root)
+export const hydrateResolvedRepository = (root: string, lock = true, location?: CacheLocation): PrepareResult => {
+  const captured = location ?? inspectCacheLocation(root)
+  return lock
+    ? withOperationLock(root, heldLocation => rebuildCache(root, heldLocation), {}, captured)
+    : rebuildCache(root, captured)
+}
 
 export const prepare = (input: RootInput = {}): PrepareResult => {
   const root = resolveRepository(parseRootInput(input, 'prepare'))
@@ -787,8 +812,8 @@ const fullResultLimit = (value: unknown) => positiveLimit(value, MAX_FULL_RESULT
 
 const compactResultLimit = (value: unknown) => positiveLimit(value, MAX_COMPACT_RESULT_LIMIT, 'compactResultLimit')
 
-const readFreshDatabase = <Result>(root: string, read: (database: DatabaseSync) => Result) => {
-  const database = openReaderDatabase(root)
+const readFreshDatabase = <Result>(root: string, location: CacheLocation, read: (database: DatabaseSync) => Result) => {
+  const database = openReaderDatabase(root, location)
   try {
     const metadata = readMetadata(database)
     if (!metadataIsFresh(root, database, metadata)) {
@@ -802,17 +827,18 @@ const readFreshDatabase = <Result>(root: string, read: (database: DatabaseSync) 
 
 const withPreparedDatabase = <Result>(input: RootInput, read: (database: DatabaseSync) => Result) => {
   const root = resolveRepository(input)
+  const location = inspectCacheLocation(root)
   try {
-    prepareResolved(root)
-    return readFreshDatabase(root, read)
+    prepareResolved(root, true, location)
+    return readFreshDatabase(root, location, read)
   } catch (error) {
     if (error instanceof EncephalonError) {
       throw error
     }
     if (isRecoverableCacheFailure(error)) {
-      withOperationLock(root, () => rebuildCache(root))
+      withOperationLock(root, captured => rebuildCache(root, captured), {}, location)
       try {
-        return readFreshDatabase(root, read)
+        return readFreshDatabase(root, location, read)
       } catch (retryError) {
         if (retryError instanceof EncephalonError) {
           throw retryError
@@ -1070,8 +1096,12 @@ const assertGatherBudgets = (input: GatherInput) => {
   searches.forEach(literalMatchQuery)
 }
 
-const readFreshTransaction = <Result>(root: string, read: (database: DatabaseSync) => Result) => {
-  const database = openReaderDatabase(root)
+const readFreshTransaction = <Result>(
+  root: string,
+  location: CacheLocation,
+  read: (database: DatabaseSync) => Result,
+) => {
+  const database = openReaderDatabase(root, location)
   try {
     database.exec('BEGIN')
     const metadata = readMetadata(database)
@@ -1118,24 +1148,25 @@ export const gatherRecords = (input: GatherInput): GatherResult => {
   assertGatherBudgets(parsed)
   compactResultLimit(parsed.limit)
   const root = resolveRepository(parsed)
+  const location = inspectCacheLocation(root)
   try {
     let hydrated: HydrateResult | null = null
     if (parsed.hydrate === true) {
       hydrated = {
-        recordsIndexed: hydrateResolvedRepository(root).recordsIndexed,
+        recordsIndexed: hydrateResolvedRepository(root, true, location).recordsIndexed,
       }
     } else {
-      prepareResolved(root)
+      prepareResolved(root, true, location)
     }
-    return readFreshTransaction(root, database => readGatherFromDatabase(database, parsed, hydrated))
+    return readFreshTransaction(root, location, database => readGatherFromDatabase(database, parsed, hydrated))
   } catch (error) {
     if (error instanceof EncephalonError) {
       throw error
     }
     if (isRecoverableCacheFailure(error)) {
-      const recovered = withOperationLock(root, () => rebuildCache(root))
+      const recovered = withOperationLock(root, captured => rebuildCache(root, captured), {}, location)
       try {
-        return readFreshTransaction(root, database =>
+        return readFreshTransaction(root, location, database =>
           readGatherFromDatabase(
             database,
             parsed,

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -250,7 +250,7 @@ const createCacheSchema = (database: DatabaseSync) => {
 const openWriterDatabase = (location: CacheLocation) => {
   const { DatabaseSync: DatabaseConstructor } = loadSQLite()
   verifySQLiteFeatures(DatabaseConstructor)
-  const opened = openVerifiedCacheDatabase({
+  return openVerifiedCacheDatabase({
     afterVerifiedOpen: database => {
       database.exec('PRAGMA journal_mode = WAL; PRAGMA synchronous = FULL; PRAGMA foreign_keys = ON;')
       createCacheSchema(database)
@@ -263,13 +263,12 @@ const openWriterDatabase = (location: CacheLocation) => {
     name: 'brain.sqlite',
     openOptions: { timeout: SQLITE_BUSY_TIMEOUT_MILLISECONDS },
   })
-  return opened.database
 }
 
 const openReaderDatabase = (location: CacheLocation) => {
   const { DatabaseSync: DatabaseConstructor } = loadSQLite()
   verifySQLiteFeatures(DatabaseConstructor)
-  const opened = openVerifiedCacheDatabase({
+  return openVerifiedCacheDatabase({
     afterVerifiedOpen: database => {
       assertCacheSchema(database)
       cacheReadTestHooks.duringDatabaseInitialisation?.('reader')
@@ -286,7 +285,6 @@ const openReaderDatabase = (location: CacheLocation) => {
       timeout: SQLITE_BUSY_TIMEOUT_MILLISECONDS,
     },
   })
-  return opened.database
 }
 
 const posixRelative = (root: string, path: string) =>

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -13,17 +13,12 @@ import {
 import {
   assertCacheDatabase,
   CacheDatabaseFailure,
-  CacheDatabaseSidecarChanged,
   type CacheLocation,
-  cacheDatabaseDidOpen,
-  cacheDatabaseWillOpen,
   failCacheDatabase,
   inspectCacheDatabase,
   inspectCacheLocation,
-  MAX_CACHE_DATABASE_OPEN_ATTEMPTS,
-  prepareCacheDatabase,
+  openVerifiedCacheDatabase,
   quarantineCacheDatabase,
-  refreshCacheDatabase,
 } from './cache-location.ts'
 import { EncephalonError, fail, failWithCause, wrapIo } from './errors.ts'
 import { PACKAGE_VERSION } from './generated/version.ts'
@@ -256,110 +251,77 @@ const createCacheSchema = (database: DatabaseSync) => {
 const openWriterDatabase = (location: CacheLocation) => {
   const { DatabaseSync: DatabaseConstructor } = loadSQLite()
   verifySQLiteFeatures(DatabaseConstructor)
-  let cacheDatabase = prepareCacheDatabase(location, 'brain.sqlite')
-  const attempts = Array.from({ length: MAX_CACHE_DATABASE_OPEN_ATTEMPTS }, (_, index) => index)
-  for (const attempt of attempts) {
-    cacheDatabaseWillOpen(cacheDatabase)
-    cacheDatabase = assertCacheDatabase(location, cacheDatabase)
-    let database: DatabaseSync
-    try {
-      database = new DatabaseConstructor(cacheDatabase.path, {
-        timeout: SQLITE_BUSY_TIMEOUT_MILLISECONDS,
-      })
-    } catch (error) {
-      return failCacheDatabase(error, cacheDatabase)
-    }
-    try {
-      cacheDatabaseDidOpen(cacheDatabase)
-      // Node's SQLite API accepts only pathnames, leaving a narrow replacement race
-      // between this identity check and SQLite's internal open.
-      cacheDatabase = assertCacheDatabase(location, cacheDatabase)
+  const opened = openVerifiedCacheDatabase({
+    afterVerifiedOpen: database => {
       database.exec('PRAGMA journal_mode = WAL; PRAGMA synchronous = FULL; PRAGMA foreign_keys = ON;')
-      cacheDatabase = refreshCacheDatabase(location, cacheDatabase)
-      createCacheSchema(database)
-      assertCacheSchema(database)
+    },
+    create: true,
+    DatabaseConstructor,
+    location,
+    name: 'brain.sqlite',
+    openOptions: { timeout: SQLITE_BUSY_TIMEOUT_MILLISECONDS },
+  })
+  let cacheDatabase = opened.snapshot
+  try {
+    createCacheSchema(opened.database)
+    assertCacheSchema(opened.database)
+    cacheDatabase = assertCacheDatabase(location, cacheDatabase)
+    return opened.database
+  } catch (error) {
+    let validationError: unknown
+    try {
       cacheDatabase = assertCacheDatabase(location, cacheDatabase)
-      return database
-    } catch (error) {
-      if (error instanceof CacheDatabaseSidecarChanged) {
-        database.close()
-        cacheDatabase = error.database
-        if (attempt === MAX_CACHE_DATABASE_OPEN_ATTEMPTS - 1) {
-          throw error
-        }
-      } else {
-        let validationError: unknown
-        try {
-          cacheDatabase = assertCacheDatabase(location, cacheDatabase)
-        } catch (candidate) {
-          validationError = candidate
-        }
-        database.close()
-        if (validationError !== undefined) {
-          throw validationError
-        }
-        if (error instanceof EncephalonError) {
-          throw error
-        }
-        return failCacheDatabase(error, cacheDatabase)
-      }
+    } catch (candidate) {
+      validationError = candidate
     }
+    opened.database.close()
+    if (validationError !== undefined) {
+      throw validationError
+    }
+    if (error instanceof EncephalonError) {
+      throw error
+    }
+    return failCacheDatabase(error, cacheDatabase)
   }
-  return fail('INTERNAL_ERROR', 'The Encephalon writer database open ended unexpectedly.')
 }
 
 const openReaderDatabase = (location: CacheLocation) => {
   const { DatabaseSync: DatabaseConstructor } = loadSQLite()
   verifySQLiteFeatures(DatabaseConstructor)
-  let cacheDatabase = inspectCacheDatabase(location, 'brain.sqlite')
-  if (cacheDatabase === undefined) {
-    throw new CacheSchemaMismatch('The cache database disappeared before it was opened.')
-  }
-  const attempts = Array.from({ length: MAX_CACHE_DATABASE_OPEN_ATTEMPTS }, (_, index) => index)
-  for (const attempt of attempts) {
-    cacheDatabaseWillOpen(cacheDatabase)
+  const opened = openVerifiedCacheDatabase({
+    create: false,
+    DatabaseConstructor,
+    location,
+    missing: () => {
+      throw new CacheSchemaMismatch('The cache database disappeared before it was opened.')
+    },
+    name: 'brain.sqlite',
+    openOptions: {
+      readOnly: true,
+      timeout: SQLITE_BUSY_TIMEOUT_MILLISECONDS,
+    },
+  })
+  let cacheDatabase = opened.snapshot
+  try {
+    assertCacheSchema(opened.database)
     cacheDatabase = assertCacheDatabase(location, cacheDatabase)
-    let database: DatabaseSync
+    return opened.database
+  } catch (error) {
+    let validationError: unknown
     try {
-      database = new DatabaseConstructor(cacheDatabase.path, {
-        readOnly: true,
-        timeout: SQLITE_BUSY_TIMEOUT_MILLISECONDS,
-      })
-    } catch (error) {
-      return failCacheDatabase(error, cacheDatabase)
-    }
-    try {
-      cacheDatabaseDidOpen(cacheDatabase)
       cacheDatabase = assertCacheDatabase(location, cacheDatabase)
-      assertCacheSchema(database)
-      cacheDatabase = assertCacheDatabase(location, cacheDatabase)
-      return database
-    } catch (error) {
-      if (error instanceof CacheDatabaseSidecarChanged) {
-        database.close()
-        cacheDatabase = error.database
-        if (attempt === MAX_CACHE_DATABASE_OPEN_ATTEMPTS - 1) {
-          throw error
-        }
-      } else {
-        let validationError: unknown
-        try {
-          cacheDatabase = assertCacheDatabase(location, cacheDatabase)
-        } catch (candidate) {
-          validationError = candidate
-        }
-        database.close()
-        if (validationError !== undefined) {
-          throw validationError
-        }
-        if (error instanceof EncephalonError) {
-          throw error
-        }
-        return failCacheDatabase(error, cacheDatabase)
-      }
+    } catch (candidate) {
+      validationError = candidate
     }
+    opened.database.close()
+    if (validationError !== undefined) {
+      throw validationError
+    }
+    if (error instanceof EncephalonError) {
+      throw error
+    }
+    return failCacheDatabase(error, cacheDatabase)
   }
-  return fail('INTERNAL_ERROR', 'The Encephalon reader database open ended unexpectedly.')
 }
 
 const posixRelative = (root: string, path: string) =>

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -12,11 +12,15 @@ import {
 } from './api-input.ts'
 import {
   assertCacheDatabase,
+  CacheDatabaseFailure,
   type CacheLocation,
+  cacheDatabaseWillOpen,
+  failCacheDatabase,
   inspectCacheDatabase,
   inspectCacheLocation,
   prepareCacheDatabase,
   quarantineCacheDatabase,
+  refreshCacheDatabase,
 } from './cache-location.ts'
 import { EncephalonError, fail, failWithCause, wrapIo } from './errors.ts'
 import { PACKAGE_VERSION } from './generated/version.ts'
@@ -141,9 +145,10 @@ const loadSQLite = () => {
 }
 
 const isRecoverableCacheFailure = (error: unknown) => {
-  const sqlite = error as { errcode?: unknown; message?: unknown }
+  const failure = error instanceof CacheDatabaseFailure ? error.failure : error
+  const sqlite = failure as { errcode?: unknown; message?: unknown }
   return (
-    error instanceof CacheSchemaMismatch ||
+    failure instanceof CacheSchemaMismatch ||
     sqlite.errcode === 8 ||
     sqlite.errcode === 14 ||
     sqlite.errcode === 11 ||
@@ -163,7 +168,12 @@ const assertTableColumns = (database: DatabaseSync, table: string, expected: str
   }
 }
 
-const removeCorruptCache = (location: CacheLocation) => quarantineCacheDatabase(location, 'brain.sqlite')
+const removeCorruptCache = (location: CacheLocation, error: unknown) => {
+  if (error instanceof CacheDatabaseFailure) {
+    return quarantineCacheDatabase(location, error.database)
+  }
+  throw error
+}
 
 const verifySQLiteFeatures = (DatabaseConstructor: SQLiteModule['DatabaseSync']) => {
   if (sqliteFeaturesVerified) {
@@ -240,45 +250,86 @@ const createCacheSchema = (database: DatabaseSync) => {
   `)
 }
 
-const openWriterDatabase = (root: string, location: CacheLocation = inspectCacheLocation(root)) => {
+const openWriterDatabase = (location: CacheLocation) => {
   const { DatabaseSync: DatabaseConstructor } = loadSQLite()
   verifySQLiteFeatures(DatabaseConstructor)
-  const cacheDatabase = prepareCacheDatabase(location, 'brain.sqlite')
-  const database = new DatabaseConstructor(cacheDatabase.path, {
-    timeout: SQLITE_BUSY_TIMEOUT_MILLISECONDS,
-  })
+  let cacheDatabase = prepareCacheDatabase(location, 'brain.sqlite')
+  cacheDatabaseWillOpen(cacheDatabase)
+  cacheDatabase = assertCacheDatabase(location, cacheDatabase)
+  let database: DatabaseSync
+  try {
+    database = new DatabaseConstructor(cacheDatabase.path, {
+      timeout: SQLITE_BUSY_TIMEOUT_MILLISECONDS,
+    })
+  } catch (error) {
+    return failCacheDatabase(error, cacheDatabase)
+  }
   try {
     // Node's SQLite API accepts only pathnames, leaving a narrow replacement race
     // between this identity check and SQLite's internal open.
-    assertCacheDatabase(location, cacheDatabase)
+    cacheDatabase = assertCacheDatabase(location, cacheDatabase)
     database.exec('PRAGMA journal_mode = WAL; PRAGMA synchronous = FULL; PRAGMA foreign_keys = ON;')
+    cacheDatabase = refreshCacheDatabase(location, cacheDatabase)
     createCacheSchema(database)
     assertCacheSchema(database)
+    cacheDatabase = assertCacheDatabase(location, cacheDatabase)
     return database
   } catch (error) {
+    let validationError: unknown
+    try {
+      cacheDatabase = assertCacheDatabase(location, cacheDatabase)
+    } catch (candidate) {
+      validationError = candidate
+    }
     database.close()
-    throw error
+    if (validationError !== undefined) {
+      throw validationError
+    }
+    if (error instanceof EncephalonError) {
+      throw error
+    }
+    return failCacheDatabase(error, cacheDatabase)
   }
 }
 
-const openReaderDatabase = (root: string, location: CacheLocation = inspectCacheLocation(root)) => {
+const openReaderDatabase = (location: CacheLocation) => {
   const { DatabaseSync: DatabaseConstructor } = loadSQLite()
   verifySQLiteFeatures(DatabaseConstructor)
-  const cacheDatabase = inspectCacheDatabase(location, 'brain.sqlite')
+  let cacheDatabase = inspectCacheDatabase(location, 'brain.sqlite')
   if (cacheDatabase === undefined) {
     throw new CacheSchemaMismatch('The cache database disappeared before it was opened.')
   }
-  const database = new DatabaseConstructor(cacheDatabase.path, {
-    readOnly: true,
-    timeout: SQLITE_BUSY_TIMEOUT_MILLISECONDS,
-  })
+  cacheDatabaseWillOpen(cacheDatabase)
+  cacheDatabase = assertCacheDatabase(location, cacheDatabase)
+  let database: DatabaseSync
   try {
-    assertCacheDatabase(location, cacheDatabase)
+    database = new DatabaseConstructor(cacheDatabase.path, {
+      readOnly: true,
+      timeout: SQLITE_BUSY_TIMEOUT_MILLISECONDS,
+    })
+  } catch (error) {
+    return failCacheDatabase(error, cacheDatabase)
+  }
+  try {
+    cacheDatabase = assertCacheDatabase(location, cacheDatabase)
     assertCacheSchema(database)
+    cacheDatabase = assertCacheDatabase(location, cacheDatabase)
     return database
   } catch (error) {
+    let validationError: unknown
+    try {
+      cacheDatabase = assertCacheDatabase(location, cacheDatabase)
+    } catch (candidate) {
+      validationError = candidate
+    }
     database.close()
-    throw error
+    if (validationError !== undefined) {
+      throw validationError
+    }
+    if (error instanceof EncephalonError) {
+      throw error
+    }
+    return failCacheDatabase(error, cacheDatabase)
   }
 }
 
@@ -589,7 +640,7 @@ const writeMetadata = (database: DatabaseSync, metadata: Metadata) => {
 }
 
 const readFreshMetadata = (root: string, location: CacheLocation): Metadata | undefined => {
-  const database = openReaderDatabase(root, location)
+  const database = openReaderDatabase(location)
   try {
     const metadata = readMetadata(database)
     return metadataIsFresh(root, database, metadata) ? metadata : undefined
@@ -627,13 +678,13 @@ const rebuildCache = (root: string, location: CacheLocation = inspectCacheLocati
     const superseded = new Set(records.flatMap(record => record.supersedes ?? []))
     let database: DatabaseSync
     try {
-      database = openWriterDatabase(root, location)
+      database = openWriterDatabase(location)
     } catch (error) {
       if (!isRecoverableCacheFailure(error)) {
         throw error
       }
-      removeCorruptCache(location)
-      database = openWriterDatabase(root, location)
+      removeCorruptCache(location, error)
+      database = openWriterDatabase(location)
     }
     try {
       let existingMetadata: Metadata | undefined
@@ -813,7 +864,7 @@ const fullResultLimit = (value: unknown) => positiveLimit(value, MAX_FULL_RESULT
 const compactResultLimit = (value: unknown) => positiveLimit(value, MAX_COMPACT_RESULT_LIMIT, 'compactResultLimit')
 
 const readFreshDatabase = <Result>(root: string, location: CacheLocation, read: (database: DatabaseSync) => Result) => {
-  const database = openReaderDatabase(root, location)
+  const database = openReaderDatabase(location)
   try {
     const metadata = readMetadata(database)
     if (!metadataIsFresh(root, database, metadata)) {
@@ -827,15 +878,16 @@ const readFreshDatabase = <Result>(root: string, location: CacheLocation, read: 
 
 const withPreparedDatabase = <Result>(input: RootInput, read: (database: DatabaseSync) => Result) => {
   const root = resolveRepository(input)
-  const location = inspectCacheLocation(root)
+  let location: CacheLocation | undefined
   try {
+    location = inspectCacheLocation(root)
     prepareResolved(root, true, location)
     return readFreshDatabase(root, location, read)
   } catch (error) {
     if (error instanceof EncephalonError) {
       throw error
     }
-    if (isRecoverableCacheFailure(error)) {
+    if (isRecoverableCacheFailure(error) && location !== undefined) {
       withOperationLock(root, captured => rebuildCache(root, captured), {}, location)
       try {
         return readFreshDatabase(root, location, read)
@@ -1101,7 +1153,7 @@ const readFreshTransaction = <Result>(
   location: CacheLocation,
   read: (database: DatabaseSync) => Result,
 ) => {
-  const database = openReaderDatabase(root, location)
+  const database = openReaderDatabase(location)
   try {
     database.exec('BEGIN')
     const metadata = readMetadata(database)
@@ -1148,8 +1200,9 @@ export const gatherRecords = (input: GatherInput): GatherResult => {
   assertGatherBudgets(parsed)
   compactResultLimit(parsed.limit)
   const root = resolveRepository(parsed)
-  const location = inspectCacheLocation(root)
+  let location: CacheLocation | undefined
   try {
+    location = inspectCacheLocation(root)
     let hydrated: HydrateResult | null = null
     if (parsed.hydrate === true) {
       hydrated = {
@@ -1163,7 +1216,7 @@ export const gatherRecords = (input: GatherInput): GatherResult => {
     if (error instanceof EncephalonError) {
       throw error
     }
-    if (isRecoverableCacheFailure(error)) {
+    if (isRecoverableCacheFailure(error) && location !== undefined) {
       const recovered = withOperationLock(root, captured => rebuildCache(root, captured), {}, location)
       try {
         return readFreshTransaction(root, location, database =>

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -70,8 +70,13 @@ const isRecognizedSQLiteError = (error: unknown) => {
   )
 }
 
+const hasRecognizedIoCause = (cause: unknown, remainingDepth = 8): boolean =>
+  isRecognizedFilesystemError(cause) ||
+  isRecognizedSQLiteError(cause) ||
+  (remainingDepth > 0 && isRecord(cause) && hasRecognizedIoCause(cause.cause, remainingDepth - 1))
+
 const errorCodeForCause = (cause: unknown): EncephalonErrorCode =>
-  isRecognizedFilesystemError(cause) || isRecognizedSQLiteError(cause) ? 'IO_ERROR' : 'INTERNAL_ERROR'
+  hasRecognizedIoCause(cause) ? 'IO_ERROR' : 'INTERNAL_ERROR'
 
 const isCliSafeString = (value: string) =>
   value.length <= MAX_CLI_STRING_LENGTH && !/[\r\n]/.test(value) && !containsAbsolutePath(value)

--- a/src/init.ts
+++ b/src/init.ts
@@ -93,7 +93,7 @@ const initResolved = (input: InitEncephalonInput, hooks: InitHooks = {}): InitEn
     }))
   }
 
-  return withOperationLock(root, () => {
+  return withOperationLock(root, location => {
     const instructionPlans = planInstructionChanges(root, false)
     hooks.baselineScan?.()
     const baseline = scanBaseline(root)
@@ -122,7 +122,9 @@ const initResolved = (input: InitEncephalonInput, hooks: InitHooks = {}): InitEn
     const recordWriteOptions = hooks.recordWriteHooks === undefined ? {} : { hooks: hooks.recordWriteHooks }
     const recordsCreated = plans.map(plan => publishPlannedRecord(root, plan, recordWriteOptions))
     const cacheResult =
-      recordsCreated.length === 0 ? prepareResolvedRepository(root, false) : hydrateResolvedRepository(root, false)
+      recordsCreated.length === 0
+        ? prepareResolvedRepository(root, false, location)
+        : hydrateResolvedRepository(root, false, location)
     hooks.hydration?.(cacheResult)
     const instructionFiles = applyInstructionChanges(root, instructionPlans)
     return {

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -200,7 +200,7 @@ export const withOperationLock = <Result>(
     if (!recoveryLockHeld) {
       waitForGateRecovery()
     }
-    const opened = openVerifiedCacheDatabase({
+    gate = openVerifiedCacheDatabase({
       afterVerifiedOpen: database => {
         database.exec('BEGIN IMMEDIATE')
       },
@@ -211,7 +211,6 @@ export const withOperationLock = <Result>(
       openOptions: { timeout: remainingMilliseconds() },
       preserveDatabaseLocksAfterInitialisation: true,
     })
-    gate = opened.database
     gateTransaction = true
   }
 

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -5,19 +5,15 @@ import {
   assertCacheLockCandidates,
   type CacheDatabase,
   CacheDatabaseFailure,
-  CacheDatabaseSidecarChanged,
   type CacheLocation,
   type CacheOwnedDirectory,
-  cacheDatabaseDidOpen,
-  cacheDatabaseWillOpen,
   cacheOwnedDirectoryIsCurrent,
   cacheOwnedDirectoryMtimeMilliseconds,
   createCacheOwnedDirectory,
   failCacheDatabase,
   inspectCacheLocation,
   inspectCacheOwnedDirectory,
-  MAX_CACHE_DATABASE_OPEN_ATTEMPTS,
-  prepareCacheDatabase,
+  openVerifiedCacheDatabase,
   promoteCacheOwnedDirectory,
   quarantineCacheDatabase,
   quarantineCacheOwnedDirectory,
@@ -203,52 +199,35 @@ export const withOperationLock = <Result>(
     if (!recoveryLockHeld) {
       waitForGateRecovery()
     }
-    gateDatabase = prepareCacheDatabase(location, 'operation-lock.sqlite')
-    const attempts = Array.from({ length: MAX_CACHE_DATABASE_OPEN_ATTEMPTS }, (_, index) => index)
-    for (const attempt of attempts) {
-      cacheDatabaseWillOpen(gateDatabase)
-      gateDatabase = assertCacheDatabase(location, gateDatabase)
+    const opened = openVerifiedCacheDatabase({
+      create: true,
+      DatabaseConstructor: DatabaseSync,
+      location,
+      name: 'operation-lock.sqlite',
+      openOptions: { timeout: remainingMilliseconds() },
+    })
+    gate = opened.database
+    gateDatabase = opened.snapshot
+    try {
+      gate.exec('BEGIN IMMEDIATE')
+      gateTransaction = true
+    } catch (error) {
+      let validationError: unknown
       try {
-        gate = new DatabaseSync(gateDatabase.path, { timeout: remainingMilliseconds() })
-      } catch (error) {
-        return failCacheDatabase(error, gateDatabase)
-      }
-      try {
-        cacheDatabaseDidOpen(gateDatabase)
-        // Node's SQLite API accepts only pathnames, leaving a narrow replacement race
-        // between this identity check and SQLite's internal open.
         gateDatabase = assertCacheDatabase(location, gateDatabase)
-        gate.exec('BEGIN IMMEDIATE')
-        gateTransaction = true
-        return
-      } catch (error) {
-        if (error instanceof CacheDatabaseSidecarChanged) {
-          gate.close()
-          gate = undefined
-          gateDatabase = error.database
-          if (attempt === MAX_CACHE_DATABASE_OPEN_ATTEMPTS - 1) {
-            throw error
-          }
-        } else {
-          let validationError: unknown
-          try {
-            gateDatabase = assertCacheDatabase(location, gateDatabase)
-          } catch (candidate) {
-            validationError = candidate
-          }
-          gate.close()
-          gate = undefined
-          if (validationError !== undefined) {
-            throw validationError
-          }
-          if (error instanceof EncephalonError) {
-            throw error
-          }
-          return failCacheDatabase(error, gateDatabase)
-        }
+      } catch (candidate) {
+        validationError = candidate
       }
+      gate.close()
+      gate = undefined
+      if (validationError !== undefined) {
+        throw validationError
+      }
+      if (error instanceof EncephalonError) {
+        throw error
+      }
+      return failCacheDatabase(error, gateDatabase)
     }
-    return fail('INTERNAL_ERROR', 'The Encephalon gate database open ended unexpectedly.')
   }
 
   const recoverCorruptGate = () => {

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -1,17 +1,21 @@
 import { randomUUID } from 'node:crypto'
-import { renameSync, statSync } from 'node:fs'
-import { resolve } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import {
   assertCacheDatabase,
-  assertCacheOwnedEntries,
+  assertCacheLockCandidates,
   type CacheDatabase,
+  CacheDatabaseFailure,
   type CacheLocation,
   type CacheOwnedDirectory,
+  cacheDatabaseWillOpen,
+  cacheOwnedDirectoryIsCurrent,
+  cacheOwnedDirectoryMtimeMilliseconds,
   createCacheOwnedDirectory,
+  failCacheDatabase,
   inspectCacheLocation,
   inspectCacheOwnedDirectory,
   prepareCacheDatabase,
+  promoteCacheOwnedDirectory,
   quarantineCacheDatabase,
   quarantineCacheOwnedDirectory,
   readCacheOwner,
@@ -30,7 +34,9 @@ type LockOwner = {
 }
 
 type LockTestHooks = {
-  afterStaleObservation?: () => void
+  afterRecoveryCreation?: (() => void) | undefined
+  afterRecoveryStaleObservation?: (() => void) | undefined
+  afterStaleObservation?: (() => void) | undefined
 }
 
 const MAX_OWNER_BYTES = 4096
@@ -71,7 +77,10 @@ const processIsRunning = (pid: number) => {
 }
 
 const sqliteBusy = (error: unknown) => {
-  const candidate = error as { errcode?: unknown; message?: unknown }
+  const candidate = (error instanceof CacheDatabaseFailure ? error.failure : error) as {
+    errcode?: unknown
+    message?: unknown
+  }
   return (
     candidate.errcode === 5 ||
     candidate.errcode === 6 ||
@@ -81,7 +90,10 @@ const sqliteBusy = (error: unknown) => {
 }
 
 const sqliteCorrupt = (error: unknown) => {
-  const candidate = error as { errcode?: unknown; message?: unknown }
+  const candidate = (error instanceof CacheDatabaseFailure ? error.failure : error) as {
+    errcode?: unknown
+    message?: unknown
+  }
   return (
     candidate.errcode === 11 ||
     candidate.errcode === 26 ||
@@ -90,8 +102,6 @@ const sqliteCorrupt = (error: unknown) => {
   )
 }
 
-export const cacheDirectory = (root: string) => resolve(root, 'node_modules', '.cache', 'encephalon')
-
 export const withOperationLock = <Result>(
   root: string,
   operation: (location: CacheLocation) => Result,
@@ -99,13 +109,11 @@ export const withOperationLock = <Result>(
   capturedLocation?: CacheLocation,
 ): Result => {
   const location = capturedLocation ?? inspectCacheLocation(root)
-  assertCacheOwnedEntries(location)
-  const { directory } = location
+  assertCacheLockCandidates(location)
   const lockName = 'operation.lock'
-  const lockPath = resolve(directory, lockName)
   const recoveryName = 'operation-lock.recovery'
   const token = randomUUID()
-  const candidatePath = resolve(directory, `operation.lock.${token}`)
+  const candidateName = `operation.lock.${token}`
   const startedAt = Date.now()
   let gate: DatabaseSync | undefined
   let gateDatabase: CacheDatabase | undefined
@@ -119,52 +127,55 @@ export const withOperationLock = <Result>(
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds)
   }
 
-  const missingPath = (error: unknown) => (error as NodeJS.ErrnoException).code === 'ENOENT'
-
-  const recoveryMarkerIsStale = () => {
+  const recoveryMarkerObservation = () => {
     const recoveryDirectory = inspectCacheOwnedDirectory(location, recoveryName)
     if (recoveryDirectory === undefined) {
-      return false
+      return
     }
     const owner = readOwner(location, recoveryDirectory)
     if (owner !== undefined) {
       const acquiredAt = Date.parse(owner.acquiredAt)
       const age = Number.isFinite(acquiredAt) ? Date.now() - acquiredAt : RECOVERY_STALE_MILLISECONDS + 1
-      return !processIsRunning(owner.pid) || age > RECOVERY_STALE_MILLISECONDS
-    }
-    try {
-      return Date.now() - statSync(recoveryDirectory.path).mtimeMs > RECOVERY_STALE_MILLISECONDS
-    } catch (error) {
-      if (missingPath(error)) {
-        return false
+      return {
+        directory: recoveryDirectory,
+        stale: !processIsRunning(owner.pid) || age > RECOVERY_STALE_MILLISECONDS,
       }
-      throw error
+    }
+    return {
+      directory: recoveryDirectory,
+      stale:
+        Date.now() - cacheOwnedDirectoryMtimeMilliseconds(location, recoveryDirectory) > RECOVERY_STALE_MILLISECONDS,
     }
   }
 
-  const reclaimRecoveryMarker = () => {
-    const recoveryDirectory = inspectCacheOwnedDirectory(location, recoveryName)
-    if (recoveryDirectory !== undefined) {
+  const reclaimRecoveryMarker = (recoveryDirectory: CacheOwnedDirectory) => {
+    testHooks.afterRecoveryStaleObservation?.()
+    if (cacheOwnedDirectoryIsCurrent(location, recoveryDirectory)) {
       quarantineCacheOwnedDirectory(location, recoveryDirectory)
     }
   }
 
   const waitForGateRecovery = () => {
-    while (inspectCacheOwnedDirectory(location, recoveryName) !== undefined) {
+    let observation = recoveryMarkerObservation()
+    while (observation !== undefined) {
       if (remainingMilliseconds() === 0) {
         return fail('CACHE_BUSY', 'Timed out waiting for the Encephalon operation lock.', {
           timeoutMilliseconds: LOCK_WAIT_MILLISECONDS,
         })
       }
-      if (recoveryMarkerIsStale()) {
-        reclaimRecoveryMarker()
+      if (observation.stale) {
+        reclaimRecoveryMarker(observation.directory)
       }
       wait(Math.min(RECOVERY_POLL_MILLISECONDS, remainingMilliseconds()))
+      observation = recoveryMarkerObservation()
     }
   }
 
-  const quarantineCorruptGate = () => {
-    quarantineCacheDatabase(location, 'operation-lock.sqlite')
+  const quarantineCorruptGate = (error: unknown) => {
+    if (error instanceof CacheDatabaseFailure) {
+      return quarantineCacheDatabase(location, error.database)
+    }
+    throw error
   }
 
   const beginGateTransaction = (recoveryLockHeld = false) => {
@@ -172,26 +183,46 @@ export const withOperationLock = <Result>(
       waitForGateRecovery()
     }
     gateDatabase = prepareCacheDatabase(location, 'operation-lock.sqlite')
-    gate = new DatabaseSync(gateDatabase.path, { timeout: remainingMilliseconds() })
+    cacheDatabaseWillOpen(gateDatabase)
+    gateDatabase = assertCacheDatabase(location, gateDatabase)
+    try {
+      gate = new DatabaseSync(gateDatabase.path, { timeout: remainingMilliseconds() })
+    } catch (error) {
+      return failCacheDatabase(error, gateDatabase)
+    }
     try {
       // Node's SQLite API accepts only pathnames, leaving a narrow replacement race
       // between this identity check and SQLite's internal open.
-      assertCacheDatabase(location, gateDatabase)
+      gateDatabase = assertCacheDatabase(location, gateDatabase)
       gate.exec('BEGIN IMMEDIATE')
       gateTransaction = true
     } catch (error) {
+      let validationError: unknown
+      try {
+        gateDatabase = assertCacheDatabase(location, gateDatabase)
+      } catch (candidate) {
+        validationError = candidate
+      }
       gate.close()
       gate = undefined
-      throw error
+      if (validationError !== undefined) {
+        throw validationError
+      }
+      if (error instanceof EncephalonError) {
+        throw error
+      }
+      return failCacheDatabase(error, gateDatabase)
     }
   }
 
   const recoverCorruptGate = () => {
     let recoveryLockHeld = false
+    let ownedRecoveryDirectory: CacheOwnedDirectory | undefined
     let recoveryError: unknown
     while (!recoveryLockHeld) {
       try {
         const recoveryDirectory = createCacheOwnedDirectory(location, recoveryName)
+        ownedRecoveryDirectory = recoveryDirectory
         writeCacheOwner(
           location,
           recoveryDirectory,
@@ -201,6 +232,7 @@ export const withOperationLock = <Result>(
             token,
           })}\n`,
         )
+        testHooks.afterRecoveryCreation?.()
         recoveryLockHeld = true
       } catch (error) {
         const existingRecovery = (error as NodeJS.ErrnoException).code === 'EEXIST'
@@ -212,8 +244,9 @@ export const withOperationLock = <Result>(
             timeoutMilliseconds: LOCK_WAIT_MILLISECONDS,
           })
         }
-        if (recoveryMarkerIsStale()) {
-          reclaimRecoveryMarker()
+        const observation = recoveryMarkerObservation()
+        if (observation?.stale === true) {
+          reclaimRecoveryMarker(observation.directory)
         }
         wait(Math.min(RECOVERY_POLL_MILLISECONDS, remainingMilliseconds()))
       }
@@ -230,7 +263,7 @@ export const withOperationLock = <Result>(
         if (!sqliteCorrupt(error)) {
           throw error
         }
-        quarantineCorruptGate()
+        quarantineCorruptGate(error)
         beginGateTransaction(true)
       }
     } catch (error) {
@@ -238,9 +271,8 @@ export const withOperationLock = <Result>(
     }
     let cleanupError: unknown
     try {
-      const recoveryDirectory = inspectCacheOwnedDirectory(location, recoveryName)
-      if (recoveryDirectory !== undefined && readOwner(location, recoveryDirectory)?.token === token) {
-        quarantineCacheOwnedDirectory(location, recoveryDirectory)
+      if (ownedRecoveryDirectory !== undefined) {
+        quarantineCacheOwnedDirectory(location, ownedRecoveryDirectory)
       }
     } catch (error) {
       cleanupError = error
@@ -254,7 +286,7 @@ export const withOperationLock = <Result>(
   }
 
   try {
-    candidateDirectory = createCacheOwnedDirectory(location, `operation.lock.${token}`)
+    candidateDirectory = createCacheOwnedDirectory(location, candidateName)
     const candidateOwner: LockOwner = {
       acquiredAt: new Date().toISOString(),
       pid: process.pid,
@@ -288,8 +320,7 @@ export const withOperationLock = <Result>(
       quarantineCacheOwnedDirectory(location, staleLock)
     }
 
-    renameSync(candidatePath, lockPath)
-    ownedLockDirectory = { ...candidateDirectory, name: lockName, path: lockPath }
+    ownedLockDirectory = promoteCacheOwnedDirectory(location, candidateDirectory, lockName)
     candidateDirectory = undefined
     try {
       return operation(location)
@@ -315,7 +346,7 @@ export const withOperationLock = <Result>(
     }
     gate?.close()
     try {
-      const remainingCandidate = candidateDirectory ?? inspectCacheOwnedDirectory(location, `operation.lock.${token}`)
+      const remainingCandidate = candidateDirectory ?? inspectCacheOwnedDirectory(location, candidateName)
       if (remainingCandidate !== undefined) {
         quarantineCacheOwnedDirectory(location, remainingCandidate)
       }

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -1,18 +1,16 @@
 import { randomUUID } from 'node:crypto'
 import { DatabaseSync } from 'node:sqlite'
 import {
-  assertCacheDatabase,
   assertCacheLockCandidates,
-  type CacheDatabase,
   CacheDatabaseFailure,
   type CacheLocation,
   type CacheOwnedDirectory,
   cacheOwnedDirectoryIsCurrent,
   cacheOwnedDirectoryMtimeMilliseconds,
   createCacheOwnedDirectory,
-  failCacheDatabase,
   inspectCacheLocation,
   inspectCacheOwnedDirectory,
+  observeCacheOwnedDirectory,
   openVerifiedCacheDatabase,
   promoteCacheOwnedDirectory,
   quarantineCacheDatabase,
@@ -121,7 +119,6 @@ export const withOperationLock = <Result>(
   const candidateName = `operation.lock.${token}`
   const startedAt = Date.now()
   let gate: DatabaseSync | undefined
-  let gateDatabase: CacheDatabase | undefined
   let gateTransaction = false
   let candidateDirectory: CacheOwnedDirectory | undefined
   let ownedLockDirectory: CacheOwnedDirectory | undefined
@@ -133,10 +130,14 @@ export const withOperationLock = <Result>(
   }
 
   const recoveryMarkerObservation = (): RecoveryMarkerObservation => {
-    const recoveryDirectory = inspectCacheOwnedDirectory(location, recoveryName)
-    if (recoveryDirectory === undefined) {
+    const directoryObservation = observeCacheOwnedDirectory(location, recoveryName)
+    if (directoryObservation.kind === 'missing') {
       return { kind: 'absent' }
     }
+    if (directoryObservation.kind === 'changed') {
+      return { kind: 'retry' }
+    }
+    const recoveryDirectory = directoryObservation.directory
     testHooks.duringRecoveryObservation?.()
     try {
       const owner = readOwner(location, recoveryDirectory)
@@ -200,34 +201,18 @@ export const withOperationLock = <Result>(
       waitForGateRecovery()
     }
     const opened = openVerifiedCacheDatabase({
+      afterVerifiedOpen: database => {
+        database.exec('BEGIN IMMEDIATE')
+      },
       create: true,
       DatabaseConstructor: DatabaseSync,
       location,
       name: 'operation-lock.sqlite',
       openOptions: { timeout: remainingMilliseconds() },
+      preserveDatabaseLocksAfterInitialisation: true,
     })
     gate = opened.database
-    gateDatabase = opened.snapshot
-    try {
-      gate.exec('BEGIN IMMEDIATE')
-      gateTransaction = true
-    } catch (error) {
-      let validationError: unknown
-      try {
-        gateDatabase = assertCacheDatabase(location, gateDatabase)
-      } catch (candidate) {
-        validationError = candidate
-      }
-      gate.close()
-      gate = undefined
-      if (validationError !== undefined) {
-        throw validationError
-      }
-      if (error instanceof EncephalonError) {
-        throw error
-      }
-      return failCacheDatabase(error, gateDatabase)
-    }
+    gateTransaction = true
   }
 
   const recoverCorruptGate = () => {

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -5,8 +5,10 @@ import {
   assertCacheLockCandidates,
   type CacheDatabase,
   CacheDatabaseFailure,
+  CacheDatabaseSidecarChanged,
   type CacheLocation,
   type CacheOwnedDirectory,
+  cacheDatabaseDidOpen,
   cacheDatabaseWillOpen,
   cacheOwnedDirectoryIsCurrent,
   cacheOwnedDirectoryMtimeMilliseconds,
@@ -14,6 +16,7 @@ import {
   failCacheDatabase,
   inspectCacheLocation,
   inspectCacheOwnedDirectory,
+  MAX_CACHE_DATABASE_OPEN_ATTEMPTS,
   prepareCacheDatabase,
   promoteCacheOwnedDirectory,
   quarantineCacheDatabase,
@@ -37,7 +40,13 @@ type LockTestHooks = {
   afterRecoveryCreation?: (() => void) | undefined
   afterRecoveryStaleObservation?: (() => void) | undefined
   afterStaleObservation?: (() => void) | undefined
+  duringRecoveryObservation?: (() => void) | undefined
 }
+
+type RecoveryMarkerObservation =
+  | { kind: 'absent' }
+  | { kind: 'observed'; directory: CacheOwnedDirectory; stale: boolean }
+  | { kind: 'retry' }
 
 const MAX_OWNER_BYTES = 4096
 
@@ -127,24 +136,34 @@ export const withOperationLock = <Result>(
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds)
   }
 
-  const recoveryMarkerObservation = () => {
+  const recoveryMarkerObservation = (): RecoveryMarkerObservation => {
     const recoveryDirectory = inspectCacheOwnedDirectory(location, recoveryName)
     if (recoveryDirectory === undefined) {
-      return
+      return { kind: 'absent' }
     }
-    const owner = readOwner(location, recoveryDirectory)
-    if (owner !== undefined) {
-      const acquiredAt = Date.parse(owner.acquiredAt)
-      const age = Number.isFinite(acquiredAt) ? Date.now() - acquiredAt : RECOVERY_STALE_MILLISECONDS + 1
+    testHooks.duringRecoveryObservation?.()
+    try {
+      const owner = readOwner(location, recoveryDirectory)
+      if (owner !== undefined) {
+        const acquiredAt = Date.parse(owner.acquiredAt)
+        const age = Number.isFinite(acquiredAt) ? Date.now() - acquiredAt : RECOVERY_STALE_MILLISECONDS + 1
+        return {
+          directory: recoveryDirectory,
+          kind: 'observed',
+          stale: !processIsRunning(owner.pid) || age > RECOVERY_STALE_MILLISECONDS,
+        }
+      }
       return {
         directory: recoveryDirectory,
-        stale: !processIsRunning(owner.pid) || age > RECOVERY_STALE_MILLISECONDS,
+        kind: 'observed',
+        stale:
+          Date.now() - cacheOwnedDirectoryMtimeMilliseconds(location, recoveryDirectory) > RECOVERY_STALE_MILLISECONDS,
       }
-    }
-    return {
-      directory: recoveryDirectory,
-      stale:
-        Date.now() - cacheOwnedDirectoryMtimeMilliseconds(location, recoveryDirectory) > RECOVERY_STALE_MILLISECONDS,
+    } catch (error) {
+      if (cacheOwnedDirectoryIsCurrent(location, recoveryDirectory)) {
+        throw error
+      }
+      return { kind: 'retry' }
     }
   }
 
@@ -157,16 +176,18 @@ export const withOperationLock = <Result>(
 
   const waitForGateRecovery = () => {
     let observation = recoveryMarkerObservation()
-    while (observation !== undefined) {
+    while (observation.kind !== 'absent') {
       if (remainingMilliseconds() === 0) {
         return fail('CACHE_BUSY', 'Timed out waiting for the Encephalon operation lock.', {
           timeoutMilliseconds: LOCK_WAIT_MILLISECONDS,
         })
       }
-      if (observation.stale) {
+      if (observation.kind === 'observed' && observation.stale) {
         reclaimRecoveryMarker(observation.directory)
       }
-      wait(Math.min(RECOVERY_POLL_MILLISECONDS, remainingMilliseconds()))
+      if (observation.kind === 'observed') {
+        wait(Math.min(RECOVERY_POLL_MILLISECONDS, remainingMilliseconds()))
+      }
       observation = recoveryMarkerObservation()
     }
   }
@@ -183,36 +204,51 @@ export const withOperationLock = <Result>(
       waitForGateRecovery()
     }
     gateDatabase = prepareCacheDatabase(location, 'operation-lock.sqlite')
-    cacheDatabaseWillOpen(gateDatabase)
-    gateDatabase = assertCacheDatabase(location, gateDatabase)
-    try {
-      gate = new DatabaseSync(gateDatabase.path, { timeout: remainingMilliseconds() })
-    } catch (error) {
-      return failCacheDatabase(error, gateDatabase)
-    }
-    try {
-      // Node's SQLite API accepts only pathnames, leaving a narrow replacement race
-      // between this identity check and SQLite's internal open.
+    const attempts = Array.from({ length: MAX_CACHE_DATABASE_OPEN_ATTEMPTS }, (_, index) => index)
+    for (const attempt of attempts) {
+      cacheDatabaseWillOpen(gateDatabase)
       gateDatabase = assertCacheDatabase(location, gateDatabase)
-      gate.exec('BEGIN IMMEDIATE')
-      gateTransaction = true
-    } catch (error) {
-      let validationError: unknown
       try {
+        gate = new DatabaseSync(gateDatabase.path, { timeout: remainingMilliseconds() })
+      } catch (error) {
+        return failCacheDatabase(error, gateDatabase)
+      }
+      try {
+        cacheDatabaseDidOpen(gateDatabase)
+        // Node's SQLite API accepts only pathnames, leaving a narrow replacement race
+        // between this identity check and SQLite's internal open.
         gateDatabase = assertCacheDatabase(location, gateDatabase)
-      } catch (candidate) {
-        validationError = candidate
+        gate.exec('BEGIN IMMEDIATE')
+        gateTransaction = true
+        return
+      } catch (error) {
+        if (error instanceof CacheDatabaseSidecarChanged) {
+          gate.close()
+          gate = undefined
+          gateDatabase = error.database
+          if (attempt === MAX_CACHE_DATABASE_OPEN_ATTEMPTS - 1) {
+            throw error
+          }
+        } else {
+          let validationError: unknown
+          try {
+            gateDatabase = assertCacheDatabase(location, gateDatabase)
+          } catch (candidate) {
+            validationError = candidate
+          }
+          gate.close()
+          gate = undefined
+          if (validationError !== undefined) {
+            throw validationError
+          }
+          if (error instanceof EncephalonError) {
+            throw error
+          }
+          return failCacheDatabase(error, gateDatabase)
+        }
       }
-      gate.close()
-      gate = undefined
-      if (validationError !== undefined) {
-        throw validationError
-      }
-      if (error instanceof EncephalonError) {
-        throw error
-      }
-      return failCacheDatabase(error, gateDatabase)
     }
+    return fail('INTERNAL_ERROR', 'The Encephalon gate database open ended unexpectedly.')
   }
 
   const recoverCorruptGate = () => {
@@ -245,7 +281,7 @@ export const withOperationLock = <Result>(
           })
         }
         const observation = recoveryMarkerObservation()
-        if (observation?.stale === true) {
+        if (observation.kind === 'observed' && observation.stale) {
           reclaimRecoveryMarker(observation.directory)
         }
         wait(Math.min(RECOVERY_POLL_MILLISECONDS, remainingMilliseconds()))

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -1,7 +1,22 @@
 import { randomUUID } from 'node:crypto'
-import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { renameSync, statSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
+import {
+  assertCacheDatabase,
+  assertCacheOwnedEntries,
+  type CacheDatabase,
+  type CacheLocation,
+  type CacheOwnedDirectory,
+  createCacheOwnedDirectory,
+  inspectCacheLocation,
+  inspectCacheOwnedDirectory,
+  prepareCacheDatabase,
+  quarantineCacheDatabase,
+  quarantineCacheOwnedDirectory,
+  readCacheOwner,
+  writeCacheOwner,
+} from './cache-location.ts'
 import { EncephalonError, fail, wrapIo } from './errors.ts'
 
 const LOCK_WAIT_MILLISECONDS = 60_000
@@ -18,9 +33,12 @@ type LockTestHooks = {
   afterStaleObservation?: () => void
 }
 
-const readOwner = (path: string): LockOwner | undefined => {
+const MAX_OWNER_BYTES = 4096
+
+const readOwner = (location: CacheLocation, directory: CacheOwnedDirectory): LockOwner | undefined => {
   try {
-    const value = JSON.parse(readFileSync(resolve(path, 'owner.json'), 'utf8')) as Partial<LockOwner>
+    const contents = readCacheOwner(location, directory, MAX_OWNER_BYTES)
+    const value = JSON.parse(contents ?? '') as Partial<LockOwner>
     if (
       typeof value.token === 'string' &&
       Number.isInteger(value.pid) &&
@@ -29,13 +47,17 @@ const readOwner = (path: string): LockOwner | undefined => {
     ) {
       return value as LockOwner
     }
-  } catch {}
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) {
+      throw error
+    }
+  }
 }
 
-const releaseOwnedLock = (path: string, token: string) => {
-  const owner = readOwner(path)
+const releaseOwnedLock = (location: CacheLocation, directory: CacheOwnedDirectory, token: string) => {
+  const owner = readOwner(location, directory)
   if (owner?.token === token) {
-    rmSync(path, { force: true, recursive: true })
+    quarantineCacheOwnedDirectory(location, directory)
   }
 }
 
@@ -72,18 +94,24 @@ export const cacheDirectory = (root: string) => resolve(root, 'node_modules', '.
 
 export const withOperationLock = <Result>(
   root: string,
-  operation: () => Result,
+  operation: (location: CacheLocation) => Result,
   testHooks: LockTestHooks = {},
+  capturedLocation?: CacheLocation,
 ): Result => {
-  const directory = cacheDirectory(root)
-  const lockPath = resolve(directory, 'operation.lock')
-  const gatePath = resolve(directory, 'operation-lock.sqlite')
-  const gateRecoveryPath = resolve(directory, 'operation-lock.recovery')
+  const location = capturedLocation ?? inspectCacheLocation(root)
+  assertCacheOwnedEntries(location)
+  const { directory } = location
+  const lockName = 'operation.lock'
+  const lockPath = resolve(directory, lockName)
+  const recoveryName = 'operation-lock.recovery'
   const token = randomUUID()
   const candidatePath = resolve(directory, `operation.lock.${token}`)
   const startedAt = Date.now()
   let gate: DatabaseSync | undefined
+  let gateDatabase: CacheDatabase | undefined
   let gateTransaction = false
+  let candidateDirectory: CacheOwnedDirectory | undefined
+  let ownedLockDirectory: CacheOwnedDirectory | undefined
 
   const remainingMilliseconds = () => Math.max(0, LOCK_WAIT_MILLISECONDS - (Date.now() - startedAt))
 
@@ -94,14 +122,18 @@ export const withOperationLock = <Result>(
   const missingPath = (error: unknown) => (error as NodeJS.ErrnoException).code === 'ENOENT'
 
   const recoveryMarkerIsStale = () => {
-    const owner = readOwner(gateRecoveryPath)
+    const recoveryDirectory = inspectCacheOwnedDirectory(location, recoveryName)
+    if (recoveryDirectory === undefined) {
+      return false
+    }
+    const owner = readOwner(location, recoveryDirectory)
     if (owner !== undefined) {
       const acquiredAt = Date.parse(owner.acquiredAt)
       const age = Number.isFinite(acquiredAt) ? Date.now() - acquiredAt : RECOVERY_STALE_MILLISECONDS + 1
       return !processIsRunning(owner.pid) || age > RECOVERY_STALE_MILLISECONDS
     }
     try {
-      return Date.now() - statSync(gateRecoveryPath).mtimeMs > RECOVERY_STALE_MILLISECONDS
+      return Date.now() - statSync(recoveryDirectory.path).mtimeMs > RECOVERY_STALE_MILLISECONDS
     } catch (error) {
       if (missingPath(error)) {
         return false
@@ -111,31 +143,14 @@ export const withOperationLock = <Result>(
   }
 
   const reclaimRecoveryMarker = () => {
-    const quarantinePath = `${gateRecoveryPath}.stale-${token}`
-    try {
-      renameSync(gateRecoveryPath, quarantinePath)
-      rmSync(quarantinePath, { force: true, recursive: true })
-    } catch (error) {
-      if (!missingPath(error)) {
-        throw error
-      }
-    }
-  }
-
-  const quarantineGateCandidate = (path: string) => {
-    const quarantinePath = `${path}.corrupt-${token}`
-    try {
-      renameSync(path, quarantinePath)
-      rmSync(quarantinePath, { force: true })
-    } catch (error) {
-      if (!missingPath(error)) {
-        throw error
-      }
+    const recoveryDirectory = inspectCacheOwnedDirectory(location, recoveryName)
+    if (recoveryDirectory !== undefined) {
+      quarantineCacheOwnedDirectory(location, recoveryDirectory)
     }
   }
 
   const waitForGateRecovery = () => {
-    while (existsSync(gateRecoveryPath)) {
+    while (inspectCacheOwnedDirectory(location, recoveryName) !== undefined) {
       if (remainingMilliseconds() === 0) {
         return fail('CACHE_BUSY', 'Timed out waiting for the Encephalon operation lock.', {
           timeoutMilliseconds: LOCK_WAIT_MILLISECONDS,
@@ -149,17 +164,19 @@ export const withOperationLock = <Result>(
   }
 
   const quarantineCorruptGate = () => {
-    for (const candidate of [`${gatePath}-wal`, `${gatePath}-shm`, `${gatePath}-journal`, gatePath]) {
-      quarantineGateCandidate(candidate)
-    }
+    quarantineCacheDatabase(location, 'operation-lock.sqlite')
   }
 
   const beginGateTransaction = (recoveryLockHeld = false) => {
     if (!recoveryLockHeld) {
       waitForGateRecovery()
     }
-    gate = new DatabaseSync(gatePath, { timeout: remainingMilliseconds() })
+    gateDatabase = prepareCacheDatabase(location, 'operation-lock.sqlite')
+    gate = new DatabaseSync(gateDatabase.path, { timeout: remainingMilliseconds() })
     try {
+      // Node's SQLite API accepts only pathnames, leaving a narrow replacement race
+      // between this identity check and SQLite's internal open.
+      assertCacheDatabase(location, gateDatabase)
       gate.exec('BEGIN IMMEDIATE')
       gateTransaction = true
     } catch (error) {
@@ -171,17 +188,18 @@ export const withOperationLock = <Result>(
 
   const recoverCorruptGate = () => {
     let recoveryLockHeld = false
+    let recoveryError: unknown
     while (!recoveryLockHeld) {
       try {
-        mkdirSync(gateRecoveryPath)
-        writeFileSync(
-          resolve(gateRecoveryPath, 'owner.json'),
+        const recoveryDirectory = createCacheOwnedDirectory(location, recoveryName)
+        writeCacheOwner(
+          location,
+          recoveryDirectory,
           `${JSON.stringify({
             acquiredAt: new Date().toISOString(),
             pid: process.pid,
             token,
           })}\n`,
-          { flag: 'wx' },
         )
         recoveryLockHeld = true
       } catch (error) {
@@ -215,22 +233,37 @@ export const withOperationLock = <Result>(
         quarantineCorruptGate()
         beginGateTransaction(true)
       }
-    } finally {
-      rmSync(gateRecoveryPath, { force: true, recursive: true })
+    } catch (error) {
+      recoveryError = error
+    }
+    let cleanupError: unknown
+    try {
+      const recoveryDirectory = inspectCacheOwnedDirectory(location, recoveryName)
+      if (recoveryDirectory !== undefined && readOwner(location, recoveryDirectory)?.token === token) {
+        quarantineCacheOwnedDirectory(location, recoveryDirectory)
+      }
+    } catch (error) {
+      cleanupError = error
+    }
+    if (recoveryError !== undefined) {
+      throw recoveryError
+    }
+    if (cleanupError !== undefined) {
+      throw cleanupError
     }
   }
 
   try {
-    mkdirSync(directory, { recursive: true })
-    mkdirSync(candidatePath)
+    candidateDirectory = createCacheOwnedDirectory(location, `operation.lock.${token}`)
     const candidateOwner: LockOwner = {
       acquiredAt: new Date().toISOString(),
       pid: process.pid,
       token,
     }
-    writeFileSync(resolve(candidatePath, 'owner.json'), `${JSON.stringify(candidateOwner)}\n`, { flag: 'wx' })
+    writeCacheOwner(location, candidateDirectory, `${JSON.stringify(candidateOwner)}\n`)
 
-    if (existsSync(lockPath)) {
+    const observedLock = inspectCacheOwnedDirectory(location, lockName)
+    if (observedLock !== undefined) {
       testHooks.afterStaleObservation?.()
     }
 
@@ -250,16 +283,19 @@ export const withOperationLock = <Result>(
 
     // The SQLite transaction is the authoritative operation lock. A valid owner
     // must still hold that gate, so any directory metadata seen here is orphaned.
-    if (existsSync(lockPath)) {
-      rmSync(lockPath, { force: true, recursive: true })
+    const staleLock = inspectCacheOwnedDirectory(location, lockName)
+    if (staleLock !== undefined) {
+      quarantineCacheOwnedDirectory(location, staleLock)
     }
 
     renameSync(candidatePath, lockPath)
+    ownedLockDirectory = { ...candidateDirectory, name: lockName, path: lockPath }
+    candidateDirectory = undefined
     try {
-      return operation()
+      return operation(location)
     } finally {
       try {
-        releaseOwnedLock(lockPath, token)
+        releaseOwnedLock(location, ownedLockDirectory, token)
       } catch {
         // The SQLite gate is authoritative; stale metadata is removed by the next holder.
       }
@@ -279,7 +315,10 @@ export const withOperationLock = <Result>(
     }
     gate?.close()
     try {
-      rmSync(candidatePath, { force: true, recursive: true })
+      const remainingCandidate = candidateDirectory ?? inspectCacheOwnedDirectory(location, `operation.lock.${token}`)
+      if (remainingCandidate !== undefined) {
+        quarantineCacheOwnedDirectory(location, remainingCandidate)
+      }
     } catch {
       // Candidate cleanup must not mask the operation outcome.
     }

--- a/src/records.ts
+++ b/src/records.ts
@@ -19,6 +19,7 @@ import { basename, join, relative, resolve } from 'node:path'
 import { TextDecoder } from 'node:util'
 import { parseAddRecordInput, parseRootInput } from './api-input.ts'
 import { hydrateResolvedRepository } from './cache.ts'
+import type { CacheLocation } from './cache-location.ts'
 import { EncephalonError, fail, wrapIo } from './errors.ts'
 import { withOperationLock } from './lock.ts'
 import { ordinalStringCompare } from './order.ts'
@@ -60,8 +61,10 @@ type RecordWriteFault =
   | 'during-staging-write'
 
 export type RecordWriteHooks = {
-  fault?: (point: RecordWriteFault) => void
+  fault?: ((point: RecordWriteFault) => void) | undefined
 }
+
+export const recordWriteTestHooks: RecordWriteHooks = {}
 
 type RecordReadFault = 'after-record-fstat' | 'after-record-lstat' | 'after-record-open'
 
@@ -72,6 +75,7 @@ export type RecordReadHooks = {
 }
 
 type AddRecordOptions = {
+  cacheLocation?: CacheLocation
   hooks?: RecordWriteHooks
   hydrate?: boolean
 }
@@ -988,7 +992,7 @@ const addRecordFileResolved = (
   if (committedErrorPhase !== 'publicationFlush' && options.hydrate !== false) {
     try {
       fault(options.hooks, 'during-hydration')
-      hydrateResolvedRepository(root, false)
+      hydrateResolvedRepository(root, false, options.cacheLocation)
     } catch (error) {
       capturePostCommitError('cacheHydration', error)
     }
@@ -1006,7 +1010,9 @@ export const addRecord = (input: AddRecordInput): BrainRecord => {
   const parsed = parseAddRecordInput(input)
   const root = resolveRepository(parsed)
   try {
-    return withOperationLock(root, () => addRecordFileResolved(root, parsed.recordFile))
+    return withOperationLock(root, cacheLocation =>
+      addRecordFileResolved(root, parsed.recordFile, { cacheLocation, hooks: recordWriteTestHooks }),
+    )
   } catch (error) {
     if (error instanceof EncephalonError) {
       throw error

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -262,7 +262,12 @@ describe('cache filesystem containment', () => {
     assert.equal(readFileSync(target, 'utf8'), 'outside wal bytes')
   })
 
-  test('aborts corrupt cleanup after the cache directory is replaced', () => {
+  test('aborts corrupt cleanup after the cache directory is replaced', {
+    skip:
+      process.platform === 'win32'
+        ? 'Windows does not permit renaming a directory containing the open operation gate.'
+        : false,
+  }, () => {
     const root = createRoot()
     const cachePath = cacheDirectoryPath(root)
     const displacedPath = `${cachePath}-displaced`
@@ -548,7 +553,9 @@ describe('cache filesystem containment', () => {
     }
   })
 
-  test('retries sidecar replacement immediately after the gate transaction begins', () => {
+  test('retries sidecar replacement immediately after the gate transaction begins', {
+    skip: process.platform === 'win32' ? 'Windows does not permit renaming an open SQLite rollback journal.' : false,
+  }, () => {
     for (const persistent of [false, true]) {
       const root = createRoot()
       withOperationLock(root, () => 'prepared')
@@ -590,7 +597,9 @@ describe('cache filesystem containment', () => {
     }
   })
 
-  test('rejects an unsafe sidecar introduced after the gate transaction begins', () => {
+  test('rejects an unsafe sidecar introduced after the gate transaction begins', {
+    skip: process.platform === 'win32' ? 'Windows does not permit renaming an open SQLite rollback journal.' : false,
+  }, () => {
     const root = createRoot()
     const outside = createOutsideDirectory()
     withOperationLock(root, () => 'prepared')
@@ -616,7 +625,12 @@ describe('cache filesystem containment', () => {
     assert.equal(readFileSync(targetPath, 'utf8'), 'outside gate journal')
   })
 
-  test('carries the locked cache location through add-record hydration', () => {
+  test('carries the locked cache location through add-record hydration', {
+    skip:
+      process.platform === 'win32'
+        ? 'Windows does not permit renaming a directory containing the open operation gate.'
+        : false,
+  }, () => {
     const root = createRoot()
     functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root })
     const cachePath = cacheDirectoryPath(root)

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,11 +1,26 @@
 import assert from 'node:assert/strict'
 import { spawn, spawnSync } from 'node:child_process'
 import { once } from 'node:events'
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import { afterEach, describe, test } from 'node:test'
 import { cacheReadTestHooks } from '../src/cache.ts'
+import { cacheLocationTestHooks, sameCacheEntryIdentity } from '../src/cache-location.ts'
 import { PACKAGE_VERSION } from '../src/generated/version.ts'
 import * as api from '../src/index.ts'
 import { withOperationLock } from '../src/lock.ts'
@@ -20,7 +35,15 @@ const createRoot = () => {
   return root
 }
 
+const createOutsideDirectory = () => {
+  const directory = mkdtempSync(join(tmpdir(), 'encephalon-cache-outside-'))
+  roots.push(directory)
+  return directory
+}
+
 afterEach(() => {
+  cacheLocationTestHooks.afterQuarantineRename = undefined
+  cacheLocationTestHooks.beforeQuarantineRename = undefined
   roots.splice(0).forEach(removeTestRepository)
 })
 
@@ -65,6 +88,229 @@ const mutateCache = (root: string, mutation: (database: DatabaseSync) => void) =
     database.close()
   }
 }
+
+const assertCacheLayoutRejected = (operation: () => unknown) => {
+  assert.throws(operation, (error: unknown) => {
+    assert.equal((error as { code?: unknown }).code, 'VALIDATION_FAILED')
+    return true
+  })
+}
+
+describe('cache filesystem containment', () => {
+  test('compares cache entry identities without losing bigint precision', () => {
+    const beyondSafeInteger = BigInt(Number.MAX_SAFE_INTEGER) + 1n
+    assert.equal(
+      sameCacheEntryIdentity(
+        { dev: beyondSafeInteger, ino: beyondSafeInteger + 1n },
+        { dev: beyondSafeInteger, ino: beyondSafeInteger + 1n },
+      ),
+      true,
+    )
+    assert.equal(
+      sameCacheEntryIdentity(
+        { dev: beyondSafeInteger, ino: beyondSafeInteger + 1n },
+        { dev: beyondSafeInteger, ino: beyondSafeInteger + 2n },
+      ),
+      false,
+    )
+  })
+
+  test('rejects cache ancestor redirects without changing the redirect target', () => {
+    const cases = [
+      {
+        arrange: (root: string, outside: string) => {
+          const installedPackage = realpathSync(join(root, 'node_modules', 'encephalon'))
+          rmSync(join(root, 'node_modules'), { recursive: true })
+          symlinkSync(installedPackage, join(outside, 'encephalon'), process.platform === 'win32' ? 'junction' : 'dir')
+          symlinkSync(outside, join(root, 'node_modules'), process.platform === 'win32' ? 'junction' : 'dir')
+        },
+        name: 'node_modules',
+      },
+      {
+        arrange: (root: string, outside: string) => {
+          symlinkSync(outside, join(root, 'node_modules', '.cache'), process.platform === 'win32' ? 'junction' : 'dir')
+        },
+        name: '.cache',
+      },
+      {
+        arrange: (root: string, outside: string) => {
+          mkdirSync(join(root, 'node_modules', '.cache'))
+          symlinkSync(
+            outside,
+            join(root, 'node_modules', '.cache', 'encephalon'),
+            process.platform === 'win32' ? 'junction' : 'dir',
+          )
+        },
+        name: 'encephalon',
+      },
+    ] as const
+
+    for (const entry of cases) {
+      const root = createRoot()
+      const outside = createOutsideDirectory()
+      writeFileSync(join(outside, 'sentinel'), entry.name)
+      entry.arrange(root, outside)
+      const before = readdirSync(outside).sort(ordinalStringCompare)
+
+      assertCacheLayoutRejected(() => functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }))
+      assert.deepEqual(readdirSync(outside).sort(ordinalStringCompare), before)
+      assert.equal(readFileSync(join(outside, 'sentinel'), 'utf8'), entry.name)
+    }
+  })
+
+  test('rejects a primary database symlink without changing its target', () => {
+    const root = createRoot()
+    const outside = createOutsideDirectory()
+    const target = join(outside, 'database-target')
+    mkdirSync(cacheDirectoryPath(root), { recursive: true })
+    writeFileSync(target, 'outside database bytes')
+    symlinkSync(target, cacheDatabasePath(root))
+
+    assertCacheLayoutRejected(() => functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }))
+    assert.equal(readFileSync(target, 'utf8'), 'outside database bytes')
+    assert.equal(readFileSync(cacheDatabasePath(root), 'utf8'), 'outside database bytes')
+  })
+
+  test('rejects an unexpected cache sidecar type', () => {
+    const root = createRoot()
+    functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root })
+    const walPath = `${cacheDatabasePath(root)}-wal`
+    rmSync(walPath, { force: true })
+    mkdirSync(walPath)
+
+    assertCacheLayoutRejected(() => functionFromApi<(input: Record<string, unknown>) => unknown>('hydrate')({ root }))
+    assert.equal(statSync(walPath).isDirectory(), true)
+  })
+
+  test('rejects a cache sidecar symlink without changing its target', () => {
+    const root = createRoot()
+    const outside = createOutsideDirectory()
+    const target = join(outside, 'wal-target')
+    functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root })
+    writeFileSync(target, 'outside wal bytes')
+    symlinkSync(target, `${cacheDatabasePath(root)}-wal`)
+
+    assertCacheLayoutRejected(() => functionFromApi<(input: Record<string, unknown>) => unknown>('hydrate')({ root }))
+    assert.equal(readFileSync(target, 'utf8'), 'outside wal bytes')
+  })
+
+  test('aborts corrupt cleanup after the cache directory is replaced', () => {
+    const root = createRoot()
+    const cachePath = cacheDirectoryPath(root)
+    const displacedPath = `${cachePath}-displaced`
+    functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root })
+    writeFileSync(cacheDatabasePath(root), 'not a sqlite database')
+    cacheLocationTestHooks.beforeQuarantineRename = path => {
+      if (path.endsWith('brain.sqlite')) {
+        renameSync(cachePath, displacedPath)
+        mkdirSync(cachePath)
+        writeFileSync(join(cachePath, 'replacement-sentinel'), 'replacement cache')
+      }
+    }
+
+    assert.throws(
+      () => functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }),
+      (error: unknown) => {
+        assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED')
+        return true
+      },
+    )
+    assert.equal(readFileSync(join(cachePath, 'replacement-sentinel'), 'utf8'), 'replacement cache')
+  })
+
+  test('never unlinks a replacement at a cache quarantine path', () => {
+    const root = createRoot()
+    let quarantinePath: string | undefined
+    functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root })
+    writeFileSync(cacheDatabasePath(root), 'not a sqlite database')
+    cacheLocationTestHooks.afterQuarantineRename = path => {
+      if (path.includes('.brain.sqlite.')) {
+        quarantinePath = path
+        rmSync(path)
+        writeFileSync(path, 'replacement quarantine')
+      }
+    }
+
+    assert.throws(
+      () => functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }),
+      (error: unknown) => {
+        assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED')
+        return true
+      },
+    )
+    assert.ok(quarantinePath !== undefined)
+    assert.equal(readFileSync(quarantinePath, 'utf8'), 'replacement quarantine')
+  })
+
+  test('rejects an operation gate database symlink without changing its target', () => {
+    const root = createRoot()
+    const outside = createOutsideDirectory()
+    const target = join(outside, 'gate-target')
+    mkdirSync(cacheDirectoryPath(root), { recursive: true })
+    writeFileSync(target, 'outside gate bytes')
+    symlinkSync(target, join(cacheDirectoryPath(root), 'operation-lock.sqlite'))
+
+    assertCacheLayoutRejected(() => withOperationLock(root, () => 'entered'))
+    assert.equal(readFileSync(target, 'utf8'), 'outside gate bytes')
+  })
+
+  test('rejects an operation gate sidecar symlink without changing its target', () => {
+    const root = createRoot()
+    const outside = createOutsideDirectory()
+    const target = join(outside, 'gate-wal-target')
+    mkdirSync(cacheDirectoryPath(root), { recursive: true })
+    writeFileSync(target, 'outside gate wal bytes')
+    symlinkSync(target, join(cacheDirectoryPath(root), 'operation-lock.sqlite-wal'))
+
+    assertCacheLayoutRejected(() => withOperationLock(root, () => 'entered'))
+    assert.equal(readFileSync(target, 'utf8'), 'outside gate wal bytes')
+  })
+
+  test('rejects an operation lock directory symlink without changing its target', () => {
+    const root = createRoot()
+    const outside = createOutsideDirectory()
+    mkdirSync(cacheDirectoryPath(root), { recursive: true })
+    writeFileSync(join(outside, 'sentinel'), 'outside lock')
+    symlinkSync(
+      outside,
+      join(cacheDirectoryPath(root), 'operation.lock'),
+      process.platform === 'win32' ? 'junction' : 'dir',
+    )
+
+    assertCacheLayoutRejected(() => withOperationLock(root, () => 'entered'))
+    assert.equal(readFileSync(join(outside, 'sentinel'), 'utf8'), 'outside lock')
+  })
+
+  test('rejects an operation gate recovery symlink without changing its target', () => {
+    const root = createRoot()
+    const outside = createOutsideDirectory()
+    mkdirSync(cacheDirectoryPath(root), { recursive: true })
+    writeFileSync(join(outside, 'sentinel'), 'outside recovery')
+    symlinkSync(
+      outside,
+      join(cacheDirectoryPath(root), 'operation-lock.recovery'),
+      process.platform === 'win32' ? 'junction' : 'dir',
+    )
+
+    assertCacheLayoutRejected(() => withOperationLock(root, () => 'entered'))
+    assert.equal(readFileSync(join(outside, 'sentinel'), 'utf8'), 'outside recovery')
+  })
+
+  test('rejects an operation lock candidate symlink without changing its target', () => {
+    const root = createRoot()
+    const outside = createOutsideDirectory()
+    mkdirSync(cacheDirectoryPath(root), { recursive: true })
+    writeFileSync(join(outside, 'sentinel'), 'outside candidate')
+    symlinkSync(
+      outside,
+      join(cacheDirectoryPath(root), 'operation.lock.00000000-0000-4000-8000-000000000000'),
+      process.platform === 'win32' ? 'junction' : 'dir',
+    )
+
+    assertCacheLayoutRejected(() => withOperationLock(root, () => 'entered'))
+    assert.equal(readFileSync(join(outside, 'sentinel'), 'utf8'), 'outside candidate')
+  })
+})
 
 describe('SQLite cache and reads', () => {
   test('rejects invalid public API inputs before repository side effects', () => {
@@ -196,6 +442,27 @@ describe('SQLite cache and reads', () => {
       >('prepare')
     assert.deepEqual(prepare({ root }), { hydrated: true, recordsIndexed: 0 })
     assert.deepEqual(prepare({ root }), { hydrated: false, recordsIndexed: 0 })
+  })
+
+  test('keeps one stable real cache directory during concurrent first use', async () => {
+    const root = createRoot()
+    const firstResult = join(root, 'first-prepare-result')
+    const secondResult = join(root, 'second-prepare-result')
+    const fixture = join(import.meta.dirname, 'fixtures', 'prepare-cache.ts')
+    const before = statSync(join(root, 'node_modules'), { bigint: true })
+    const first = spawn(process.execPath, [fixture, root, firstResult], { stdio: 'inherit' })
+    const second = spawn(process.execPath, [fixture, root, secondResult], { stdio: 'inherit' })
+
+    await Promise.all([once(first, 'exit'), once(second, 'exit')])
+    assert.equal(first.exitCode, 0)
+    assert.equal(second.exitCode, 0)
+    assert.equal(JSON.parse(readFileSync(firstResult, 'utf8')).recordsIndexed, 0)
+    assert.equal(JSON.parse(readFileSync(secondResult, 'utf8')).recordsIndexed, 0)
+    assert.equal(
+      realpathSync(cacheDirectoryPath(root)),
+      join(realpathSync(root), 'node_modules', '.cache', 'encephalon'),
+    )
+    assert.equal(statSync(join(root, 'node_modules'), { bigint: true }).ino, before.ino)
   })
 
   test('uses schema version rather than package version for cache compatibility', () => {
@@ -1340,7 +1607,7 @@ describe('SQLite cache and reads', () => {
     assert.throws(
       () => listRecords({ root: secondRoot }),
       (error: unknown) => {
-        assert.equal((error as { code?: unknown }).code, 'CACHE_SCOPE_MISMATCH')
+        assert.equal((error as { code?: unknown }).code, 'VALIDATION_FAILED')
         return true
       },
     )

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -53,8 +53,10 @@ afterEach(() => {
   cacheLocationTestHooks.afterQuarantineRename = undefined
   cacheLocationTestHooks.beforeDatabaseOpen = undefined
   cacheLocationTestHooks.beforeLocationInspection = undefined
+  cacheLocationTestHooks.beforeOwnedDirectoryFinalIdentity = undefined
   cacheLocationTestHooks.beforeQuarantineRename = undefined
   cacheLocationTestHooks.duringOwnedDirectoryInspection = undefined
+  cacheReadTestHooks.duringDatabaseInitialisation = undefined
   recordWriteTestHooks.fault = undefined
   roots.splice(0).forEach(removeTestRepository)
 })
@@ -493,6 +495,55 @@ describe('cache filesystem containment', () => {
         },
       )
       assert.equal(opens, 3, entry.name)
+    }
+  })
+
+  test('retries sidecar replacement during complete writer and reader initialisation', () => {
+    for (const entry of databaseOpenCases.filter(({ name }) => name !== 'gate')) {
+      for (const persistent of [false, true]) {
+        const root = createRoot()
+        entry.prepare(root)
+        const sidecarPath = join(cacheDirectoryPath(root), 'brain.sqlite-journal')
+        writeFileSync(sidecarPath, '')
+        let initialisations = 0
+        let opens = 0
+        cacheLocationTestHooks.afterDatabaseOpen = database => {
+          if (database.name === 'brain.sqlite') {
+            opens += 1
+          }
+        }
+        cacheReadTestHooks.duringDatabaseInitialisation = mode => {
+          if (mode === entry.name) {
+            initialisations += 1
+            if (persistent || initialisations === 1) {
+              renameSync(sidecarPath, join(root, `${entry.name}-initialisation-sidecar-generation-${initialisations}`))
+              writeFileSync(sidecarPath, '')
+            }
+          }
+        }
+
+        if (persistent) {
+          assert.throws(
+            () => entry.operation(root),
+            (error: unknown) => {
+              assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED', entry.name)
+              return true
+            },
+          )
+        } else {
+          entry.operation(root)
+        }
+        const expectedAttempts = persistent ? 3 : 2
+        assert.equal(initialisations, expectedAttempts, entry.name)
+        assert.equal(opens, expectedAttempts, entry.name)
+        assert.equal(
+          statSync(join(root, `${entry.name}-initialisation-sidecar-generation-1`)).isFile(),
+          true,
+          entry.name,
+        )
+        cacheLocationTestHooks.afterDatabaseOpen = undefined
+        cacheReadTestHooks.duringDatabaseInitialisation = undefined
+      }
     }
   })
 
@@ -1801,7 +1852,36 @@ describe('SQLite cache and reads', () => {
     )
   })
 
-  test('does not return a predecessor identity after an owned-directory successor replaces it', () => {
+  test('reports a recovery marker missing only after a stable absent observation', () => {
+    const root = createRoot()
+    const recoveryPath = join(cacheDirectoryPath(root), 'operation-lock.recovery')
+    let inspections = 0
+    cacheLocationTestHooks.duringOwnedDirectoryInspection = path => {
+      if (basename(path) === 'operation-lock.recovery') {
+        inspections += 1
+        if (inspections === 1) {
+          mkdirSync(path)
+          writeFileSync(
+            join(path, 'owner.json'),
+            `${JSON.stringify({ acquiredAt: new Date().toISOString(), pid: process.pid, token: 'appearing' })}\n`,
+          )
+        } else if (inspections === 2) {
+          rmSync(path, { recursive: true })
+        }
+      }
+    }
+
+    assert.equal(
+      withOperationLock(root, () => {
+        assert.equal(existsSync(recoveryPath), false)
+        return 'entered'
+      }),
+      'entered',
+    )
+    assert.equal(inspections, 3)
+  })
+
+  test('rejects an ambiguous owned-directory observation after a successor replaces it', () => {
     const root = createRoot()
     const recoveryPath = join(cacheDirectoryPath(root), 'operation-lock.recovery')
     const displacedPath = join(root, 'owned-directory-realpath-predecessor')
@@ -1816,10 +1896,59 @@ describe('SQLite cache and reads', () => {
       }
     }
 
-    assert.equal(inspectCacheOwnedDirectory(location, 'operation-lock.recovery'), undefined)
+    assert.throws(
+      () => inspectCacheOwnedDirectory(location, 'operation-lock.recovery'),
+      (error: unknown) => {
+        assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED')
+        return true
+      },
+    )
     const successor = statSync(recoveryPath, { bigint: true })
     assert.equal(sameCacheEntryIdentity(predecessor, successor), false)
     assert.equal(sameCacheEntryIdentity(predecessor, statSync(displacedPath, { bigint: true })), true)
+  })
+
+  test('reobserves a recovery successor replaced at the final directory identity boundary', () => {
+    const root = createRoot()
+    const recoveryPath = join(cacheDirectoryPath(root), 'operation-lock.recovery')
+    const displacedPath = join(root, 'final-identity-recovery-predecessor')
+    mkdirSync(recoveryPath, { recursive: true })
+    writeFileSync(
+      join(recoveryPath, 'owner.json'),
+      `${JSON.stringify({ acquiredAt: new Date().toISOString(), pid: process.pid, token: 'final-predecessor' })}\n`,
+    )
+    cacheLocationTestHooks.beforeOwnedDirectoryFinalIdentity = path => {
+      if (basename(path) === 'operation-lock.recovery') {
+        cacheLocationTestHooks.beforeOwnedDirectoryFinalIdentity = undefined
+        renameSync(path, displacedPath)
+        mkdirSync(path)
+        writeFileSync(
+          join(path, 'owner.json'),
+          `${JSON.stringify({ acquiredAt: new Date().toISOString(), pid: process.pid, token: 'final-successor' })}\n`,
+        )
+      }
+    }
+    let successorObservations = 0
+
+    assert.equal(
+      withOperationLock(
+        root,
+        () => {
+          assert.equal(existsSync(recoveryPath), false)
+          return 'entered'
+        },
+        {
+          duringRecoveryObservation: () => {
+            successorObservations += 1
+            assert.match(readFileSync(join(recoveryPath, 'owner.json'), 'utf8'), /final-successor/u)
+            rmSync(recoveryPath, { recursive: true })
+          },
+        },
+      ),
+      'entered',
+    )
+    assert.equal(successorObservations, 1)
+    assert.match(readFileSync(join(displacedPath, 'owner.json'), 'utf8'), /final-predecessor/u)
   })
 
   test('reobserves when a recovery predecessor completes during observation', () => {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -49,6 +49,7 @@ const createOutsideDirectory = () => {
 }
 
 afterEach(() => {
+  cacheLocationTestHooks.afterDatabaseLockInitialisation = undefined
   cacheLocationTestHooks.afterDatabaseOpen = undefined
   cacheLocationTestHooks.afterQuarantineRename = undefined
   cacheLocationTestHooks.beforeDatabaseOpen = undefined
@@ -545,6 +546,74 @@ describe('cache filesystem containment', () => {
         cacheReadTestHooks.duringDatabaseInitialisation = undefined
       }
     }
+  })
+
+  test('retries sidecar replacement immediately after the gate transaction begins', () => {
+    for (const persistent of [false, true]) {
+      const root = createRoot()
+      withOperationLock(root, () => 'prepared')
+      const sidecarPath = join(cacheDirectoryPath(root), 'operation-lock.sqlite-journal')
+      writeFileSync(sidecarPath, '')
+      let attempts = 0
+      cacheLocationTestHooks.afterDatabaseOpen = database => {
+        if (database.name === 'operation-lock.sqlite' && !existsSync(sidecarPath)) {
+          writeFileSync(sidecarPath, '')
+        }
+      }
+      cacheLocationTestHooks.afterDatabaseLockInitialisation = database => {
+        if (database.name === 'operation-lock.sqlite') {
+          attempts += 1
+          if (persistent || attempts === 1) {
+            renameSync(sidecarPath, join(root, `gate-sidecar-generation-${attempts}`))
+            writeFileSync(sidecarPath, '')
+          }
+        }
+      }
+
+      if (persistent) {
+        assert.throws(
+          () => withOperationLock(root, () => 'entered'),
+          (error: unknown) => {
+            assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED')
+            return true
+          },
+        )
+      } else {
+        assert.equal(
+          withOperationLock(root, () => 'entered'),
+          'entered',
+        )
+      }
+      assert.equal(attempts, persistent ? 3 : 2)
+      cacheLocationTestHooks.afterDatabaseLockInitialisation = undefined
+      cacheLocationTestHooks.afterDatabaseOpen = undefined
+    }
+  })
+
+  test('rejects an unsafe sidecar introduced after the gate transaction begins', () => {
+    const root = createRoot()
+    const outside = createOutsideDirectory()
+    withOperationLock(root, () => 'prepared')
+    const sidecarPath = join(cacheDirectoryPath(root), 'operation-lock.sqlite-journal')
+    const displacedPath = join(root, 'safe-gate-journal')
+    const targetPath = join(outside, 'gate-journal-target')
+    writeFileSync(sidecarPath, '')
+    writeFileSync(targetPath, 'outside gate journal')
+    cacheLocationTestHooks.afterDatabaseOpen = database => {
+      if (database.name === 'operation-lock.sqlite' && !existsSync(sidecarPath)) {
+        writeFileSync(sidecarPath, '')
+      }
+    }
+    cacheLocationTestHooks.afterDatabaseLockInitialisation = database => {
+      if (database.name === 'operation-lock.sqlite') {
+        cacheLocationTestHooks.afterDatabaseLockInitialisation = undefined
+        renameSync(sidecarPath, displacedPath)
+        symlinkSync(targetPath, sidecarPath)
+      }
+    }
+
+    assertCacheLayoutRejected(() => withOperationLock(root, () => 'entered'))
+    assert.equal(readFileSync(targetPath, 'utf8'), 'outside gate journal')
   })
 
   test('carries the locked cache location through add-record hydration', () => {
@@ -2198,6 +2267,47 @@ describe('SQLite cache and reads', () => {
     assert.equal(existsSync(firstEntered), true)
     assert.equal(existsSync(secondEntered), true)
     assert.equal(existsSync(join(cachePath, 'operation-lock.sqlite')), true)
+  })
+
+  test('keeps a persistent WAL operation gate exclusive until its holder releases', async () => {
+    const root = createRoot()
+    withOperationLock(root, () => 'prepared')
+    const gatePath = join(cacheDirectoryPath(root), 'operation-lock.sqlite')
+    const database = new DatabaseSync(gatePath)
+    try {
+      const mode = database.prepare('PRAGMA journal_mode = WAL').get() as { journal_mode?: unknown }
+      assert.equal(mode.journal_mode, 'wal')
+    } finally {
+      database.close()
+    }
+    const fixture = join(import.meta.dirname, 'fixtures', 'hold-operation-lock-until-release.ts')
+    const releasePath = join(root, 'release-wal-operation-lock')
+    const firstAttempted = join(root, 'first-wal-lock-attempted')
+    const firstEntered = join(root, 'first-wal-lock-entered')
+    const secondAttempted = join(root, 'second-wal-lock-attempted')
+    const secondEntered = join(root, 'second-wal-lock-entered')
+    const first = spawn(process.execPath, [fixture, root, firstAttempted, firstEntered, releasePath], {
+      stdio: 'inherit',
+    })
+    waitForPath(firstEntered, first)
+    const second = spawn(process.execPath, [fixture, root, secondAttempted, secondEntered, releasePath], {
+      stdio: 'inherit',
+    })
+    waitForPath(secondAttempted, second)
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 300)
+    const secondEnteredBeforeRelease = existsSync(secondEntered)
+    writeFileSync(releasePath, 'release')
+
+    if (first.exitCode === null) {
+      await once(first, 'exit')
+    }
+    if (second.exitCode === null) {
+      await once(second, 'exit')
+    }
+    assert.equal(first.exitCode, 0)
+    assert.equal(second.exitCode, 0)
+    assert.equal(secondEnteredBeforeRelease, false)
+    assert.equal(existsSync(secondEntered), true)
   })
 
   test('rejects a symlinked canonical root without traversing it', {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -2273,6 +2273,7 @@ describe('SQLite cache and reads', () => {
     const root = createRoot()
     withOperationLock(root, () => 'prepared')
     const gatePath = join(cacheDirectoryPath(root), 'operation-lock.sqlite')
+    const verifiedCacheDirectory = inspectCacheLocation(root).directory
     const database = new DatabaseSync(gatePath)
     try {
       const mode = database.prepare('PRAGMA journal_mode = WAL').get() as { journal_mode?: unknown }
@@ -2294,8 +2295,26 @@ describe('SQLite cache and reads', () => {
       stdio: 'inherit',
     })
     waitForPath(secondAttempted, second)
-    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 300)
+    const candidateDeadline = Date.now() + 5000
+    let secondCandidateObserved = false
+    while (
+      !(secondCandidateObserved || existsSync(secondEntered)) &&
+      first.exitCode === null &&
+      second.exitCode === null &&
+      Date.now() < candidateDeadline
+    ) {
+      secondCandidateObserved = readdirSync(verifiedCacheDirectory, { withFileTypes: true }).some(
+        entry => entry.isDirectory() && /^operation\.lock\.[0-9a-f-]{36}$/u.test(entry.name),
+      )
+      if (!secondCandidateObserved) {
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10)
+      }
+    }
     const secondEnteredBeforeRelease = existsSync(secondEntered)
+    assert.equal(secondCandidateObserved || secondEnteredBeforeRelease, true)
+    assert.equal(first.exitCode, null)
+    assert.equal(second.exitCode, null)
+    assert.equal(secondEnteredBeforeRelease, false)
     writeFileSync(releasePath, 'release')
 
     if (first.exitCode === null) {
@@ -2306,7 +2325,6 @@ describe('SQLite cache and reads', () => {
     }
     assert.equal(first.exitCode, 0)
     assert.equal(second.exitCode, 0)
-    assert.equal(secondEnteredBeforeRelease, false)
     assert.equal(existsSync(secondEntered), true)
   })
 

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -21,7 +21,12 @@ import { basename, join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import { afterEach, describe, test } from 'node:test'
 import { cacheReadTestHooks } from '../src/cache.ts'
-import { cacheLocationTestHooks, sameCacheEntryIdentity } from '../src/cache-location.ts'
+import {
+  cacheLocationTestHooks,
+  inspectCacheLocation,
+  inspectCacheOwnedDirectory,
+  sameCacheEntryIdentity,
+} from '../src/cache-location.ts'
 import { PACKAGE_VERSION } from '../src/generated/version.ts'
 import * as api from '../src/index.ts'
 import { withOperationLock } from '../src/lock.ts'
@@ -49,6 +54,7 @@ afterEach(() => {
   cacheLocationTestHooks.beforeDatabaseOpen = undefined
   cacheLocationTestHooks.beforeLocationInspection = undefined
   cacheLocationTestHooks.beforeQuarantineRename = undefined
+  cacheLocationTestHooks.duringOwnedDirectoryInspection = undefined
   recordWriteTestHooks.fault = undefined
   roots.splice(0).forEach(removeTestRepository)
 })
@@ -74,6 +80,27 @@ const waitForPath = (path: string, process: ReturnType<typeof spawn>) => {
 const cacheDirectoryPath = (root: string) => join(root, 'node_modules', '.cache', 'encephalon')
 
 const cacheDatabasePath = (root: string) => join(root, 'node_modules', '.cache', 'encephalon', 'brain.sqlite')
+
+const databaseOpenCases = [
+  {
+    databaseName: 'brain.sqlite',
+    name: 'writer',
+    operation: (root: string) => functionFromApi<(input: Record<string, unknown>) => unknown>('hydrate')({ root }),
+    prepare: (root: string) => functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }),
+  },
+  {
+    databaseName: 'brain.sqlite',
+    name: 'reader',
+    operation: (root: string) => functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }),
+    prepare: (root: string) => functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }),
+  },
+  {
+    databaseName: 'operation-lock.sqlite',
+    name: 'gate',
+    operation: (root: string) => withOperationLock(root, () => 'entered'),
+    prepare: (root: string) => withOperationLock(root, () => 'prepared'),
+  },
+] as const
 
 const addCacheRecord = (root: string) =>
   functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>>('addRecord')({
@@ -303,26 +330,7 @@ describe('cache filesystem containment', () => {
   })
 
   test('rejects valid primary replacements between inspection and SQLite open', () => {
-    const cases = [
-      {
-        databaseName: 'brain.sqlite',
-        operation: (root: string) => functionFromApi<(input: Record<string, unknown>) => unknown>('hydrate')({ root }),
-        prepare: (root: string) => functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }),
-      },
-      {
-        databaseName: 'brain.sqlite',
-        operation: (root: string) =>
-          functionFromApi<(input: Record<string, unknown>) => unknown>('listRecords')({ root }),
-        prepare: (root: string) => functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }),
-      },
-      {
-        databaseName: 'operation-lock.sqlite',
-        operation: (root: string) => withOperationLock(root, () => 'entered'),
-        prepare: (root: string) => withOperationLock(root, () => 'prepared'),
-      },
-    ] as const
-
-    for (const [index, entry] of cases.entries()) {
+    for (const [index, entry] of databaseOpenCases.entries()) {
       const root = createRoot()
       entry.prepare(root)
       const databasePath = join(cacheDirectoryPath(root), entry.databaseName)
@@ -350,47 +358,22 @@ describe('cache filesystem containment', () => {
     }
   })
 
-  test('rejects primary and sidecar replacements immediately after SQLite opens', () => {
-    const cases = [
-      {
-        databaseName: 'brain.sqlite',
-        operation: (root: string) => functionFromApi<(input: Record<string, unknown>) => unknown>('hydrate')({ root }),
-        prepare: (root: string) => functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }),
-      },
-      {
-        databaseName: 'brain.sqlite',
-        operation: (root: string) =>
-          functionFromApi<(input: Record<string, unknown>) => unknown>('listRecords')({ root }),
-        prepare: (root: string) => functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }),
-      },
-      {
-        databaseName: 'operation-lock.sqlite',
-        operation: (root: string) => withOperationLock(root, () => 'entered'),
-        prepare: (root: string) => withOperationLock(root, () => 'prepared'),
-      },
-    ] as const
-
-    for (const [index, entry] of cases.entries()) {
+  test('rejects primary replacements immediately after SQLite opens where open-file rename is supported', {
+    skip: process.platform === 'win32',
+  }, () => {
+    for (const [index, entry] of databaseOpenCases.entries()) {
       const root = createRoot()
       entry.prepare(root)
       const databasePath = join(cacheDirectoryPath(root), entry.databaseName)
-      const sidecarPath = `${databasePath}-journal`
       const replacementDatabasePath = join(root, `after-open-database-${index}.sqlite`)
-      const replacementSidecarPath = join(root, `after-open-sidecar-${index}`)
       const displacedDatabasePath = join(root, `after-open-displaced-database-${index}.sqlite`)
-      const displacedSidecarPath = join(root, `after-open-displaced-sidecar-${index}`)
       copyFileSync(databasePath, replacementDatabasePath)
-      writeFileSync(sidecarPath, 'original journal')
-      writeFileSync(replacementSidecarPath, 'replacement journal')
       const replacementDatabase = statSync(replacementDatabasePath, { bigint: true })
-      const replacementSidecar = statSync(replacementSidecarPath, { bigint: true })
       cacheLocationTestHooks.afterDatabaseOpen = database => {
         if (database.name === entry.databaseName) {
           cacheLocationTestHooks.afterDatabaseOpen = undefined
           renameSync(databasePath, displacedDatabasePath)
           renameSync(replacementDatabasePath, databasePath)
-          renameSync(sidecarPath, displacedSidecarPath)
-          renameSync(replacementSidecarPath, sidecarPath)
         }
       }
 
@@ -402,33 +385,32 @@ describe('cache filesystem containment', () => {
         },
       )
       assert.equal(sameCacheEntryIdentity(replacementDatabase, statSync(databasePath, { bigint: true })), true)
-      assert.equal(sameCacheEntryIdentity(replacementSidecar, statSync(sidecarPath, { bigint: true })), true)
     }
   })
 
-  test('rejects a sidecar identity change across SQLite open', () => {
-    const root = createRoot()
-    functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root })
-    const journalPath = `${cacheDatabasePath(root)}-journal`
-    const replacementPath = join(root, 'replacement-journal')
-    writeFileSync(journalPath, 'original journal')
-    writeFileSync(replacementPath, 'replacement journal')
-    cacheLocationTestHooks.beforeDatabaseOpen = database => {
-      if (database.name === 'brain.sqlite') {
-        cacheLocationTestHooks.beforeDatabaseOpen = undefined
-        rmSync(journalPath)
-        renameSync(replacementPath, journalPath)
+  test('retries pre-open sidecar replacement once across every database path', () => {
+    for (const entry of databaseOpenCases) {
+      const root = createRoot()
+      entry.prepare(root)
+      const databasePath = join(cacheDirectoryPath(root), entry.databaseName)
+      const sidecarPath = `${databasePath}-journal`
+      const displacedSidecarPath = join(root, `${entry.name}-pre-open-sidecar-predecessor`)
+      writeFileSync(sidecarPath, '')
+      let attempts = 0
+      cacheLocationTestHooks.beforeDatabaseOpen = database => {
+        if (database.name === entry.databaseName) {
+          attempts += 1
+          if (attempts === 1) {
+            renameSync(sidecarPath, displacedSidecarPath)
+            writeFileSync(sidecarPath, '')
+          }
+        }
       }
-    }
 
-    assert.throws(
-      () => functionFromApi<(input: Record<string, unknown>) => unknown>('listRecords')({ root }),
-      (error: unknown) => {
-        assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED')
-        return true
-      },
-    )
-    assert.equal(readFileSync(journalPath, 'utf8'), 'replacement journal')
+      entry.operation(root)
+      assert.equal(attempts, 2, entry.name)
+      assert.equal(statSync(displacedSidecarPath).isFile(), true, entry.name)
+    }
   })
 
   test('accepts verified sidecar appearance and disappearance across SQLite open', () => {
@@ -464,55 +446,54 @@ describe('cache filesystem containment', () => {
     }
   })
 
-  test('retries from a fresh snapshot after an open sidecar identity changes', () => {
-    const root = createRoot()
-    withOperationLock(root, () => 'prepared')
-    const journalPath = join(cacheDirectoryPath(root), 'operation-lock.sqlite-journal')
-    const replacementPath = join(root, 'retry-sidecar-replacement')
-    const displacedPath = join(root, 'retry-sidecar-predecessor')
-    writeFileSync(journalPath, 'sidecar predecessor')
-    writeFileSync(replacementPath, 'sidecar successor')
-    let opens = 0
-    cacheLocationTestHooks.afterDatabaseOpen = database => {
-      if (database.name === 'operation-lock.sqlite') {
-        opens += 1
-        if (opens === 1) {
-          renameSync(journalPath, displacedPath)
-          renameSync(replacementPath, journalPath)
+  test('retries one post-open sidecar replacement across every database path', () => {
+    for (const entry of databaseOpenCases) {
+      const root = createRoot()
+      entry.prepare(root)
+      const sidecarPath = join(cacheDirectoryPath(root), `${entry.databaseName}-journal`)
+      const displacedPath = join(root, `${entry.name}-post-open-sidecar-predecessor`)
+      writeFileSync(sidecarPath, '')
+      let opens = 0
+      cacheLocationTestHooks.afterDatabaseOpen = database => {
+        if (database.name === entry.databaseName) {
+          opens += 1
+          if (opens === 1) {
+            renameSync(sidecarPath, displacedPath)
+            writeFileSync(sidecarPath, '')
+          }
         }
       }
-    }
 
-    assert.equal(
-      withOperationLock(root, () => 'entered'),
-      'entered',
-    )
-    assert.equal(opens, 2)
-    assert.equal(readFileSync(displacedPath, 'utf8'), 'sidecar predecessor')
+      entry.operation(root)
+      assert.equal(opens, 2, entry.name)
+      assert.equal(statSync(displacedPath).isFile(), true, entry.name)
+    }
   })
 
-  test('bounds retries when an open sidecar identity keeps changing', () => {
-    const root = createRoot()
-    withOperationLock(root, () => 'prepared')
-    const journalPath = join(cacheDirectoryPath(root), 'operation-lock.sqlite-journal')
-    writeFileSync(journalPath, 'sidecar generation zero')
-    let opens = 0
-    cacheLocationTestHooks.afterDatabaseOpen = database => {
-      if (database.name === 'operation-lock.sqlite') {
-        opens += 1
-        rmSync(journalPath, { force: true })
-        writeFileSync(journalPath, `sidecar generation ${opens}`)
+  test('bounds persistent post-open sidecar replacements across every database path', () => {
+    for (const entry of databaseOpenCases) {
+      const root = createRoot()
+      entry.prepare(root)
+      const sidecarPath = join(cacheDirectoryPath(root), `${entry.databaseName}-journal`)
+      writeFileSync(sidecarPath, '')
+      let opens = 0
+      cacheLocationTestHooks.afterDatabaseOpen = database => {
+        if (database.name === entry.databaseName) {
+          opens += 1
+          renameSync(sidecarPath, join(root, `${entry.name}-sidecar-generation-${opens - 1}`))
+          writeFileSync(sidecarPath, '')
+        }
       }
-    }
 
-    assert.throws(
-      () => withOperationLock(root, () => 'entered'),
-      (error: unknown) => {
-        assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED')
-        return true
-      },
-    )
-    assert.equal(opens, 3)
+      assert.throws(
+        () => entry.operation(root),
+        (error: unknown) => {
+          assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED', entry.name)
+          return true
+        },
+      )
+      assert.equal(opens, 3, entry.name)
+    }
   })
 
   test('carries the locked cache location through add-record hydration', () => {
@@ -1797,6 +1778,48 @@ describe('SQLite cache and reads', () => {
       'entered',
     )
     assert.equal(existsSync(recoveryPath), false)
+  })
+
+  test('reobserves a recovery marker that disappears between directory lstat and realpath', () => {
+    const root = createRoot()
+    const recoveryPath = join(cacheDirectoryPath(root), 'operation-lock.recovery')
+    mkdirSync(recoveryPath, { recursive: true })
+    writeFileSync(
+      join(recoveryPath, 'owner.json'),
+      `${JSON.stringify({ acquiredAt: new Date().toISOString(), pid: process.pid, token: 'realpath-gap' })}\n`,
+    )
+    cacheLocationTestHooks.duringOwnedDirectoryInspection = path => {
+      if (basename(path) === 'operation-lock.recovery') {
+        cacheLocationTestHooks.duringOwnedDirectoryInspection = undefined
+        rmSync(path, { recursive: true })
+      }
+    }
+
+    assert.equal(
+      withOperationLock(root, () => 'entered'),
+      'entered',
+    )
+  })
+
+  test('does not return a predecessor identity after an owned-directory successor replaces it', () => {
+    const root = createRoot()
+    const recoveryPath = join(cacheDirectoryPath(root), 'operation-lock.recovery')
+    const displacedPath = join(root, 'owned-directory-realpath-predecessor')
+    mkdirSync(recoveryPath, { recursive: true })
+    const predecessor = statSync(recoveryPath, { bigint: true })
+    const location = inspectCacheLocation(root)
+    cacheLocationTestHooks.duringOwnedDirectoryInspection = path => {
+      if (basename(path) === 'operation-lock.recovery') {
+        cacheLocationTestHooks.duringOwnedDirectoryInspection = undefined
+        renameSync(path, displacedPath)
+        mkdirSync(path)
+      }
+    }
+
+    assert.equal(inspectCacheOwnedDirectory(location, 'operation-lock.recovery'), undefined)
+    const successor = statSync(recoveryPath, { bigint: true })
+    assert.equal(sameCacheEntryIdentity(predecessor, successor), false)
+    assert.equal(sameCacheEntryIdentity(predecessor, statSync(displacedPath, { bigint: true })), true)
   })
 
   test('reobserves when a recovery predecessor completes during observation', () => {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -17,7 +17,7 @@ import {
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import { afterEach, describe, test } from 'node:test'
 import { cacheReadTestHooks } from '../src/cache.ts'
@@ -44,8 +44,10 @@ const createOutsideDirectory = () => {
 }
 
 afterEach(() => {
+  cacheLocationTestHooks.afterDatabaseOpen = undefined
   cacheLocationTestHooks.afterQuarantineRename = undefined
   cacheLocationTestHooks.beforeDatabaseOpen = undefined
+  cacheLocationTestHooks.beforeLocationInspection = undefined
   cacheLocationTestHooks.beforeQuarantineRename = undefined
   recordWriteTestHooks.fault = undefined
   roots.splice(0).forEach(removeTestRepository)
@@ -237,7 +239,7 @@ describe('cache filesystem containment', () => {
     functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root })
     writeFileSync(cacheDatabasePath(root), 'not a sqlite database')
     cacheLocationTestHooks.beforeQuarantineRename = path => {
-      if (path.endsWith('brain.sqlite')) {
+      if (basename(path) === 'brain.sqlite') {
         renameSync(cachePath, displacedPath)
         mkdirSync(cachePath)
         writeFileSync(join(cachePath, 'replacement-sentinel'), 'replacement cache')
@@ -284,7 +286,7 @@ describe('cache filesystem containment', () => {
     functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root })
     writeFileSync(cacheDatabasePath(root), 'not a sqlite database')
     cacheLocationTestHooks.beforeQuarantineRename = path => {
-      if (path.endsWith('/brain.sqlite')) {
+      if (basename(path) === 'brain.sqlite') {
         renameSync(path, displacedPath)
         writeFileSync(path, 'replacement primary')
       }
@@ -348,6 +350,62 @@ describe('cache filesystem containment', () => {
     }
   })
 
+  test('rejects primary and sidecar replacements immediately after SQLite opens', () => {
+    const cases = [
+      {
+        databaseName: 'brain.sqlite',
+        operation: (root: string) => functionFromApi<(input: Record<string, unknown>) => unknown>('hydrate')({ root }),
+        prepare: (root: string) => functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }),
+      },
+      {
+        databaseName: 'brain.sqlite',
+        operation: (root: string) =>
+          functionFromApi<(input: Record<string, unknown>) => unknown>('listRecords')({ root }),
+        prepare: (root: string) => functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }),
+      },
+      {
+        databaseName: 'operation-lock.sqlite',
+        operation: (root: string) => withOperationLock(root, () => 'entered'),
+        prepare: (root: string) => withOperationLock(root, () => 'prepared'),
+      },
+    ] as const
+
+    for (const [index, entry] of cases.entries()) {
+      const root = createRoot()
+      entry.prepare(root)
+      const databasePath = join(cacheDirectoryPath(root), entry.databaseName)
+      const sidecarPath = `${databasePath}-journal`
+      const replacementDatabasePath = join(root, `after-open-database-${index}.sqlite`)
+      const replacementSidecarPath = join(root, `after-open-sidecar-${index}`)
+      const displacedDatabasePath = join(root, `after-open-displaced-database-${index}.sqlite`)
+      const displacedSidecarPath = join(root, `after-open-displaced-sidecar-${index}`)
+      copyFileSync(databasePath, replacementDatabasePath)
+      writeFileSync(sidecarPath, 'original journal')
+      writeFileSync(replacementSidecarPath, 'replacement journal')
+      const replacementDatabase = statSync(replacementDatabasePath, { bigint: true })
+      const replacementSidecar = statSync(replacementSidecarPath, { bigint: true })
+      cacheLocationTestHooks.afterDatabaseOpen = database => {
+        if (database.name === entry.databaseName) {
+          cacheLocationTestHooks.afterDatabaseOpen = undefined
+          renameSync(databasePath, displacedDatabasePath)
+          renameSync(replacementDatabasePath, databasePath)
+          renameSync(sidecarPath, displacedSidecarPath)
+          renameSync(replacementSidecarPath, sidecarPath)
+        }
+      }
+
+      assert.throws(
+        () => entry.operation(root),
+        (error: unknown) => {
+          assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED')
+          return true
+        },
+      )
+      assert.equal(sameCacheEntryIdentity(replacementDatabase, statSync(databasePath, { bigint: true })), true)
+      assert.equal(sameCacheEntryIdentity(replacementSidecar, statSync(sidecarPath, { bigint: true })), true)
+    }
+  })
+
   test('rejects a sidecar identity change across SQLite open', () => {
     const root = createRoot()
     functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root })
@@ -371,6 +429,90 @@ describe('cache filesystem containment', () => {
       },
     )
     assert.equal(readFileSync(journalPath, 'utf8'), 'replacement journal')
+  })
+
+  test('accepts verified sidecar appearance and disappearance across SQLite open', () => {
+    const cases = [
+      {
+        arrange: (_path: string) => {},
+        mutate: (path: string) => writeFileSync(path, 'appeared journal'),
+        name: 'appearance',
+      },
+      {
+        arrange: (path: string) => writeFileSync(path, 'disappearing journal'),
+        mutate: (path: string) => rmSync(path, { force: true }),
+        name: 'disappearance',
+      },
+    ] as const
+
+    for (const entry of cases) {
+      const root = createRoot()
+      withOperationLock(root, () => 'prepared')
+      const journalPath = join(cacheDirectoryPath(root), 'operation-lock.sqlite-journal')
+      entry.arrange(journalPath)
+      cacheLocationTestHooks.afterDatabaseOpen = database => {
+        if (database.name === 'operation-lock.sqlite') {
+          cacheLocationTestHooks.afterDatabaseOpen = undefined
+          entry.mutate(journalPath)
+        }
+      }
+
+      assert.equal(
+        withOperationLock(root, () => entry.name),
+        entry.name,
+      )
+    }
+  })
+
+  test('retries from a fresh snapshot after an open sidecar identity changes', () => {
+    const root = createRoot()
+    withOperationLock(root, () => 'prepared')
+    const journalPath = join(cacheDirectoryPath(root), 'operation-lock.sqlite-journal')
+    const replacementPath = join(root, 'retry-sidecar-replacement')
+    const displacedPath = join(root, 'retry-sidecar-predecessor')
+    writeFileSync(journalPath, 'sidecar predecessor')
+    writeFileSync(replacementPath, 'sidecar successor')
+    let opens = 0
+    cacheLocationTestHooks.afterDatabaseOpen = database => {
+      if (database.name === 'operation-lock.sqlite') {
+        opens += 1
+        if (opens === 1) {
+          renameSync(journalPath, displacedPath)
+          renameSync(replacementPath, journalPath)
+        }
+      }
+    }
+
+    assert.equal(
+      withOperationLock(root, () => 'entered'),
+      'entered',
+    )
+    assert.equal(opens, 2)
+    assert.equal(readFileSync(displacedPath, 'utf8'), 'sidecar predecessor')
+  })
+
+  test('bounds retries when an open sidecar identity keeps changing', () => {
+    const root = createRoot()
+    withOperationLock(root, () => 'prepared')
+    const journalPath = join(cacheDirectoryPath(root), 'operation-lock.sqlite-journal')
+    writeFileSync(journalPath, 'sidecar generation zero')
+    let opens = 0
+    cacheLocationTestHooks.afterDatabaseOpen = database => {
+      if (database.name === 'operation-lock.sqlite') {
+        opens += 1
+        rmSync(journalPath, { force: true })
+        writeFileSync(journalPath, `sidecar generation ${opens}`)
+      }
+    }
+
+    assert.throws(
+      () => withOperationLock(root, () => 'entered'),
+      (error: unknown) => {
+        assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED')
+        return true
+      },
+    )
+    assert.equal(opens, 3)
   })
 
   test('carries the locked cache location through add-record hydration', () => {
@@ -607,7 +749,9 @@ describe('SQLite cache and reads', () => {
 
     for (const [name, operation] of cases) {
       const root = createRoot()
-      chmodSync(join(root, 'node_modules'), 0o500)
+      cacheLocationTestHooks.beforeLocationInspection = () => {
+        throw Object.assign(new Error('Injected cache location inspection failure.'), { code: 'EACCES' })
+      }
       try {
         assert.throws(
           () => operation(root),
@@ -618,7 +762,7 @@ describe('SQLite cache and reads', () => {
           },
         )
       } finally {
-        chmodSync(join(root, 'node_modules'), 0o700)
+        cacheLocationTestHooks.beforeLocationInspection = undefined
       }
     }
   })
@@ -1653,6 +1797,61 @@ describe('SQLite cache and reads', () => {
       'entered',
     )
     assert.equal(existsSync(recoveryPath), false)
+  })
+
+  test('reobserves when a recovery predecessor completes during observation', () => {
+    const root = createRoot()
+    const recoveryPath = join(cacheDirectoryPath(root), 'operation-lock.recovery')
+    mkdirSync(recoveryPath, { recursive: true })
+    writeFileSync(
+      join(recoveryPath, 'owner.json'),
+      `${JSON.stringify({ acquiredAt: new Date().toISOString(), pid: process.pid, token: 'completing-predecessor' })}\n`,
+    )
+    let observations = 0
+
+    assert.equal(
+      withOperationLock(root, () => 'entered', {
+        duringRecoveryObservation: () => {
+          observations += 1
+          rmSync(recoveryPath, { recursive: true })
+        },
+      }),
+      'entered',
+    )
+    assert.equal(observations, 1)
+  })
+
+  test('reobserves a successor that replaces a recovery predecessor during observation', () => {
+    const root = createRoot()
+    const recoveryPath = join(cacheDirectoryPath(root), 'operation-lock.recovery')
+    const displacedPath = join(root, 'observed-recovery-predecessor')
+    mkdirSync(recoveryPath, { recursive: true })
+    writeFileSync(
+      join(recoveryPath, 'owner.json'),
+      `${JSON.stringify({ acquiredAt: new Date().toISOString(), pid: process.pid, token: 'observed-predecessor' })}\n`,
+    )
+    let observations = 0
+
+    assert.equal(
+      withOperationLock(root, () => 'entered', {
+        duringRecoveryObservation: () => {
+          observations += 1
+          if (observations === 1) {
+            renameSync(recoveryPath, displacedPath)
+            mkdirSync(recoveryPath)
+            writeFileSync(
+              join(recoveryPath, 'owner.json'),
+              `${JSON.stringify({ acquiredAt: new Date().toISOString(), pid: process.pid, token: 'observed-successor' })}\n`,
+            )
+          } else {
+            rmSync(recoveryPath, { recursive: true })
+          }
+        },
+      }),
+      'entered',
+    )
+    assert.equal(observations, 2)
+    assert.match(readFileSync(join(displacedPath, 'owner.json'), 'utf8'), /observed-predecessor/u)
   })
 
   test('reobserves a replacement recovery marker before reclaiming it', async () => {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -3,6 +3,7 @@ import { spawn, spawnSync } from 'node:child_process'
 import { once } from 'node:events'
 import {
   chmodSync,
+  copyFileSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -25,6 +26,7 @@ import { PACKAGE_VERSION } from '../src/generated/version.ts'
 import * as api from '../src/index.ts'
 import { withOperationLock } from '../src/lock.ts'
 import { ordinalStringCompare } from '../src/order.ts'
+import { recordWriteTestHooks } from '../src/records.ts'
 import { createTestRepository, ensureParent, removeTestRepository } from '../test/helpers.ts'
 
 const roots: string[] = []
@@ -43,7 +45,9 @@ const createOutsideDirectory = () => {
 
 afterEach(() => {
   cacheLocationTestHooks.afterQuarantineRename = undefined
+  cacheLocationTestHooks.beforeDatabaseOpen = undefined
   cacheLocationTestHooks.beforeQuarantineRename = undefined
+  recordWriteTestHooks.fault = undefined
   roots.splice(0).forEach(removeTestRepository)
 })
 
@@ -113,6 +117,13 @@ describe('cache filesystem containment', () => {
       ),
       false,
     )
+    assert.equal(
+      sameCacheEntryIdentity(
+        { dev: beyondSafeInteger, ino: beyondSafeInteger + 1n },
+        { dev: beyondSafeInteger + 1n, ino: beyondSafeInteger + 1n },
+      ),
+      false,
+    )
   })
 
   test('rejects cache ancestor redirects without changing the redirect target', () => {
@@ -124,12 +135,14 @@ describe('cache filesystem containment', () => {
           symlinkSync(installedPackage, join(outside, 'encephalon'), process.platform === 'win32' ? 'junction' : 'dir')
           symlinkSync(outside, join(root, 'node_modules'), process.platform === 'win32' ? 'junction' : 'dir')
         },
+        entry: 'node_modules',
         name: 'node_modules',
       },
       {
         arrange: (root: string, outside: string) => {
           symlinkSync(outside, join(root, 'node_modules', '.cache'), process.platform === 'win32' ? 'junction' : 'dir')
         },
+        entry: 'node_modules/.cache',
         name: '.cache',
       },
       {
@@ -141,6 +154,7 @@ describe('cache filesystem containment', () => {
             process.platform === 'win32' ? 'junction' : 'dir',
           )
         },
+        entry: 'node_modules/.cache/encephalon',
         name: 'encephalon',
       },
     ] as const
@@ -152,7 +166,18 @@ describe('cache filesystem containment', () => {
       entry.arrange(root, outside)
       const before = readdirSync(outside).sort(ordinalStringCompare)
 
-      assertCacheLayoutRejected(() => functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }))
+      assert.throws(
+        () => functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }),
+        (error: unknown) => {
+          assert.equal((error as { code?: unknown }).code, 'VALIDATION_FAILED')
+          assert.deepEqual((error as { details?: unknown }).details, {
+            entry: entry.entry,
+            invariant: 'real-directory',
+          })
+          assert.equal(JSON.stringify(error).includes(outside), false)
+          return true
+        },
+      )
       assert.deepEqual(readdirSync(outside).sort(ordinalStringCompare), before)
       assert.equal(readFileSync(join(outside, 'sentinel'), 'utf8'), entry.name)
     }
@@ -166,7 +191,18 @@ describe('cache filesystem containment', () => {
     writeFileSync(target, 'outside database bytes')
     symlinkSync(target, cacheDatabasePath(root))
 
-    assertCacheLayoutRejected(() => functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }))
+    assert.throws(
+      () => functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }),
+      (error: unknown) => {
+        assert.equal((error as { code?: unknown }).code, 'VALIDATION_FAILED')
+        assert.deepEqual((error as { details?: unknown }).details, {
+          entry: 'node_modules/.cache/encephalon/brain.sqlite',
+          invariant: 'regular-non-symlink-file',
+        })
+        assert.equal(JSON.stringify(error).includes(outside), false)
+        return true
+      },
+    )
     assert.equal(readFileSync(target, 'utf8'), 'outside database bytes')
     assert.equal(readFileSync(cacheDatabasePath(root), 'utf8'), 'outside database bytes')
   })
@@ -240,6 +276,134 @@ describe('cache filesystem containment', () => {
     )
     assert.ok(quarantinePath !== undefined)
     assert.equal(readFileSync(quarantinePath, 'utf8'), 'replacement quarantine')
+  })
+
+  test('never quarantines a replacement at the corrupt primary source path', () => {
+    const root = createRoot()
+    const displacedPath = join(root, 'displaced-corrupt-brain.sqlite')
+    functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root })
+    writeFileSync(cacheDatabasePath(root), 'not a sqlite database')
+    cacheLocationTestHooks.beforeQuarantineRename = path => {
+      if (path.endsWith('/brain.sqlite')) {
+        renameSync(path, displacedPath)
+        writeFileSync(path, 'replacement primary')
+      }
+    }
+
+    assert.throws(
+      () => functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }),
+      (error: unknown) => {
+        assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED')
+        return true
+      },
+    )
+    assert.equal(readFileSync(cacheDatabasePath(root), 'utf8'), 'replacement primary')
+  })
+
+  test('rejects valid primary replacements between inspection and SQLite open', () => {
+    const cases = [
+      {
+        databaseName: 'brain.sqlite',
+        operation: (root: string) => functionFromApi<(input: Record<string, unknown>) => unknown>('hydrate')({ root }),
+        prepare: (root: string) => functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }),
+      },
+      {
+        databaseName: 'brain.sqlite',
+        operation: (root: string) =>
+          functionFromApi<(input: Record<string, unknown>) => unknown>('listRecords')({ root }),
+        prepare: (root: string) => functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root }),
+      },
+      {
+        databaseName: 'operation-lock.sqlite',
+        operation: (root: string) => withOperationLock(root, () => 'entered'),
+        prepare: (root: string) => withOperationLock(root, () => 'prepared'),
+      },
+    ] as const
+
+    for (const [index, entry] of cases.entries()) {
+      const root = createRoot()
+      entry.prepare(root)
+      const databasePath = join(cacheDirectoryPath(root), entry.databaseName)
+      const replacementPath = join(root, `valid-replacement-${index}.sqlite`)
+      const displacedPath = join(root, `displaced-${index}.sqlite`)
+      copyFileSync(databasePath, replacementPath)
+      const replacement = statSync(replacementPath, { bigint: true })
+      cacheLocationTestHooks.beforeDatabaseOpen = database => {
+        if (database.name === entry.databaseName) {
+          cacheLocationTestHooks.beforeDatabaseOpen = undefined
+          renameSync(databasePath, displacedPath)
+          renameSync(replacementPath, databasePath)
+        }
+      }
+
+      assert.throws(
+        () => entry.operation(root),
+        (error: unknown) => {
+          assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED')
+          return true
+        },
+      )
+      const preserved = statSync(databasePath, { bigint: true })
+      assert.equal(sameCacheEntryIdentity(replacement, preserved), true)
+    }
+  })
+
+  test('rejects a sidecar identity change across SQLite open', () => {
+    const root = createRoot()
+    functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root })
+    const journalPath = `${cacheDatabasePath(root)}-journal`
+    const replacementPath = join(root, 'replacement-journal')
+    writeFileSync(journalPath, 'original journal')
+    writeFileSync(replacementPath, 'replacement journal')
+    cacheLocationTestHooks.beforeDatabaseOpen = database => {
+      if (database.name === 'brain.sqlite') {
+        cacheLocationTestHooks.beforeDatabaseOpen = undefined
+        rmSync(journalPath)
+        renameSync(replacementPath, journalPath)
+      }
+    }
+
+    assert.throws(
+      () => functionFromApi<(input: Record<string, unknown>) => unknown>('listRecords')({ root }),
+      (error: unknown) => {
+        assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED')
+        return true
+      },
+    )
+    assert.equal(readFileSync(journalPath, 'utf8'), 'replacement journal')
+  })
+
+  test('carries the locked cache location through add-record hydration', () => {
+    const root = createRoot()
+    functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root })
+    const cachePath = cacheDirectoryPath(root)
+    const displacedPath = `${cachePath}-before-add-hydration`
+    recordWriteTestHooks.fault = point => {
+      if (point === 'during-hydration') {
+        recordWriteTestHooks.fault = undefined
+        renameSync(cachePath, displacedPath)
+        mkdirSync(cachePath)
+        writeFileSync(join(cachePath, 'replacement-sentinel'), 'replacement cache')
+      }
+    }
+
+    assert.throws(
+      () =>
+        functionFromApi<(input: Record<string, unknown>) => unknown>('addRecord')({
+          id: 'locked-location-hydration',
+          kind: 'context',
+          payload: null,
+          root,
+          source: 'agent',
+          subject: 'cache.location',
+        }),
+      (error: unknown) => {
+        assert.equal((error as { details?: { postCommitPhase?: unknown } }).details?.postCommitPhase, 'cacheHydration')
+        assert.equal(((error as Error).cause as { code?: unknown }).code, 'REPOSITORY_CHANGED')
+        return true
+      },
+    )
+    assert.deepEqual(readdirSync(cachePath), ['replacement-sentinel'])
   })
 
   test('rejects an operation gate database symlink without changing its target', () => {
@@ -431,6 +595,34 @@ describe('SQLite cache and reads', () => {
     }
   })
 
+  test('wraps cache-location filesystem failures from prepared reads and gathers', () => {
+    const cases = [
+      ['list', (root: string) => functionFromApi<(input: Record<string, unknown>) => unknown>('listRecords')({ root })],
+      [
+        'gather',
+        (root: string) =>
+          functionFromApi<(input: Record<string, unknown>) => unknown>('gatherRecords')({ root, searches: [] }),
+      ],
+    ] as const
+
+    for (const [name, operation] of cases) {
+      const root = createRoot()
+      chmodSync(join(root, 'node_modules'), 0o500)
+      try {
+        assert.throws(
+          () => operation(root),
+          (error: unknown) => {
+            assert.equal((error as { code?: unknown }).code, 'IO_ERROR', name)
+            assert.equal(JSON.stringify(error).includes(root), false, name)
+            return true
+          },
+        )
+      } finally {
+        chmodSync(join(root, 'node_modules'), 0o700)
+      }
+    }
+  })
+
   test('prepares an empty repository before a cache directory exists', () => {
     const root = createRoot()
     const prepare =
@@ -448,16 +640,36 @@ describe('SQLite cache and reads', () => {
     const root = createRoot()
     const firstResult = join(root, 'first-prepare-result')
     const secondResult = join(root, 'second-prepare-result')
+    const firstReady = join(root, 'first-prepare-ready')
+    const secondReady = join(root, 'second-prepare-ready')
+    const releasePath = join(root, 'release-first-prepare')
     const fixture = join(import.meta.dirname, 'fixtures', 'prepare-cache.ts')
     const before = statSync(join(root, 'node_modules'), { bigint: true })
-    const first = spawn(process.execPath, [fixture, root, firstResult], { stdio: 'inherit' })
-    const second = spawn(process.execPath, [fixture, root, secondResult], { stdio: 'inherit' })
+    const first = spawn(process.execPath, [fixture, root, firstResult, firstReady, releasePath], { stdio: 'inherit' })
+    const second = spawn(process.execPath, [fixture, root, secondResult, secondReady, releasePath], {
+      stdio: 'inherit',
+    })
+    const exits = [once(first, 'exit'), once(second, 'exit')]
 
-    await Promise.all([once(first, 'exit'), once(second, 'exit')])
-    assert.equal(first.exitCode, 0)
-    assert.equal(second.exitCode, 0)
-    assert.equal(JSON.parse(readFileSync(firstResult, 'utf8')).recordsIndexed, 0)
-    assert.equal(JSON.parse(readFileSync(secondResult, 'utf8')).recordsIndexed, 0)
+    waitForPath(firstReady, first)
+    waitForPath(secondReady, second)
+    writeFileSync(releasePath, 'release')
+    const exitResults = await Promise.all(exits)
+    assert.equal(exitResults[0]?.[0], 0)
+    assert.equal(exitResults[1]?.[0], 0)
+    const firstOutput = JSON.parse(readFileSync(firstResult, 'utf8')) as {
+      cacheIdentity: { dev: string; ino: string }
+      result: { recordsIndexed: number }
+    }
+    const secondOutput = JSON.parse(readFileSync(secondResult, 'utf8')) as typeof firstOutput
+    assert.equal(firstOutput.result.recordsIndexed, 0)
+    assert.equal(secondOutput.result.recordsIndexed, 0)
+    assert.deepEqual(firstOutput.cacheIdentity, secondOutput.cacheIdentity)
+    const finalIdentity = statSync(cacheDirectoryPath(root), { bigint: true })
+    assert.deepEqual(firstOutput.cacheIdentity, {
+      dev: finalIdentity.dev.toString(),
+      ino: finalIdentity.ino.toString(),
+    })
     assert.equal(
       realpathSync(cacheDirectoryPath(root)),
       join(realpathSync(root), 'node_modules', '.cache', 'encephalon'),
@@ -1441,6 +1653,99 @@ describe('SQLite cache and reads', () => {
       'entered',
     )
     assert.equal(existsSync(recoveryPath), false)
+  })
+
+  test('reobserves a replacement recovery marker before reclaiming it', async () => {
+    const root = createRoot()
+    const recoveryPath = join(root, 'node_modules', '.cache', 'encephalon', 'operation-lock.recovery')
+    const displacedPath = join(root, 'displaced-recovery-predecessor')
+    const removalResult = join(root, 'recovery-successor-removal')
+    const fixture = join(import.meta.dirname, 'fixtures', 'remove-path-after-delay.ts')
+    mkdirSync(recoveryPath, { recursive: true })
+    writeFileSync(
+      join(recoveryPath, 'owner.json'),
+      `${JSON.stringify({ acquiredAt: new Date().toISOString(), pid: 2_147_483_647, token: 'predecessor' })}\n`,
+    )
+    let remover: ReturnType<typeof spawn> | undefined
+
+    assert.equal(
+      withOperationLock(root, () => 'entered', {
+        afterRecoveryStaleObservation: () => {
+          renameSync(recoveryPath, displacedPath)
+          mkdirSync(recoveryPath)
+          writeFileSync(
+            join(recoveryPath, 'owner.json'),
+            `${JSON.stringify({ acquiredAt: new Date().toISOString(), pid: process.pid, token: 'successor' })}\n`,
+          )
+          remover = spawn(process.execPath, [fixture, recoveryPath, removalResult, '100'], { stdio: 'inherit' })
+        },
+      }),
+      'entered',
+    )
+    assert.ok(remover !== undefined)
+    if (remover.exitCode === null) {
+      await once(remover, 'exit')
+    }
+    assert.equal(readFileSync(removalResult, 'utf8'), 'removed')
+  })
+
+  test('cleans only the captured recovery directory identity', () => {
+    const root = createRoot()
+    const cachePath = cacheDirectoryPath(root)
+    const recoveryPath = join(cachePath, 'operation-lock.recovery')
+    const displacedPath = join(root, 'displaced-owned-recovery')
+    mkdirSync(cachePath, { recursive: true })
+    writeFileSync(join(cachePath, 'operation-lock.sqlite'), 'not a sqlite database')
+
+    assert.throws(
+      () =>
+        withOperationLock(root, () => 'entered', {
+          afterRecoveryCreation: () => {
+            renameSync(recoveryPath, displacedPath)
+            mkdirSync(recoveryPath)
+            writeFileSync(join(recoveryPath, 'owner.json'), readFileSync(join(displacedPath, 'owner.json')))
+            writeFileSync(join(recoveryPath, 'successor-sentinel'), 'successor recovery')
+          },
+        }),
+      (error: unknown) => {
+        assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED')
+        return true
+      },
+    )
+    assert.equal(readFileSync(join(recoveryPath, 'successor-sentinel'), 'utf8'), 'successor recovery')
+  })
+
+  test('preserves directory replacements at lock and recovery quarantine paths', () => {
+    const cases = ['operation.lock', 'operation-lock.recovery'] as const
+    for (const name of cases) {
+      const root = createRoot()
+      const path = join(cacheDirectoryPath(root), name)
+      mkdirSync(path, { recursive: true })
+      writeFileSync(
+        join(path, 'owner.json'),
+        `${JSON.stringify({ acquiredAt: new Date().toISOString(), pid: 2_147_483_647, token: name })}\n`,
+      )
+      let quarantinePath: string | undefined
+      cacheLocationTestHooks.afterQuarantineRename = candidate => {
+        if (candidate.includes(`.${name}.`)) {
+          quarantinePath = candidate
+          rmSync(candidate, { recursive: true })
+          mkdirSync(candidate)
+          writeFileSync(join(candidate, 'replacement-sentinel'), name)
+        }
+      }
+
+      assert.throws(
+        () => withOperationLock(root, () => 'entered'),
+        (error: unknown) => {
+          assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED')
+          return true
+        },
+      )
+      assert.ok(quarantinePath !== undefined)
+      assert.equal(readFileSync(join(quarantinePath, 'replacement-sentinel'), 'utf8'), name)
+      cacheLocationTestHooks.afterQuarantineRename = undefined
+    }
   })
 
   test('serialises two contenders recovering the same malformed operation gate', async () => {

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import { describe, test } from 'node:test'
+import { CacheDatabaseFailure } from '../src/cache-location.ts'
 import { cliErrorResponse, EncephalonError, wrapIo } from '../src/errors.ts'
 import type { EncephalonErrorCode } from '../src/types.ts'
 
@@ -46,6 +47,35 @@ describe('error classification', () => {
 
   test('classifies plain errors without errno as internal defects', () => {
     assertWrappedCode(new Error('Unable to write file.'), 'INTERNAL_ERROR')
+  })
+
+  test('classifies wrapped SQLite I/O failures as expected public errors', () => {
+    const database = {
+      dev: 1n,
+      ino: 2n,
+      name: 'brain.sqlite' as const,
+      path: 'brain.sqlite',
+      relativePath: 'node_modules/.cache/encephalon/brain.sqlite',
+      sidecars: {},
+    }
+    for (const errcode of [10, 14]) {
+      const failure = Object.assign(new Error(`SQLite failure ${errcode}`), {
+        code: 'ERR_SQLITE_ERROR',
+        errcode,
+      })
+      const wrapped = new CacheDatabaseFailure(failure, database, { cause: failure })
+
+      assert.throws(
+        () => wrapIo('Unable to access the cache.', wrapped),
+        (error: unknown) => {
+          const classified = error as EncephalonError
+          assert.equal(classified.code, 'IO_ERROR')
+          assert.equal(classified.cause, wrapped)
+          assert.equal(cliErrorResponse(classified).exitCode, 2)
+          return true
+        },
+      )
+    }
   })
 })
 

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -77,6 +77,35 @@ describe('error classification', () => {
       )
     }
   })
+
+  test('keeps wrapped SQLite programmer failures internal', () => {
+    const database = {
+      dev: 1n,
+      ino: 2n,
+      name: 'brain.sqlite' as const,
+      path: 'brain.sqlite',
+      relativePath: 'node_modules/.cache/encephalon/brain.sqlite',
+      sidecars: {},
+    }
+    for (const errcode of [1, 19, 1555]) {
+      const failure = Object.assign(new Error(`SQLite programmer failure ${errcode}`), {
+        code: 'ERR_SQLITE_ERROR',
+        errcode,
+      })
+      const wrapped = new CacheDatabaseFailure(failure, database, { cause: failure })
+
+      assert.throws(
+        () => wrapIo('Unable to access the cache.', wrapped),
+        (error: unknown) => {
+          const classified = error as EncephalonError
+          assert.equal(classified.code, 'INTERNAL_ERROR')
+          assert.equal(classified.cause, wrapped)
+          assert.equal(cliErrorResponse(classified).exitCode, 1)
+          return true
+        },
+      )
+    }
+  })
 })
 
 describe('CLI error projection', () => {

--- a/test/fixtures/hold-operation-lock-until-release.ts
+++ b/test/fixtures/hold-operation-lock-until-release.ts
@@ -1,0 +1,20 @@
+import { existsSync, writeFileSync } from 'node:fs'
+import { withOperationLock } from '../../src/lock.ts'
+
+const [root, attemptedPath, enteredPath, releasePath] = process.argv.slice(2)
+
+if (root === undefined || attemptedPath === undefined || enteredPath === undefined || releasePath === undefined) {
+  throw new Error('Expected repository, attempted, entered, and release paths.')
+}
+
+const wait = () => {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10)
+}
+
+writeFileSync(attemptedPath, 'attempted')
+withOperationLock(root, () => {
+  writeFileSync(enteredPath, 'entered')
+  while (!existsSync(releasePath)) {
+    wait()
+  }
+})

--- a/test/fixtures/prepare-cache.ts
+++ b/test/fixtures/prepare-cache.ts
@@ -1,0 +1,10 @@
+import { writeFileSync } from 'node:fs'
+import { prepare } from '../../src/cache.ts'
+
+const [root, resultPath] = process.argv.slice(2)
+
+if (root === undefined || resultPath === undefined) {
+  throw new Error('Expected a repository root and result path.')
+}
+
+writeFileSync(resultPath, JSON.stringify(prepare({ root })))

--- a/test/fixtures/prepare-cache.ts
+++ b/test/fixtures/prepare-cache.ts
@@ -1,10 +1,24 @@
-import { writeFileSync } from 'node:fs'
+import { existsSync, statSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { prepare } from '../../src/cache.ts'
 
-const [root, resultPath] = process.argv.slice(2)
+const [root, resultPath, readyPath, releasePath] = process.argv.slice(2)
 
-if (root === undefined || resultPath === undefined) {
-  throw new Error('Expected a repository root and result path.')
+if (root === undefined || resultPath === undefined || readyPath === undefined || releasePath === undefined) {
+  throw new Error('Expected repository, result, ready, and release paths.')
 }
 
-writeFileSync(resultPath, JSON.stringify(prepare({ root })))
+writeFileSync(readyPath, 'ready')
+while (!existsSync(releasePath)) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10)
+}
+
+const result = prepare({ root })
+const cache = statSync(join(root, 'node_modules', '.cache', 'encephalon'), { bigint: true })
+writeFileSync(
+  resultPath,
+  JSON.stringify({
+    cacheIdentity: { dev: cache.dev.toString(), ino: cache.ino.toString() },
+    result,
+  }),
+)

--- a/test/fixtures/remove-path-after-delay.ts
+++ b/test/fixtures/remove-path-after-delay.ts
@@ -1,0 +1,12 @@
+import { existsSync, rmSync, writeFileSync } from 'node:fs'
+
+const [path, resultPath, delayText] = process.argv.slice(2)
+
+if (path === undefined || resultPath === undefined || delayText === undefined) {
+  throw new Error('Expected a path, result path, and delay.')
+}
+
+Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Number(delayText))
+const existed = existsSync(path)
+rmSync(path, { force: true, recursive: true })
+writeFileSync(resultPath, existed ? 'removed' : 'missing')


### PR DESCRIPTION
## Human summary

Cache access is now confined to the verified repository cache. Replaced files, links, and SQLite sidecars are detected before they can redirect reads, writes, recovery, or clean-up.

## Summary

- Centralise cache path and filesystem identity validation in one cache-location authority.
- Reject symlinks, junctions, unexpected entry types, and repository or cache replacements throughout initialisation, reads, writes, locking, and recovery.
- Verify SQLite databases and sidecars before and after open, preserve the operation gate across WAL-mode contention, and quarantine only the exact corrupt cache identity observed.
- Keep public API and CLI behaviour unchanged while sanitising new filesystem failure details.
- Add adversarial race, corruption, recovery, sidecar, cross-process contention, and error-projection coverage.
- Update the maintained cache-safety contract and user-facing cache description.

Linear: https://linear.app/marcoappio/issue/MAR-2562/cache-prevent-symlink-escape-through-cache-roots-and-sqlite