### PR TITLE
[MAR-2564] Centralise SQLite error classification

### DIFF
--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-12 for audited snapshot `04d47bd9a330410738d4c939ab305c578a73f2ed`.
+Last reviewed: 2026-08-12 for audited snapshot `5f50f2bd3c9e896480bf954b44fdc13c74bc5bd2`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-12 for audited snapshot `7bc6f8855fdb4c9268e3d29767a5900edd4e4dd3`.
+Last reviewed: 2026-08-12 for audited snapshot `04d47bd9a330410738d4c939ab305c578a73f2ed`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 
@@ -37,6 +37,7 @@ This document is the concise contract maintainers should update when public beha
 - Cache rebuilds are transactional and repository-scoped. Corrupt or incompatible cache state is removed and rebuilt rather than treated as canonical data.
 - SQLite result classification normalises extended numeric codes to their primary result, gives structured numeric and symbolic codes precedence over messages, and uses bounded message fallback only for generic SQLite runtime errors.
 - Disposable cache recovery is limited to corrupt, not-a-database, schema, read-only, and cannot-open failures. Busy, locked, general I/O, and unknown failures are terminal for that rebuild attempt; the operation gate separately reports busy or locked contention and recovers only corrupt or not-a-database state.
+- Public I/O wrapping recognises busy, locked, corrupt, not-a-database, read-only, cannot-open, and general I/O categories as environmental failures. Schema and unknown SQLite failures remain internal errors after any cache recovery is exhausted.
 - Freshness is determined from explicit cache metadata and a manifest of canonical records plus referenced artifacts.
 - Node's pathname-only SQLite API leaves a narrow replacement race inside SQLite's open after the surrounding identity checks. Defending against arbitrary same-user mutation between those boundaries is not a supported security boundary.
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-12 for audited snapshot `abbdcfb0daf267e4308559b7af3cfe88c9a43564`.
+Last reviewed: 2026-08-12 for audited snapshot `7bc6f8855fdb4c9268e3d29767a5900edd4e4dd3`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 
@@ -35,6 +35,8 @@ This document is the concise contract maintainers should update when public beha
 - Missing cache ancestors are created individually. New primary databases use exclusive no-follow descriptor creation before SQLite opens the verified pathname, and destructive recovery removes only the exact identity moved to a verified sibling quarantine.
 - Every `list`, `show`, `search`, and `gather` operation prepares the cache before reading.
 - Cache rebuilds are transactional and repository-scoped. Corrupt or incompatible cache state is removed and rebuilt rather than treated as canonical data.
+- SQLite result classification normalises extended numeric codes to their primary result, gives structured numeric and symbolic codes precedence over messages, and uses bounded message fallback only for generic SQLite runtime errors.
+- Disposable cache recovery is limited to corrupt, not-a-database, schema, read-only, and cannot-open failures. Busy, locked, general I/O, and unknown failures are terminal for that rebuild attempt; the operation gate separately reports busy or locked contention and recovers only corrupt or not-a-database state.
 - Freshness is determined from explicit cache metadata and a manifest of canonical records plus referenced artifacts.
 - Node's pathname-only SQLite API leaves a narrow replacement race inside SQLite's open after the surrounding identity checks. Defending against arbitrary same-user mutation between those boundaries is not a supported security boundary.
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -25,6 +25,7 @@ import { ordinalStringCompare } from './order.ts'
 import { canonicalRecordPath, readRecords } from './records.ts'
 import { resolveRepository } from './repository.ts'
 import { MAX_RECORD_BYTES, parseRecordFile, validateArtifactPath } from './schema.ts'
+import { classifySQLiteError } from './sqlite-error.ts'
 import type {
   BrainRecord,
   CompactBrainRecord,
@@ -143,17 +144,14 @@ const loadSQLite = () => {
 
 const isRecoverableCacheFailure = (error: unknown) => {
   const failure = error instanceof CacheDatabaseFailure ? error.failure : error
-  const sqlite = failure as { errcode?: unknown; message?: unknown }
+  const category = classifySQLiteError(failure)
   return (
     failure instanceof CacheSchemaMismatch ||
-    sqlite.errcode === 8 ||
-    sqlite.errcode === 14 ||
-    sqlite.errcode === 11 ||
-    sqlite.errcode === 26 ||
-    (typeof sqlite.message === 'string' &&
-      /database disk image is malformed|file is not a database|malformed database schema|no such (?:column|table)|has no column named/i.test(
-        sqlite.message,
-      ))
+    category === 'cantopen' ||
+    category === 'corrupt' ||
+    category === 'notadb' ||
+    category === 'readonly' ||
+    category === 'schema'
   )
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -44,11 +44,22 @@ const isRecognizedFilesystemError = (error: unknown) => {
   return typeof error.code === 'string' && FILESYSTEM_ERROR_CODES.has(error.code)
 }
 
-const isRecognizedSQLiteError = (error: unknown) => classifySQLiteError(error) !== 'unknown'
+const isEnvironmentalSQLiteError = (error: unknown) => {
+  const category = classifySQLiteError(error)
+  return (
+    category === 'busy' ||
+    category === 'cantopen' ||
+    category === 'corrupt' ||
+    category === 'io' ||
+    category === 'locked' ||
+    category === 'notadb' ||
+    category === 'readonly'
+  )
+}
 
 const hasRecognizedIoCause = (cause: unknown, remainingDepth = 8): boolean =>
   isRecognizedFilesystemError(cause) ||
-  isRecognizedSQLiteError(cause) ||
+  isEnvironmentalSQLiteError(cause) ||
   (remainingDepth > 0 && isRecord(cause) && hasRecognizedIoCause(cause.cause, remainingDepth - 1))
 
 const errorCodeForCause = (cause: unknown): EncephalonErrorCode =>

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,4 @@
+import { classifySQLiteError } from './sqlite-error.ts'
 import type { EncephalonErrorCode, JsonValue } from './types.ts'
 
 const FILESYSTEM_ERROR_CODES = new Set([
@@ -21,19 +22,6 @@ const FILESYSTEM_ERROR_CODES = new Set([
   'ESTALE',
   'EXDEV',
 ])
-const SQLITE_IO_ERROR_CODES = new Set([3, 5, 6, 7, 8, 10, 11, 13, 14, 26])
-const SQLITE_IO_STRING_CODES = new Set([
-  'SQLITE_BUSY',
-  'SQLITE_CANTOPEN',
-  'SQLITE_CORRUPT',
-  'SQLITE_FULL',
-  'SQLITE_IOERR',
-  'SQLITE_LOCKED',
-  'SQLITE_NOMEM',
-  'SQLITE_NOTADB',
-  'SQLITE_PERM',
-  'SQLITE_READONLY',
-])
 const MAX_CLI_STRING_LENGTH = 256
 const MAX_CLI_ARRAY_LENGTH = 25
 const MAX_CLI_OBJECT_KEYS = 25
@@ -56,19 +44,7 @@ const isRecognizedFilesystemError = (error: unknown) => {
   return typeof error.code === 'string' && FILESYSTEM_ERROR_CODES.has(error.code)
 }
 
-const isRecognizedSQLiteError = (error: unknown) => {
-  if (!isRecord(error)) {
-    return false
-  }
-  return (
-    (typeof error.code === 'string' && SQLITE_IO_STRING_CODES.has(error.code)) ||
-    (typeof error.errcode === 'number' && SQLITE_IO_ERROR_CODES.has(error.errcode & 0xff)) ||
-    (typeof error.message === 'string' &&
-      /database disk image is malformed|database is locked|file is not a database|SQLITE_(?:BUSY|CANTOPEN|CORRUPT|FULL|IOERR|LOCKED|NOMEM|NOTADB|PERM|READONLY)/i.test(
-        error.message,
-      ))
-  )
-}
+const isRecognizedSQLiteError = (error: unknown) => classifySQLiteError(error) !== 'unknown'
 
 const hasRecognizedIoCause = (cause: unknown, remainingDepth = 8): boolean =>
   isRecognizedFilesystemError(cause) ||

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -19,6 +19,7 @@ import {
   writeCacheOwner,
 } from './cache-location.ts'
 import { EncephalonError, fail, wrapIo } from './errors.ts'
+import { classifySQLiteError, type SQLiteErrorCategory } from './sqlite-error.ts'
 
 const LOCK_WAIT_MILLISECONDS = 60_000
 const RECOVERY_POLL_MILLISECONDS = 50
@@ -79,31 +80,8 @@ const processIsRunning = (pid: number) => {
   }
 }
 
-const sqliteBusy = (error: unknown) => {
-  const candidate = (error instanceof CacheDatabaseFailure ? error.failure : error) as {
-    errcode?: unknown
-    message?: unknown
-  }
-  return (
-    candidate.errcode === 5 ||
-    candidate.errcode === 6 ||
-    (typeof candidate.message === 'string' &&
-      /(?:database is locked|SQLITE_BUSY|SQLITE_LOCKED)/i.test(candidate.message))
-  )
-}
-
-const sqliteCorrupt = (error: unknown) => {
-  const candidate = (error instanceof CacheDatabaseFailure ? error.failure : error) as {
-    errcode?: unknown
-    message?: unknown
-  }
-  return (
-    candidate.errcode === 11 ||
-    candidate.errcode === 26 ||
-    (typeof candidate.message === 'string' &&
-      /database disk image is malformed|file is not a database|malformed database schema/i.test(candidate.message))
-  )
-}
+const sqliteFailureCategory = (error: unknown): SQLiteErrorCategory =>
+  classifySQLiteError(error instanceof CacheDatabaseFailure ? error.failure : error)
 
 export const withOperationLock = <Result>(
   root: string,
@@ -254,16 +232,18 @@ export const withOperationLock = <Result>(
       try {
         beginGateTransaction(true)
       } catch (error) {
-        if (sqliteBusy(error)) {
+        const category = sqliteFailureCategory(error)
+        if (category === 'busy' || category === 'locked') {
           return fail('CACHE_BUSY', 'Timed out waiting for the Encephalon operation lock.', {
             timeoutMilliseconds: LOCK_WAIT_MILLISECONDS,
           })
         }
-        if (!sqliteCorrupt(error)) {
+        if (category === 'corrupt' || category === 'notadb') {
+          quarantineCorruptGate(error)
+          beginGateTransaction(true)
+        } else {
           throw error
         }
-        quarantineCorruptGate(error)
-        beginGateTransaction(true)
       }
     } catch (error) {
       recoveryError = error
@@ -301,15 +281,17 @@ export const withOperationLock = <Result>(
     try {
       beginGateTransaction()
     } catch (error) {
-      if (sqliteBusy(error)) {
+      const category = sqliteFailureCategory(error)
+      if (category === 'busy' || category === 'locked') {
         return fail('CACHE_BUSY', 'Timed out waiting for the Encephalon operation lock.', {
           timeoutMilliseconds: LOCK_WAIT_MILLISECONDS,
         })
       }
-      if (!sqliteCorrupt(error)) {
+      if (category === 'corrupt' || category === 'notadb') {
+        recoverCorruptGate()
+      } else {
         throw error
       }
-      recoverCorruptGate()
     }
 
     // The SQLite transaction is the authoritative operation lock. A valid owner

--- a/src/sqlite-error.ts
+++ b/src/sqlite-error.ts
@@ -1,0 +1,133 @@
+export type SQLiteErrorCategory =
+  | 'busy'
+  | 'cantopen'
+  | 'corrupt'
+  | 'io'
+  | 'locked'
+  | 'notadb'
+  | 'readonly'
+  | 'schema'
+  | 'unknown'
+
+const MAX_MESSAGE_FALLBACK_LENGTH = 512
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && !Array.isArray(value) && typeof value === 'object'
+
+const categoryForPrimaryCode = (code: number): SQLiteErrorCategory => {
+  switch (code) {
+    case 3:
+    case 7:
+    case 10:
+    case 13:
+      return 'io'
+    case 5:
+      return 'busy'
+    case 6:
+      return 'locked'
+    case 8:
+      return 'readonly'
+    case 11:
+      return 'corrupt'
+    case 14:
+      return 'cantopen'
+    case 26:
+      return 'notadb'
+    default:
+      return 'unknown'
+  }
+}
+
+const categoryForSymbolicCode = (code: string): SQLiteErrorCategory => {
+  const match = /^SQLITE_([A-Z]+)(?:_[A-Z0-9]+)*$/.exec(code)
+  if (match !== null) {
+    switch (match[1]) {
+      case 'BUSY':
+        return 'busy'
+      case 'CANTOPEN':
+        return 'cantopen'
+      case 'CORRUPT':
+        return 'corrupt'
+      case 'FULL':
+      case 'IOERR':
+      case 'NOMEM':
+      case 'PERM':
+        return 'io'
+      case 'LOCKED':
+        return 'locked'
+      case 'NOTADB':
+        return 'notadb'
+      case 'READONLY':
+        return 'readonly'
+      default:
+        return 'unknown'
+    }
+  }
+  return 'unknown'
+}
+
+const categoryForSchemaMessage = (message: string): SQLiteErrorCategory => {
+  if (/^(?:no such (?:column|table):|table .+ has no column named )/i.test(message)) {
+    return 'schema'
+  }
+  return 'unknown'
+}
+
+const categoryForRuntimeMessage = (message: unknown): SQLiteErrorCategory => {
+  if (typeof message === 'string') {
+    const bounded = message.slice(0, MAX_MESSAGE_FALLBACK_LENGTH).trim()
+    if (/^database is locked(?:$|:)/i.test(bounded)) {
+      return 'busy'
+    }
+    if (/^database table is locked(?:$|:)/i.test(bounded)) {
+      return 'locked'
+    }
+    if (/^(?:database disk image is malformed|malformed database schema)/i.test(bounded)) {
+      return 'corrupt'
+    }
+    if (/^file is not a database/i.test(bounded)) {
+      return 'notadb'
+    }
+    if (/^attempt to write a readonly database/i.test(bounded)) {
+      return 'readonly'
+    }
+    if (/^unable to open database file/i.test(bounded)) {
+      return 'cantopen'
+    }
+    if (/^(?:access permission denied|database or disk is full|disk I\/O error|out of memory)/i.test(bounded)) {
+      return 'io'
+    }
+    return categoryForSchemaMessage(bounded)
+  }
+  return 'unknown'
+}
+
+export const classifySQLiteError = (error: unknown): SQLiteErrorCategory => {
+  if (isRecord(error)) {
+    const { code, errcode, message } = error
+    if (typeof errcode === 'number' && Number.isSafeInteger(errcode) && errcode >= 0) {
+      const primaryCode = errcode & 0xff
+      const category = categoryForPrimaryCode(primaryCode)
+      if (category !== 'unknown') {
+        return category
+      }
+      if (primaryCode === 1 && typeof message === 'string') {
+        return categoryForSchemaMessage(message.slice(0, MAX_MESSAGE_FALLBACK_LENGTH).trim())
+      }
+      return 'unknown'
+    }
+    if (typeof code === 'string') {
+      const category = categoryForSymbolicCode(code)
+      if (category !== 'unknown') {
+        return category
+      }
+      if (code === 'ERR_SQLITE_ERROR') {
+        return categoryForRuntimeMessage(message)
+      }
+      if (code === 'SQLITE_ERROR' && typeof message === 'string') {
+        return categoryForSchemaMessage(message.slice(0, MAX_MESSAGE_FALLBACK_LENGTH).trim())
+      }
+    }
+  }
+  return 'unknown'
+}

--- a/src/sqlite-error.ts
+++ b/src/sqlite-error.ts
@@ -10,28 +10,43 @@ export type SQLiteErrorCategory =
   | 'unknown'
 
 const MAX_MESSAGE_FALLBACK_LENGTH = 512
+const SQLITE_PRIMARY_RESULT_MASK = 0xff
+const SQLITE_RESULT_ERROR = 1
+const SQLITE_RESULT_PERM = 3
+const SQLITE_RESULT_BUSY = 5
+const SQLITE_RESULT_LOCKED = 6
+const SQLITE_RESULT_NOMEM = 7
+const SQLITE_RESULT_READONLY = 8
+const SQLITE_RESULT_IOERR = 10
+const SQLITE_RESULT_CORRUPT = 11
+const SQLITE_RESULT_FULL = 13
+const SQLITE_RESULT_CANTOPEN = 14
+const SQLITE_RESULT_SCHEMA = 17
+const SQLITE_RESULT_NOTADB = 26
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && !Array.isArray(value) && typeof value === 'object'
 
 const categoryForPrimaryCode = (code: number): SQLiteErrorCategory => {
   switch (code) {
-    case 3:
-    case 7:
-    case 10:
-    case 13:
+    case SQLITE_RESULT_PERM:
+    case SQLITE_RESULT_NOMEM:
+    case SQLITE_RESULT_IOERR:
+    case SQLITE_RESULT_FULL:
       return 'io'
-    case 5:
+    case SQLITE_RESULT_BUSY:
       return 'busy'
-    case 6:
+    case SQLITE_RESULT_LOCKED:
       return 'locked'
-    case 8:
+    case SQLITE_RESULT_READONLY:
       return 'readonly'
-    case 11:
+    case SQLITE_RESULT_CORRUPT:
       return 'corrupt'
-    case 14:
+    case SQLITE_RESULT_CANTOPEN:
       return 'cantopen'
-    case 26:
+    case SQLITE_RESULT_SCHEMA:
+      return 'schema'
+    case SQLITE_RESULT_NOTADB:
       return 'notadb'
     default:
       return 'unknown'
@@ -59,6 +74,8 @@ const categoryForSymbolicCode = (code: string): SQLiteErrorCategory => {
         return 'notadb'
       case 'READONLY':
         return 'readonly'
+      case 'SCHEMA':
+        return 'schema'
       default:
         return 'unknown'
     }
@@ -106,12 +123,12 @@ export const classifySQLiteError = (error: unknown): SQLiteErrorCategory => {
   if (isRecord(error)) {
     const { code, errcode, message } = error
     if (typeof errcode === 'number' && Number.isSafeInteger(errcode) && errcode >= 0) {
-      const primaryCode = errcode & 0xff
+      const primaryCode = errcode & SQLITE_PRIMARY_RESULT_MASK
       const category = categoryForPrimaryCode(primaryCode)
       if (category !== 'unknown') {
         return category
       }
-      if (primaryCode === 1 && typeof message === 'string') {
+      if (primaryCode === SQLITE_RESULT_ERROR && typeof message === 'string') {
         return categoryForSchemaMessage(message.slice(0, MAX_MESSAGE_FALLBACK_LENGTH).trim())
       }
       return 'unknown'

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -43,10 +43,19 @@ describe('error classification', () => {
       Object.assign(new Error('UNIQUE constraint failed'), { code: 'ERR_SQLITE_ERROR', errcode: 1555 }),
       'INTERNAL_ERROR',
     )
+    assertWrappedCode(
+      Object.assign(new Error('database is locked'), {
+        code: 'SQLITE_BUSY_SNAPSHOT',
+        errcode: 19,
+      }),
+      'INTERNAL_ERROR',
+    )
+    assertWrappedCode(Object.assign(new Error('snapshot is busy'), { code: 'SQLITE_BUSY_SNAPSHOT' }), 'IO_ERROR')
   })
 
   test('classifies plain errors without errno as internal defects', () => {
     assertWrappedCode(new Error('Unable to write file.'), 'INTERNAL_ERROR')
+    assertWrappedCode(new Error('database is locked'), 'INTERNAL_ERROR')
   })
 
   test('classifies wrapped SQLite I/O failures as expected public errors', () => {

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -53,24 +53,6 @@ describe('error classification', () => {
     assertWrappedCode(Object.assign(new Error('snapshot is busy'), { code: 'SQLITE_BUSY_SNAPSHOT' }), 'IO_ERROR')
   })
 
-  test('preserves the public boundary between environmental and internal SQLite failures', () => {
-    const cases = [
-      { code: 'IO_ERROR', error: { errcode: 5 }, name: 'busy' },
-      { code: 'IO_ERROR', error: { errcode: 14 }, name: 'cannot open' },
-      { code: 'IO_ERROR', error: { errcode: 11 }, name: 'corrupt' },
-      { code: 'IO_ERROR', error: { errcode: 10 }, name: 'I/O' },
-      { code: 'IO_ERROR', error: { errcode: 6 }, name: 'locked' },
-      { code: 'IO_ERROR', error: { errcode: 26 }, name: 'not a database' },
-      { code: 'IO_ERROR', error: { errcode: 8 }, name: 'read-only' },
-      { code: 'INTERNAL_ERROR', error: { errcode: 1, message: 'no such table: metadata' }, name: 'schema' },
-      { code: 'INTERNAL_ERROR', error: { errcode: 19 }, name: 'unknown' },
-    ] as const
-
-    for (const entry of cases) {
-      assertWrappedCode(Object.assign(new Error(entry.name), { code: 'ERR_SQLITE_ERROR', ...entry.error }), entry.code)
-    }
-  })
-
   test('classifies plain errors without errno as internal defects', () => {
     assertWrappedCode(new Error('Unable to write file.'), 'INTERNAL_ERROR')
     assertWrappedCode(new Error('database is locked'), 'INTERNAL_ERROR')

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -53,6 +53,24 @@ describe('error classification', () => {
     assertWrappedCode(Object.assign(new Error('snapshot is busy'), { code: 'SQLITE_BUSY_SNAPSHOT' }), 'IO_ERROR')
   })
 
+  test('preserves the public boundary between environmental and internal SQLite failures', () => {
+    const cases = [
+      { code: 'IO_ERROR', error: { errcode: 5 }, name: 'busy' },
+      { code: 'IO_ERROR', error: { errcode: 14 }, name: 'cannot open' },
+      { code: 'IO_ERROR', error: { errcode: 11 }, name: 'corrupt' },
+      { code: 'IO_ERROR', error: { errcode: 10 }, name: 'I/O' },
+      { code: 'IO_ERROR', error: { errcode: 6 }, name: 'locked' },
+      { code: 'IO_ERROR', error: { errcode: 26 }, name: 'not a database' },
+      { code: 'IO_ERROR', error: { errcode: 8 }, name: 'read-only' },
+      { code: 'INTERNAL_ERROR', error: { errcode: 1, message: 'no such table: metadata' }, name: 'schema' },
+      { code: 'INTERNAL_ERROR', error: { errcode: 19 }, name: 'unknown' },
+    ] as const
+
+    for (const entry of cases) {
+      assertWrappedCode(Object.assign(new Error(entry.name), { code: 'ERR_SQLITE_ERROR', ...entry.error }), entry.code)
+    }
+  })
+
   test('classifies plain errors without errno as internal defects', () => {
     assertWrappedCode(new Error('Unable to write file.'), 'INTERNAL_ERROR')
     assertWrappedCode(new Error('database is locked'), 'INTERNAL_ERROR')

--- a/test/sqlite-error.test.ts
+++ b/test/sqlite-error.test.ts
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import { classifySQLiteError, type SQLiteErrorCategory } from '../src/sqlite-error.ts'
+
+type ClassificationCase = {
+  category: SQLiteErrorCategory
+  error: unknown
+  name: string
+}
+
+const assertClassifications = (cases: ClassificationCase[]) => {
+  for (const entry of cases) {
+    assert.equal(classifySQLiteError(entry.error), entry.category, entry.name)
+  }
+}
+
+describe('SQLite error classification', () => {
+  test('normalises primary and extended numeric result codes', () => {
+    assertClassifications([
+      { category: 'busy', error: { errcode: 5 }, name: 'BUSY' },
+      { category: 'busy', error: { errcode: 517 }, name: 'BUSY_SNAPSHOT' },
+      { category: 'locked', error: { errcode: 6 }, name: 'LOCKED' },
+      { category: 'locked', error: { errcode: 262 }, name: 'LOCKED_SHAREDCACHE' },
+      { category: 'corrupt', error: { errcode: 11 }, name: 'CORRUPT' },
+      { category: 'corrupt', error: { errcode: 267 }, name: 'CORRUPT_VTAB' },
+      { category: 'notadb', error: { errcode: 26 }, name: 'NOTADB' },
+      { category: 'readonly', error: { errcode: 8 }, name: 'READONLY' },
+      { category: 'readonly', error: { errcode: 264 }, name: 'READONLY_RECOVERY' },
+      { category: 'cantopen', error: { errcode: 14 }, name: 'CANTOPEN' },
+      { category: 'cantopen', error: { errcode: 270 }, name: 'CANTOPEN_NOTEMPDIR' },
+      { category: 'io', error: { errcode: 10 }, name: 'IOERR' },
+      { category: 'io', error: { errcode: 266 }, name: 'IOERR_READ' },
+      { category: 'io', error: { errcode: 3 }, name: 'PERM' },
+      { category: 'io', error: { errcode: 7 }, name: 'NOMEM' },
+      { category: 'io', error: { errcode: 13 }, name: 'FULL' },
+      { category: 'unknown', error: { errcode: 19 }, name: 'CONSTRAINT' },
+      { category: 'unknown', error: { errcode: 1555 }, name: 'CONSTRAINT_PRIMARYKEY' },
+    ])
+  })
+
+  test('accepts extended symbolic result codes and gives numeric codes precedence', () => {
+    assertClassifications([
+      { category: 'busy', error: { code: 'SQLITE_BUSY_SNAPSHOT' }, name: 'symbolic BUSY_SNAPSHOT' },
+      {
+        category: 'locked',
+        error: { code: 'SQLITE_LOCKED_SHAREDCACHE' },
+        name: 'symbolic LOCKED_SHAREDCACHE',
+      },
+      { category: 'corrupt', error: { code: 'SQLITE_CORRUPT_SEQUENCE' }, name: 'symbolic CORRUPT_SEQUENCE' },
+      { category: 'notadb', error: { code: 'SQLITE_NOTADB' }, name: 'symbolic NOTADB' },
+      { category: 'readonly', error: { code: 'SQLITE_READONLY_ROLLBACK' }, name: 'symbolic READONLY_ROLLBACK' },
+      { category: 'cantopen', error: { code: 'SQLITE_CANTOPEN_ISDIR' }, name: 'symbolic CANTOPEN_ISDIR' },
+      { category: 'io', error: { code: 'SQLITE_IOERR_FSYNC' }, name: 'symbolic IOERR_FSYNC' },
+      { category: 'io', error: { code: 'SQLITE_FULL' }, name: 'symbolic FULL' },
+      {
+        category: 'unknown',
+        error: { code: 'SQLITE_BUSY_SNAPSHOT', errcode: 19, message: 'database is locked' },
+        name: 'numeric constraint contradicts busy code and message',
+      },
+      {
+        category: 'corrupt',
+        error: { code: 'SQLITE_BUSY', errcode: 267, message: 'database is locked' },
+        name: 'numeric extended corruption contradicts busy code and message',
+      },
+      {
+        category: 'unknown',
+        error: { code: 'SQLITE_CONSTRAINT_UNIQUE', message: 'database is locked' },
+        name: 'symbolic constraint contradicts busy message',
+      },
+    ])
+  })
+
+  test('uses bounded message fallback only for generic SQLite runtime errors', () => {
+    assertClassifications([
+      {
+        category: 'busy',
+        error: Object.assign(new Error('database is locked'), { code: 'ERR_SQLITE_ERROR' }),
+        name: 'runtime-only busy message',
+      },
+      {
+        category: 'locked',
+        error: Object.assign(new Error('database table is locked'), { code: 'ERR_SQLITE_ERROR' }),
+        name: 'runtime-only locked message',
+      },
+      {
+        category: 'corrupt',
+        error: Object.assign(new Error('database disk image is malformed'), { code: 'ERR_SQLITE_ERROR' }),
+        name: 'runtime-only corrupt message',
+      },
+      {
+        category: 'notadb',
+        error: Object.assign(new Error('file is not a database'), { code: 'ERR_SQLITE_ERROR' }),
+        name: 'runtime-only not-a-database message',
+      },
+      {
+        category: 'readonly',
+        error: Object.assign(new Error('attempt to write a readonly database'), { code: 'ERR_SQLITE_ERROR' }),
+        name: 'runtime-only read-only message',
+      },
+      {
+        category: 'cantopen',
+        error: Object.assign(new Error('unable to open database file'), { code: 'ERR_SQLITE_ERROR' }),
+        name: 'runtime-only cannot-open message',
+      },
+      {
+        category: 'io',
+        error: Object.assign(new Error('disk I/O error'), { code: 'ERR_SQLITE_ERROR' }),
+        name: 'runtime-only I/O message',
+      },
+      {
+        category: 'schema',
+        error: Object.assign(new Error('no such table: metadata'), { code: 'ERR_SQLITE_ERROR', errcode: 1 }),
+        name: 'generic SQLite result refined by schema message',
+      },
+      {
+        category: 'unknown',
+        error: Object.assign(new Error('database is locked'), { code: 'ERR_SQLITE_ERROR', errcode: 1 }),
+        name: 'generic numeric result is not overridden by a busy message',
+      },
+      { category: 'unknown', error: new Error('database is locked'), name: 'arbitrary locked Error' },
+      {
+        category: 'unknown',
+        error: Object.assign(new Error(`${'x'.repeat(4096)}database is locked`), { code: 'ERR_SQLITE_ERROR' }),
+        name: 'message outside fallback bound',
+      },
+    ])
+  })
+})

--- a/test/sqlite-error.test.ts
+++ b/test/sqlite-error.test.ts
@@ -33,6 +33,7 @@ describe('SQLite error classification', () => {
       { category: 'io', error: { errcode: 3 }, name: 'PERM' },
       { category: 'io', error: { errcode: 7 }, name: 'NOMEM' },
       { category: 'io', error: { errcode: 13 }, name: 'FULL' },
+      { category: 'schema', error: { errcode: 17 }, name: 'SCHEMA' },
       { category: 'unknown', error: { errcode: 19 }, name: 'CONSTRAINT' },
       { category: 'unknown', error: { errcode: 1555 }, name: 'CONSTRAINT_PRIMARYKEY' },
     ])
@@ -52,6 +53,9 @@ describe('SQLite error classification', () => {
       { category: 'cantopen', error: { code: 'SQLITE_CANTOPEN_ISDIR' }, name: 'symbolic CANTOPEN_ISDIR' },
       { category: 'io', error: { code: 'SQLITE_IOERR_FSYNC' }, name: 'symbolic IOERR_FSYNC' },
       { category: 'io', error: { code: 'SQLITE_FULL' }, name: 'symbolic FULL' },
+      { category: 'io', error: { code: 'SQLITE_NOMEM' }, name: 'symbolic NOMEM' },
+      { category: 'io', error: { code: 'SQLITE_PERM' }, name: 'symbolic PERM' },
+      { category: 'schema', error: { code: 'SQLITE_SCHEMA' }, name: 'symbolic SCHEMA' },
       {
         category: 'unknown',
         error: { code: 'SQLITE_BUSY_SNAPSHOT', errcode: 19, message: 'database is locked' },
@@ -66,6 +70,11 @@ describe('SQLite error classification', () => {
         category: 'unknown',
         error: { code: 'SQLITE_CONSTRAINT_UNIQUE', message: 'database is locked' },
         name: 'symbolic constraint contradicts busy message',
+      },
+      {
+        category: 'readonly',
+        error: { code: 'SQLITE_READONLY', message: 'database is locked' },
+        name: 'known read-only code contradicts busy message',
       },
     ])
   })
@@ -108,9 +117,52 @@ describe('SQLite error classification', () => {
         name: 'runtime-only I/O message',
       },
       {
+        category: 'io',
+        error: Object.assign(new Error('access permission denied'), { code: 'ERR_SQLITE_ERROR' }),
+        name: 'runtime-only permission message',
+      },
+      {
+        category: 'io',
+        error: Object.assign(new Error('database or disk is full'), { code: 'ERR_SQLITE_ERROR' }),
+        name: 'runtime-only full message',
+      },
+      {
+        category: 'io',
+        error: Object.assign(new Error('out of memory'), { code: 'ERR_SQLITE_ERROR' }),
+        name: 'runtime-only memory message',
+      },
+      {
         category: 'schema',
         error: Object.assign(new Error('no such table: metadata'), { code: 'ERR_SQLITE_ERROR', errcode: 1 }),
         name: 'generic SQLite result refined by schema message',
+      },
+      {
+        category: 'schema',
+        error: Object.assign(new Error('no such column: records.value'), { code: 'ERR_SQLITE_ERROR', errcode: 1 }),
+        name: 'generic SQLite result refined by no-such-column message',
+      },
+      {
+        category: 'schema',
+        error: Object.assign(new Error('table records has no column named value'), {
+          code: 'ERR_SQLITE_ERROR',
+          errcode: 1,
+        }),
+        name: 'generic SQLite result refined by has-no-column message',
+      },
+      {
+        category: 'schema',
+        error: Object.assign(new Error('no such table: metadata'), { code: 'ERR_SQLITE_ERROR' }),
+        name: 'generic runtime schema fallback',
+      },
+      {
+        category: 'schema',
+        error: Object.assign(new Error('no such table: metadata'), { code: 'SQLITE_ERROR' }),
+        name: 'symbolic primary schema fallback',
+      },
+      {
+        category: 'corrupt',
+        error: Object.assign(new Error('malformed database schema (metadata)'), { code: 'ERR_SQLITE_ERROR' }),
+        name: 'runtime-only malformed schema message',
       },
       {
         category: 'unknown',
@@ -119,9 +171,18 @@ describe('SQLite error classification', () => {
       },
       { category: 'unknown', error: new Error('database is locked'), name: 'arbitrary locked Error' },
       {
+        category: 'schema',
+        error: Object.assign(new Error(`table ${'x'.repeat(100)} has no column named value`), {
+          code: 'ERR_SQLITE_ERROR',
+        }),
+        name: 'schema message within fallback bound',
+      },
+      {
         category: 'unknown',
-        error: Object.assign(new Error(`${'x'.repeat(4096)}database is locked`), { code: 'ERR_SQLITE_ERROR' }),
-        name: 'message outside fallback bound',
+        error: Object.assign(new Error(`table ${'x'.repeat(600)} has no column named value`), {
+          code: 'ERR_SQLITE_ERROR',
+        }),
+        name: 'schema message outside fallback bound',
       },
     ])
   })

--- a/test/sqlite-policy.test.ts
+++ b/test/sqlite-policy.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict'
+import { afterEach, describe, test } from 'node:test'
+import { cacheReadTestHooks } from '../src/cache.ts'
+import { cacheLocationTestHooks } from '../src/cache-location.ts'
+import { EncephalonError } from '../src/errors.ts'
+import { prepare } from '../src/index.ts'
+import { withOperationLock } from '../src/lock.ts'
+import type { SQLiteErrorCategory } from '../src/sqlite-error.ts'
+import { createTestRepository, removeTestRepository } from './helpers.ts'
+
+type PolicyCase = {
+  category: SQLiteErrorCategory
+  error: Error
+  publicCode: 'INTERNAL_ERROR' | 'IO_ERROR'
+}
+
+const sqliteError = (errcode: number, message: string) =>
+  Object.assign(new Error(message), { code: 'ERR_SQLITE_ERROR', errcode })
+
+const policyCases: PolicyCase[] = [
+  { category: 'busy', error: sqliteError(5, 'database is locked'), publicCode: 'IO_ERROR' },
+  { category: 'cantopen', error: sqliteError(14, 'unable to open database file'), publicCode: 'IO_ERROR' },
+  { category: 'corrupt', error: sqliteError(11, 'database disk image is malformed'), publicCode: 'IO_ERROR' },
+  { category: 'io', error: sqliteError(10, 'disk I/O error'), publicCode: 'IO_ERROR' },
+  { category: 'locked', error: sqliteError(6, 'database table is locked'), publicCode: 'IO_ERROR' },
+  { category: 'notadb', error: sqliteError(26, 'file is not a database'), publicCode: 'IO_ERROR' },
+  { category: 'readonly', error: sqliteError(8, 'attempt to write a readonly database'), publicCode: 'IO_ERROR' },
+  { category: 'schema', error: sqliteError(1, 'no such table: metadata'), publicCode: 'INTERNAL_ERROR' },
+  { category: 'unknown', error: sqliteError(19, 'constraint failed'), publicCode: 'INTERNAL_ERROR' },
+]
+
+const roots: string[] = []
+
+const createRoot = () => {
+  const root = createTestRepository()
+  roots.push(root)
+  return root
+}
+
+const assertErrorCode = (operation: () => unknown, code: string) => {
+  assert.throws(operation, (error: unknown) => {
+    assert.ok(error instanceof EncephalonError)
+    assert.equal(error.code, code)
+    return true
+  })
+}
+
+afterEach(() => {
+  cacheLocationTestHooks.afterDatabaseLockInitialisation = undefined
+  cacheReadTestHooks.duringDatabaseInitialisation = undefined
+  roots.splice(0).forEach(removeTestRepository)
+})
+
+describe('SQLite consumer policies', () => {
+  test('cache recovery accepts only disposable cache categories', () => {
+    const recoverable = new Set(['cantopen', 'corrupt', 'notadb', 'readonly', 'schema'])
+    for (const entry of policyCases) {
+      const root = createRoot()
+      let writerInitialisations = 0
+      cacheReadTestHooks.duringDatabaseInitialisation = mode => {
+        if (mode === 'writer') {
+          writerInitialisations += 1
+          if (writerInitialisations === 1) {
+            throw entry.error
+          }
+        }
+      }
+
+      if (recoverable.has(entry.category)) {
+        assert.deepEqual(prepare({ root }), { hydrated: true, recordsIndexed: 0 }, entry.category)
+        assert.equal(writerInitialisations, 2, entry.category)
+      } else {
+        assertErrorCode(() => prepare({ root }), entry.publicCode)
+        assert.equal(writerInitialisations, 1, entry.category)
+      }
+      cacheReadTestHooks.duringDatabaseInitialisation = undefined
+    }
+
+    const root = createRoot()
+    let exhaustedSchemaInitialisations = 0
+    cacheReadTestHooks.duringDatabaseInitialisation = mode => {
+      if (mode === 'writer') {
+        exhaustedSchemaInitialisations += 1
+        throw sqliteError(1, 'no such table: metadata')
+      }
+    }
+    assertErrorCode(() => prepare({ root }), 'INTERNAL_ERROR')
+    assert.equal(exhaustedSchemaInitialisations, 2)
+  })
+
+  test('operation gate handles only contention and disposable corruption categories', () => {
+    const recoverable = new Set(['corrupt', 'notadb'])
+    for (const entry of policyCases) {
+      const root = createRoot()
+      let gateInitialisations = 0
+      cacheLocationTestHooks.afterDatabaseLockInitialisation = () => {
+        gateInitialisations += 1
+        if (gateInitialisations === 1) {
+          throw entry.error
+        }
+      }
+
+      if (entry.category === 'busy' || entry.category === 'locked') {
+        assertErrorCode(() => withOperationLock(root, () => 'entered'), 'CACHE_BUSY')
+        assert.equal(gateInitialisations, 1, entry.category)
+      } else if (recoverable.has(entry.category)) {
+        assert.equal(
+          withOperationLock(root, () => 'entered'),
+          'entered',
+          entry.category,
+        )
+        assert.equal(gateInitialisations, 2, entry.category)
+      } else {
+        assertErrorCode(() => withOperationLock(root, () => 'entered'), entry.publicCode)
+        assert.equal(gateInitialisations, 1, entry.category)
+      }
+      cacheLocationTestHooks.afterDatabaseLockInitialisation = undefined
+    }
+  })
+})

--- a/test/sqlite-policy.test.ts
+++ b/test/sqlite-policy.test.ts
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict'
 import { afterEach, describe, test } from 'node:test'
 import { cacheReadTestHooks } from '../src/cache.ts'
 import { cacheLocationTestHooks } from '../src/cache-location.ts'
-import { EncephalonError } from '../src/errors.ts'
+import { EncephalonError, wrapIo } from '../src/errors.ts'
 import { prepare } from '../src/index.ts'
 import { withOperationLock } from '../src/lock.ts'
-import type { SQLiteErrorCategory } from '../src/sqlite-error.ts'
+import { classifySQLiteError, type SQLiteErrorCategory } from '../src/sqlite-error.ts'
 import { createTestRepository, removeTestRepository } from './helpers.ts'
 
 type PolicyCase = {
@@ -14,20 +14,45 @@ type PolicyCase = {
   publicCode: 'INTERNAL_ERROR' | 'IO_ERROR'
 }
 
-const sqliteError = (errcode: number, message: string) =>
-  Object.assign(new Error(message), { code: 'ERR_SQLITE_ERROR', errcode })
+const sqliteError = (message: string, fields: Record<string, unknown>) => Object.assign(new Error(message), fields)
 
 const policyCases: PolicyCase[] = [
-  { category: 'busy', error: sqliteError(5, 'database is locked'), publicCode: 'IO_ERROR' },
-  { category: 'cantopen', error: sqliteError(14, 'unable to open database file'), publicCode: 'IO_ERROR' },
-  { category: 'corrupt', error: sqliteError(11, 'database disk image is malformed'), publicCode: 'IO_ERROR' },
-  { category: 'io', error: sqliteError(10, 'disk I/O error'), publicCode: 'IO_ERROR' },
-  { category: 'locked', error: sqliteError(6, 'database table is locked'), publicCode: 'IO_ERROR' },
-  { category: 'notadb', error: sqliteError(26, 'file is not a database'), publicCode: 'IO_ERROR' },
-  { category: 'readonly', error: sqliteError(8, 'attempt to write a readonly database'), publicCode: 'IO_ERROR' },
-  { category: 'schema', error: sqliteError(1, 'no such table: metadata'), publicCode: 'INTERNAL_ERROR' },
-  { category: 'unknown', error: sqliteError(19, 'constraint failed'), publicCode: 'INTERNAL_ERROR' },
+  { category: 'busy', error: sqliteError('busy snapshot', { errcode: 517 }), publicCode: 'IO_ERROR' },
+  {
+    category: 'cantopen',
+    error: sqliteError('cannot open directory', { code: 'SQLITE_CANTOPEN_ISDIR' }),
+    publicCode: 'IO_ERROR',
+  },
+  {
+    category: 'corrupt',
+    error: sqliteError('database disk image is malformed', { code: 'ERR_SQLITE_ERROR' }),
+    publicCode: 'IO_ERROR',
+  },
+  { category: 'io', error: sqliteError('I/O read', { errcode: 266 }), publicCode: 'IO_ERROR' },
+  {
+    category: 'locked',
+    error: sqliteError('shared cache lock', { code: 'SQLITE_LOCKED_SHAREDCACHE' }),
+    publicCode: 'IO_ERROR',
+  },
+  {
+    category: 'notadb',
+    error: sqliteError('file is not a database', { code: 'ERR_SQLITE_ERROR' }),
+    publicCode: 'IO_ERROR',
+  },
+  { category: 'readonly', error: sqliteError('read-only recovery', { errcode: 264 }), publicCode: 'IO_ERROR' },
+  {
+    category: 'schema',
+    error: sqliteError('no such table: metadata', { code: 'ERR_SQLITE_ERROR' }),
+    publicCode: 'INTERNAL_ERROR',
+  },
+  {
+    category: 'unknown',
+    error: sqliteError('database is locked', { code: 'SQLITE_BUSY', errcode: 19 }),
+    publicCode: 'INTERNAL_ERROR',
+  },
 ]
+
+const corruptRecoveryError = sqliteError('corrupt virtual table', { errcode: 267 })
 
 const roots: string[] = []
 
@@ -52,6 +77,13 @@ afterEach(() => {
 })
 
 describe('SQLite consumer policies', () => {
+  test('public wrapping preserves category policy across SQLite representations', () => {
+    for (const entry of policyCases) {
+      assert.equal(classifySQLiteError(entry.error), entry.category, entry.category)
+      assertErrorCode(() => wrapIo('Wrapped failure.', entry.error), entry.publicCode)
+    }
+  })
+
   test('cache recovery accepts only disposable cache categories', () => {
     const recoverable = new Set(['cantopen', 'corrupt', 'notadb', 'readonly', 'schema'])
     for (const entry of policyCases) {
@@ -81,7 +113,7 @@ describe('SQLite consumer policies', () => {
     cacheReadTestHooks.duringDatabaseInitialisation = mode => {
       if (mode === 'writer') {
         exhaustedSchemaInitialisations += 1
-        throw sqliteError(1, 'no such table: metadata')
+        throw sqliteError('no such table: metadata', { code: 'ERR_SQLITE_ERROR' })
       }
     }
     assertErrorCode(() => prepare({ root }), 'INTERNAL_ERROR')
@@ -113,6 +145,39 @@ describe('SQLite consumer policies', () => {
       } else {
         assertErrorCode(() => withOperationLock(root, () => 'entered'), entry.publicCode)
         assert.equal(gateInitialisations, 1, entry.category)
+      }
+      cacheLocationTestHooks.afterDatabaseLockInitialisation = undefined
+    }
+  })
+
+  test('operation gate preserves category policy while corrupt recovery is held', () => {
+    const recoverable = new Set(['corrupt', 'notadb'])
+    for (const entry of policyCases) {
+      const root = createRoot()
+      let gateInitialisations = 0
+      cacheLocationTestHooks.afterDatabaseLockInitialisation = () => {
+        gateInitialisations += 1
+        if (gateInitialisations === 1) {
+          throw corruptRecoveryError
+        }
+        if (gateInitialisations === 2) {
+          throw entry.error
+        }
+      }
+
+      if (entry.category === 'busy' || entry.category === 'locked') {
+        assertErrorCode(() => withOperationLock(root, () => 'entered'), 'CACHE_BUSY')
+        assert.equal(gateInitialisations, 2, entry.category)
+      } else if (recoverable.has(entry.category)) {
+        assert.equal(
+          withOperationLock(root, () => 'entered'),
+          'entered',
+          entry.category,
+        )
+        assert.equal(gateInitialisations, 3, entry.category)
+      } else {
+        assertErrorCode(() => withOperationLock(root, () => 'entered'), entry.publicCode)
+        assert.equal(gateInitialisations, 2, entry.category)
       }
       cacheLocationTestHooks.afterDatabaseLockInitialisation = undefined
     }


### PR DESCRIPTION
## Human summary

SQLite failures now receive one consistent interpretation, so extended busy, corruption, read-only, and file errors follow the correct cache, lock, and public-error behaviour.

## Summary

- Add one pure internal classifier for numeric, symbolic, and bounded message-only SQLite errors.
- Normalise extended result codes while giving structured numeric codes precedence over contradictory text.
- Keep cache recovery, operation-lock recovery, and public wrapping as explicit consumer policies.
- Preserve existing public error codes and sanitised messages while preventing non-SQLite errors from being misclassified by broad words.
- Add mutation-sensitive unit and integration coverage for cache, gate, recovery-held, and public-boundary behaviour.
- Document the recoverable and terminal category contract.

Linear: https://linear.app/marcoappio/issue/MAR-2564/sqlite-centralize-extended-result-code-classification
