### PR TITLE
[MAR-2546] Make gate recovery ownership token-safe

### DIFF
--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-12 for audited snapshot `5f50f2bd3c9e896480bf954b44fdc13c74bc5bd2`.
+Last reviewed: 2026-08-12 for audited snapshot `1f20e04b8a499f0114f34510b35999e23617be5f`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 
@@ -33,6 +33,8 @@ This document is the concise contract maintainers should update when public beha
 - SQLite is disposable derived state under `node_modules/.cache/encephalon`.
 - The repository, cache ancestors, SQLite databases and sidecars, operation-lock metadata, recovery entries, and quarantine entries must be real contained filesystem entries verified by type, native realpath, and stable identity. Static symlinks, junction redirects, unexpected types, and replacements at validation boundaries fail closed.
 - Missing cache ancestors are created individually. New primary databases use exclusive no-follow descriptor creation before SQLite opens the verified pathname, and destructive recovery removes only the exact identity moved to a verified sibling quarantine.
+- Corrupt operation-gate recovery is serialised by a bounded owner marker. A well-formed live owner is never reclaimed because of age; dead, malformed, or ownerless markers remain reclaimable, and recovery work plus cleanup is conditional on the captured directory identity and random owner token.
+- Recovery-marker exclusion begins with atomic directory creation. An owner file that is briefly absent is age-reclaimed rather than published by candidate-directory rename because Node has no cross-platform no-replace directory rename, and replacement semantics could displace an empty live marker.
 - Every `list`, `show`, `search`, and `gather` operation prepares the cache before reading.
 - Cache rebuilds are transactional and repository-scoped. Corrupt or incompatible cache state is removed and rebuilt rather than treated as canonical data.
 - SQLite result classification normalises extended numeric codes to their primary result, gives structured numeric and symbolic codes precedence over messages, and uses bounded message fallback only for generic SQLite runtime errors.

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-12 for audited snapshot `01f9f6d3ba394401ed1a0d53d7da82041210bc63`.
+Last reviewed: 2026-08-12 for audited snapshot `bf2b4be76246db9418ea98b9e869d3e3cd609ec0`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 
@@ -33,7 +33,7 @@ This document is the concise contract maintainers should update when public beha
 - SQLite is disposable derived state under `node_modules/.cache/encephalon`.
 - The repository, cache ancestors, SQLite databases and sidecars, operation-lock metadata, recovery entries, and quarantine entries must be real contained filesystem entries verified by type, native realpath, and stable identity. Static symlinks, junction redirects, unexpected types, and replacements at validation boundaries fail closed.
 - Missing cache ancestors are created individually. New primary databases use exclusive no-follow descriptor creation before SQLite opens the verified pathname, and destructive recovery removes only the exact identity moved to a verified sibling quarantine.
-- Corrupt operation-gate recovery is serialised by a bounded owner marker and one total deadline. A well-formed live owner is never reclaimed because of age; dead, malformed, or ownerless markers remain reclaimable only while their observed state remains current at the destructive boundary. Recovery work plus cleanup is conditional on the captured directory identity and random owner token, and cleanup failure prevents entry into the protected operation.
+- Corrupt operation-gate recovery is serialised by a bounded owner marker and one total deadline. A well-formed live owner is never reclaimed because of age; oversized, non-record, otherwise malformed, dead, or ownerless markers remain reclaimable only while their observed state remains current at the destructive boundary. Recovery work, successful gate initialisation, and cleanup are conditional on the captured directory identity and random owner token. Cleanup failure prevents entry into the protected operation, and a later call may reclaim only that exact abandoned identity and token.
 - Recovery-marker exclusion begins with atomic directory creation. An owner file that is briefly absent is age-reclaimed rather than published by candidate-directory rename because Node has no cross-platform no-replace directory rename, and replacement semantics could displace an empty live marker.
 - Every `list`, `show`, `search`, and `gather` operation prepares the cache before reading.
 - Cache rebuilds are transactional and repository-scoped. Corrupt or incompatible cache state is removed and rebuilt rather than treated as canonical data.

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-12 for audited snapshot `1f20e04b8a499f0114f34510b35999e23617be5f`.
+Last reviewed: 2026-08-12 for audited snapshot `01f9f6d3ba394401ed1a0d53d7da82041210bc63`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 
@@ -33,7 +33,7 @@ This document is the concise contract maintainers should update when public beha
 - SQLite is disposable derived state under `node_modules/.cache/encephalon`.
 - The repository, cache ancestors, SQLite databases and sidecars, operation-lock metadata, recovery entries, and quarantine entries must be real contained filesystem entries verified by type, native realpath, and stable identity. Static symlinks, junction redirects, unexpected types, and replacements at validation boundaries fail closed.
 - Missing cache ancestors are created individually. New primary databases use exclusive no-follow descriptor creation before SQLite opens the verified pathname, and destructive recovery removes only the exact identity moved to a verified sibling quarantine.
-- Corrupt operation-gate recovery is serialised by a bounded owner marker. A well-formed live owner is never reclaimed because of age; dead, malformed, or ownerless markers remain reclaimable, and recovery work plus cleanup is conditional on the captured directory identity and random owner token.
+- Corrupt operation-gate recovery is serialised by a bounded owner marker and one total deadline. A well-formed live owner is never reclaimed because of age; dead, malformed, or ownerless markers remain reclaimable only while their observed state remains current at the destructive boundary. Recovery work plus cleanup is conditional on the captured directory identity and random owner token, and cleanup failure prevents entry into the protected operation.
 - Recovery-marker exclusion begins with atomic directory creation. An owner file that is briefly absent is age-reclaimed rather than published by candidate-directory rename because Node has no cross-platform no-replace directory rename, and replacement semantics could displace an empty live marker.
 - Every `list`, `show`, `search`, and `gather` operation prepares the cache before reading.
 - Cache rebuilds are transactional and repository-scoped. Corrupt or incompatible cache state is removed and rebuilt rather than treated as canonical data.

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-12 for audited snapshot `bf2b4be76246db9418ea98b9e869d3e3cd609ec0`.
+Last reviewed: 2026-08-12 for audited snapshot `eaff22439ae593b4d38a5a801a7d56704b9b5754`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 

--- a/src/cache-location.ts
+++ b/src/cache-location.ts
@@ -845,30 +845,30 @@ export const quarantineCacheOwnedDirectory = (
   assertOwnedDirectory(location, directory)
   cacheLocationTestHooks.beforeQuarantineRename?.(directory.path)
   assertOwnedDirectory(location, directory)
-  if (!(ownershipIsCurrent?.() ?? true)) {
-    return false
+  if (ownershipIsCurrent?.() ?? true) {
+    const quarantineName = `.${directory.name}.${randomUUID()}.quarantine`
+    const quarantinePath = resolve(location.directory, quarantineName)
+    renameSync(directory.path, quarantinePath)
+    assertCacheLocation(location)
+    const movedMetadata = quarantineMetadata(quarantinePath, ownedDirectoryRelativePath(directory.name))
+    if (!(movedMetadata.isDirectory() && sameCacheEntryIdentity(directory, identityFrom(movedMetadata)))) {
+      return changedLayout(ownedDirectoryRelativePath(directory.name), 'stable-quarantine-identity')
+    }
+    const movedIncarnation = incarnationFrom(movedMetadata)
+    cacheLocationTestHooks.afterQuarantineRename?.(quarantinePath)
+    assertCacheLocation(location)
+    const metadata = quarantineMetadata(quarantinePath, ownedDirectoryRelativePath(directory.name))
+    if (!(metadata.isDirectory() && sameCacheEntryIncarnation(movedIncarnation, incarnationFrom(metadata)))) {
+      return changedLayout(ownedDirectoryRelativePath(directory.name), 'stable-quarantine-identity')
+    }
+    const ownerPath = resolve(quarantinePath, 'owner.json')
+    const owner = inspectRegularFile(ownerPath, `${ownedDirectoryRelativePath(directory.name)}/owner.json`)
+    if (owner !== undefined) {
+      unlinkSync(ownerPath)
+    }
+    rmdirSync(quarantinePath)
+    assertCacheLocation(location)
+    return true
   }
-  const quarantineName = `.${directory.name}.${randomUUID()}.quarantine`
-  const quarantinePath = resolve(location.directory, quarantineName)
-  renameSync(directory.path, quarantinePath)
-  assertCacheLocation(location)
-  const movedMetadata = quarantineMetadata(quarantinePath, ownedDirectoryRelativePath(directory.name))
-  if (!(movedMetadata.isDirectory() && sameCacheEntryIdentity(directory, identityFrom(movedMetadata)))) {
-    return changedLayout(ownedDirectoryRelativePath(directory.name), 'stable-quarantine-identity')
-  }
-  const movedIncarnation = incarnationFrom(movedMetadata)
-  cacheLocationTestHooks.afterQuarantineRename?.(quarantinePath)
-  assertCacheLocation(location)
-  const metadata = quarantineMetadata(quarantinePath, ownedDirectoryRelativePath(directory.name))
-  if (!(metadata.isDirectory() && sameCacheEntryIncarnation(movedIncarnation, incarnationFrom(metadata)))) {
-    return changedLayout(ownedDirectoryRelativePath(directory.name), 'stable-quarantine-identity')
-  }
-  const ownerPath = resolve(quarantinePath, 'owner.json')
-  const owner = inspectRegularFile(ownerPath, `${ownedDirectoryRelativePath(directory.name)}/owner.json`)
-  if (owner !== undefined) {
-    unlinkSync(ownerPath)
-  }
-  rmdirSync(quarantinePath)
-  assertCacheLocation(location)
-  return true
+  return false
 }

--- a/src/cache-location.ts
+++ b/src/cache-location.ts
@@ -837,10 +837,17 @@ export const readCacheOwner = (location: CacheLocation, directory: CacheOwnedDir
   }
 }
 
-export const quarantineCacheOwnedDirectory = (location: CacheLocation, directory: CacheOwnedDirectory) => {
+export const quarantineCacheOwnedDirectory = (
+  location: CacheLocation,
+  directory: CacheOwnedDirectory,
+  ownershipIsCurrent?: () => boolean,
+) => {
   assertOwnedDirectory(location, directory)
   cacheLocationTestHooks.beforeQuarantineRename?.(directory.path)
   assertOwnedDirectory(location, directory)
+  if (!(ownershipIsCurrent?.() ?? true)) {
+    return false
+  }
   const quarantineName = `.${directory.name}.${randomUUID()}.quarantine`
   const quarantinePath = resolve(location.directory, quarantineName)
   renameSync(directory.path, quarantinePath)
@@ -863,4 +870,5 @@ export const quarantineCacheOwnedDirectory = (location: CacheLocation, directory
   }
   rmdirSync(quarantinePath)
   assertCacheLocation(location)
+  return true
 }

--- a/src/cache-location.ts
+++ b/src/cache-location.ts
@@ -823,8 +823,11 @@ export const readCacheOwner = (location: CacheLocation, directory: CacheOwnedDir
   const descriptor = openSync(path, constants.O_RDONLY | NO_FOLLOW)
   try {
     const metadata = fstatSync(descriptor, { bigint: true })
-    if (!sameCacheEntryIdentity(captured, identityFrom(metadata)) || metadata.size > BigInt(maximumBytes)) {
+    if (!sameCacheEntryIdentity(captured, identityFrom(metadata))) {
       return invalidLayout(`${ownedDirectoryRelativePath(directory.name)}/owner.json`, 'bounded-stable-owner-file')
+    }
+    if (metadata.size > BigInt(maximumBytes)) {
+      return
     }
     const bytes = Buffer.alloc(Number(metadata.size))
     const read = readSync(descriptor, bytes, 0, bytes.length, 0)

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -49,6 +49,8 @@ type OwnedRecoveryMarker = {
 }
 
 const MAX_OWNER_BYTES = 4096
+const MAX_OWNER_TIMESTAMP_LENGTH = 64
+const MAX_OWNER_TOKEN_LENGTH = 128
 
 const readOwner = (location: CacheLocation, directory: CacheOwnedDirectory): LockOwner | undefined => {
   try {
@@ -56,9 +58,13 @@ const readOwner = (location: CacheLocation, directory: CacheOwnedDirectory): Loc
     const value = JSON.parse(contents ?? '') as Partial<LockOwner>
     if (
       typeof value.token === 'string' &&
-      Number.isInteger(value.pid) &&
+      value.token.length > 0 &&
+      value.token.length <= MAX_OWNER_TOKEN_LENGTH &&
+      Number.isSafeInteger(value.pid) &&
       (value.pid ?? 0) > 0 &&
-      typeof value.acquiredAt === 'string'
+      typeof value.acquiredAt === 'string' &&
+      value.acquiredAt.length > 0 &&
+      value.acquiredAt.length <= MAX_OWNER_TIMESTAMP_LENGTH
     ) {
       return value as LockOwner
     }

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -43,6 +43,11 @@ type RecoveryMarkerObservation =
   | { kind: 'observed'; directory: CacheOwnedDirectory; stale: boolean }
   | { kind: 'retry' }
 
+type OwnedRecoveryMarker = {
+  directory: CacheOwnedDirectory
+  token: string
+}
+
 const MAX_OWNER_BYTES = 4096
 
 const readOwner = (location: CacheLocation, directory: CacheOwnedDirectory): LockOwner | undefined => {
@@ -67,7 +72,7 @@ const readOwner = (location: CacheLocation, directory: CacheOwnedDirectory): Loc
 const releaseOwnedLock = (location: CacheLocation, directory: CacheOwnedDirectory, token: string) => {
   const owner = readOwner(location, directory)
   if (owner?.token === token) {
-    quarantineCacheOwnedDirectory(location, directory)
+    quarantineCacheOwnedDirectory(location, directory, () => readOwner(location, directory)?.token === token)
   }
 }
 
@@ -76,7 +81,7 @@ const processIsRunning = (pid: number) => {
     process.kill(pid, 0)
     return true
   } catch (error) {
-    return (error as NodeJS.ErrnoException).code === 'EPERM'
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH'
   }
 }
 
@@ -120,12 +125,10 @@ export const withOperationLock = <Result>(
     try {
       const owner = readOwner(location, recoveryDirectory)
       if (owner !== undefined) {
-        const acquiredAt = Date.parse(owner.acquiredAt)
-        const age = Number.isFinite(acquiredAt) ? Date.now() - acquiredAt : RECOVERY_STALE_MILLISECONDS + 1
         return {
           directory: recoveryDirectory,
           kind: 'observed',
-          stale: !processIsRunning(owner.pid) || age > RECOVERY_STALE_MILLISECONDS,
+          stale: !processIsRunning(owner.pid),
         }
       }
       return {
@@ -146,6 +149,20 @@ export const withOperationLock = <Result>(
     testHooks.afterRecoveryStaleObservation?.()
     if (cacheOwnedDirectoryIsCurrent(location, recoveryDirectory)) {
       quarantineCacheOwnedDirectory(location, recoveryDirectory)
+    }
+  }
+
+  const recoveryMarkerIsOwned = (marker: OwnedRecoveryMarker) => {
+    try {
+      if (cacheOwnedDirectoryIsCurrent(location, marker.directory)) {
+        return readOwner(location, marker.directory)?.token === marker.token
+      }
+      return false
+    } catch (error) {
+      if (cacheOwnedDirectoryIsCurrent(location, marker.directory)) {
+        throw error
+      }
+      return false
     }
   }
 
@@ -192,14 +209,11 @@ export const withOperationLock = <Result>(
     gateTransaction = true
   }
 
-  const recoverCorruptGate = () => {
-    let recoveryLockHeld = false
-    let ownedRecoveryDirectory: CacheOwnedDirectory | undefined
-    let recoveryError: unknown
-    while (!recoveryLockHeld) {
+  const acquireRecoveryMarker = (): OwnedRecoveryMarker => {
+    let ownedMarker: OwnedRecoveryMarker | undefined
+    while (ownedMarker === undefined) {
       try {
         const recoveryDirectory = createCacheOwnedDirectory(location, recoveryName)
-        ownedRecoveryDirectory = recoveryDirectory
         writeCacheOwner(
           location,
           recoveryDirectory,
@@ -210,7 +224,10 @@ export const withOperationLock = <Result>(
           })}\n`,
         )
         testHooks.afterRecoveryCreation?.()
-        recoveryLockHeld = true
+        const candidate = { directory: recoveryDirectory, token }
+        if (recoveryMarkerIsOwned(candidate)) {
+          ownedMarker = candidate
+        }
       } catch (error) {
         const existingRecovery = (error as NodeJS.ErrnoException).code === 'EEXIST'
         if (!existingRecovery) {
@@ -228,9 +245,15 @@ export const withOperationLock = <Result>(
         wait(Math.min(RECOVERY_POLL_MILLISECONDS, remainingMilliseconds()))
       }
     }
-    try {
+    return ownedMarker
+  }
+
+  const recoverGateWhileOwned = (ownedMarker: OwnedRecoveryMarker) => {
+    let recovered = false
+    if (recoveryMarkerIsOwned(ownedMarker)) {
       try {
         beginGateTransaction(true)
+        recovered = true
       } catch (error) {
         const category = sqliteFailureCategory(error)
         if (category === 'busy' || category === 'locked') {
@@ -239,28 +262,34 @@ export const withOperationLock = <Result>(
           })
         }
         if (category === 'corrupt' || category === 'notadb') {
-          quarantineCorruptGate(error)
-          beginGateTransaction(true)
+          if (recoveryMarkerIsOwned(ownedMarker)) {
+            quarantineCorruptGate(error)
+            if (recoveryMarkerIsOwned(ownedMarker)) {
+              beginGateTransaction(true)
+              recovered = true
+            }
+          }
         } else {
           throw error
         }
       }
-    } catch (error) {
-      recoveryError = error
     }
-    let cleanupError: unknown
-    try {
-      if (ownedRecoveryDirectory !== undefined) {
-        quarantineCacheOwnedDirectory(location, ownedRecoveryDirectory)
+    return recovered
+  }
+
+  const recoverCorruptGate = () => {
+    let recovered = false
+    while (!recovered) {
+      const ownedMarker = acquireRecoveryMarker()
+      try {
+        recovered = recoverGateWhileOwned(ownedMarker)
+      } finally {
+        try {
+          releaseOwnedLock(location, ownedMarker.directory, ownedMarker.token)
+        } catch {
+          // Recovery-marker cleanup cannot replace the gate recovery result.
+        }
       }
-    } catch (error) {
-      cleanupError = error
-    }
-    if (recoveryError !== undefined) {
-      throw recoveryError
-    }
-    if (cleanupError !== undefined) {
-      throw cleanupError
     }
   }
 

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -17,6 +17,7 @@ import {
   quarantineCacheDatabase,
   quarantineCacheOwnedDirectory,
   readCacheOwner,
+  sameCacheEntryIdentity,
   writeCacheOwner,
 } from './cache-location.ts'
 import { EncephalonError, fail, wrapIo } from './errors.ts'
@@ -56,11 +57,23 @@ type OwnedRecoveryMarker = {
 }
 
 const abandonedRecoveryMarkers = new Map<string, OwnedRecoveryMarker>()
+const MAX_ABANDONED_RECOVERY_MARKERS = 64
 
 const MAX_OWNER_BYTES = 4096
 const MAX_OWNER_PID = 2_147_483_647
 const MAX_OWNER_TIMESTAMP_LENGTH = 64
 const MAX_OWNER_TOKEN_LENGTH = 128
+
+const rememberAbandonedRecoveryMarker = (marker: OwnedRecoveryMarker) => {
+  abandonedRecoveryMarkers.delete(marker.directory.path)
+  abandonedRecoveryMarkers.set(marker.directory.path, marker)
+  if (abandonedRecoveryMarkers.size > MAX_ABANDONED_RECOVERY_MARKERS) {
+    const oldestPath = abandonedRecoveryMarkers.keys().next().value
+    if (oldestPath !== undefined) {
+      abandonedRecoveryMarkers.delete(oldestPath)
+    }
+  }
+}
 
 const readOwner = (location: CacheLocation, directory: CacheOwnedDirectory): LockOwner | undefined => {
   try {
@@ -133,8 +146,7 @@ export const withOperationLock = <Result>(
       const matches =
         abandoned.directory.path === directory.path &&
         abandoned.directory.name === directory.name &&
-        abandoned.directory.dev === directory.dev &&
-        abandoned.directory.ino === directory.ino &&
+        sameCacheEntryIdentity(abandoned.directory, directory) &&
         owner?.token === abandoned.token
       if (!matches) {
         abandonedRecoveryMarkers.delete(directory.path)
@@ -296,6 +308,20 @@ export const withOperationLock = <Result>(
     return owned
   }
 
+  const beginRecoveryGate = (ownedMarker: OwnedRecoveryMarker) => {
+    try {
+      return { category: undefined, recovered: beginGateWhileRecoveryOwned(ownedMarker) }
+    } catch (error) {
+      const category = sqliteFailureCategory(error)
+      if (category === 'busy' || category === 'locked') {
+        return fail('CACHE_BUSY', 'Timed out waiting for the Encephalon operation lock.', {
+          timeoutMilliseconds: LOCK_WAIT_MILLISECONDS,
+        })
+      }
+      return { category, error, recovered: false }
+    }
+  }
+
   const acquireRecoveryMarker = (): OwnedRecoveryMarker => {
     let ownedMarker: OwnedRecoveryMarker | undefined
     while (ownedMarker === undefined) {
@@ -345,24 +371,22 @@ export const withOperationLock = <Result>(
   const recoverGateWhileOwned = (ownedMarker: OwnedRecoveryMarker) => {
     let recovered = false
     if (recoveryMarkerIsOwned(ownedMarker)) {
-      try {
-        recovered = beginGateWhileRecoveryOwned(ownedMarker)
-      } catch (error) {
-        const category = sqliteFailureCategory(error)
-        if (category === 'busy' || category === 'locked') {
-          return fail('CACHE_BUSY', 'Timed out waiting for the Encephalon operation lock.', {
-            timeoutMilliseconds: LOCK_WAIT_MILLISECONDS,
-          })
-        }
-        if (category === 'corrupt' || category === 'notadb') {
+      const initial = beginRecoveryGate(ownedMarker)
+      ;({ recovered } = initial)
+      if (initial.error !== undefined) {
+        if (initial.category === 'corrupt' || initial.category === 'notadb') {
           if (recoveryMarkerIsOwned(ownedMarker)) {
-            quarantineCorruptGate(error)
+            quarantineCorruptGate(initial.error)
             if (recoveryMarkerIsOwned(ownedMarker)) {
-              recovered = beginGateWhileRecoveryOwned(ownedMarker)
+              const retried = beginRecoveryGate(ownedMarker)
+              ;({ recovered } = retried)
+              if (retried.error !== undefined) {
+                throw retried.error
+              }
             }
           }
         } else {
-          throw error
+          throw initial.error
         }
       }
     }
@@ -384,7 +408,7 @@ export const withOperationLock = <Result>(
         releaseOwnedLock(location, ownedMarker.directory, ownedMarker.token)
         abandonedRecoveryMarkers.delete(ownedMarker.directory.path)
       } catch (error) {
-        abandonedRecoveryMarkers.set(ownedMarker.directory.path, ownedMarker)
+        rememberAbandonedRecoveryMarker(ownedMarker)
         cleanupError = error
       }
       if (recoveryError !== undefined) {

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import { resolve } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import {
   assertCacheLockCandidates,
@@ -54,6 +55,8 @@ type OwnedRecoveryMarker = {
   token: string
 }
 
+const abandonedRecoveryMarkers = new Map<string, OwnedRecoveryMarker>()
+
 const MAX_OWNER_BYTES = 4096
 const MAX_OWNER_PID = 2_147_483_647
 const MAX_OWNER_TIMESTAMP_LENGTH = 64
@@ -62,19 +65,22 @@ const MAX_OWNER_TOKEN_LENGTH = 128
 const readOwner = (location: CacheLocation, directory: CacheOwnedDirectory): LockOwner | undefined => {
   try {
     const contents = readCacheOwner(location, directory, MAX_OWNER_BYTES)
-    const value = JSON.parse(contents ?? '') as Partial<LockOwner>
-    if (
-      typeof value.token === 'string' &&
-      value.token.length > 0 &&
-      value.token.length <= MAX_OWNER_TOKEN_LENGTH &&
-      Number.isSafeInteger(value.pid) &&
-      (value.pid ?? 0) > 0 &&
-      (value.pid ?? 0) <= MAX_OWNER_PID &&
-      typeof value.acquiredAt === 'string' &&
-      value.acquiredAt.length > 0 &&
-      value.acquiredAt.length <= MAX_OWNER_TIMESTAMP_LENGTH
-    ) {
-      return value as LockOwner
+    const parsed: unknown = JSON.parse(contents ?? '')
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      const value = parsed as Partial<LockOwner>
+      if (
+        typeof value.token === 'string' &&
+        value.token.length > 0 &&
+        value.token.length <= MAX_OWNER_TOKEN_LENGTH &&
+        Number.isSafeInteger(value.pid) &&
+        (value.pid ?? 0) > 0 &&
+        (value.pid ?? 0) <= MAX_OWNER_PID &&
+        typeof value.acquiredAt === 'string' &&
+        value.acquiredAt.length > 0 &&
+        value.acquiredAt.length <= MAX_OWNER_TIMESTAMP_LENGTH
+      ) {
+        return value as LockOwner
+      }
     }
   } catch (error) {
     if (!(error instanceof SyntaxError)) {
@@ -121,6 +127,23 @@ export const withOperationLock = <Result>(
   let candidateDirectory: CacheOwnedDirectory | undefined
   let ownedLockDirectory: CacheOwnedDirectory | undefined
 
+  const recoveryMarkerWasAbandoned = (directory: CacheOwnedDirectory, owner: LockOwner | undefined) => {
+    const abandoned = abandonedRecoveryMarkers.get(directory.path)
+    if (abandoned !== undefined) {
+      const matches =
+        abandoned.directory.path === directory.path &&
+        abandoned.directory.name === directory.name &&
+        abandoned.directory.dev === directory.dev &&
+        abandoned.directory.ino === directory.ino &&
+        owner?.token === abandoned.token
+      if (!matches) {
+        abandonedRecoveryMarkers.delete(directory.path)
+      }
+      return matches
+    }
+    return false
+  }
+
   const remainingMilliseconds = () => Math.max(0, LOCK_WAIT_MILLISECONDS - (now() - startedAt))
 
   const wait = (milliseconds: number) => {
@@ -130,6 +153,7 @@ export const withOperationLock = <Result>(
   const recoveryMarkerObservation = (): RecoveryMarkerObservation => {
     const directoryObservation = observeCacheOwnedDirectory(location, recoveryName)
     if (directoryObservation.kind === 'missing') {
+      abandonedRecoveryMarkers.delete(resolve(location.directory, recoveryName))
       return { kind: 'absent' }
     }
     if (directoryObservation.kind === 'changed') {
@@ -140,13 +164,15 @@ export const withOperationLock = <Result>(
     try {
       const owner = readOwner(location, recoveryDirectory)
       if (owner !== undefined) {
+        const abandoned = recoveryMarkerWasAbandoned(recoveryDirectory, owner)
         return {
           directory: recoveryDirectory,
           kind: 'observed',
           owner: { pid: owner.pid, token: owner.token },
-          stale: !processIsRunning(owner.pid),
+          stale: abandoned || !processIsRunning(owner.pid),
         }
       }
+      recoveryMarkerWasAbandoned(recoveryDirectory, owner)
       return {
         directory: recoveryDirectory,
         kind: 'observed',
@@ -167,9 +193,10 @@ export const withOperationLock = <Result>(
       return (
         currentOwner?.token === observation.owner.token &&
         currentOwner.pid === observation.owner.pid &&
-        !processIsRunning(currentOwner.pid)
+        (recoveryMarkerWasAbandoned(observation.directory, currentOwner) || !processIsRunning(currentOwner.pid))
       )
     }
+    recoveryMarkerWasAbandoned(observation.directory, currentOwner)
     return (
       currentOwner === undefined &&
       now() - cacheOwnedDirectoryMtimeMilliseconds(location, observation.directory) > RECOVERY_STALE_MILLISECONDS
@@ -179,7 +206,12 @@ export const withOperationLock = <Result>(
   const reclaimRecoveryMarker = (observation: Extract<RecoveryMarkerObservation, { kind: 'observed' }>) => {
     testHooks.afterRecoveryStaleObservation?.()
     if (cacheOwnedDirectoryIsCurrent(location, observation.directory)) {
-      quarantineCacheOwnedDirectory(location, observation.directory, () => recoveryMarkerRemainsStale(observation))
+      const reclaimed = quarantineCacheOwnedDirectory(location, observation.directory, () =>
+        recoveryMarkerRemainsStale(observation),
+      )
+      if (reclaimed) {
+        abandonedRecoveryMarkers.delete(observation.directory.path)
+      }
     }
   }
 
@@ -240,6 +272,30 @@ export const withOperationLock = <Result>(
     gateTransaction = true
   }
 
+  const releaseGate = () => {
+    if (gateTransaction) {
+      try {
+        gate?.exec('ROLLBACK')
+      } catch {
+        // Closing the connection below releases its operating-system lock.
+      }
+    }
+    gateTransaction = false
+    gate?.close()
+    gate = undefined
+  }
+
+  const beginGateWhileRecoveryOwned = (ownedMarker: OwnedRecoveryMarker) => {
+    let owned = false
+    beginGateTransaction(true)
+    if (recoveryMarkerIsOwned(ownedMarker)) {
+      owned = true
+    } else {
+      releaseGate()
+    }
+    return owned
+  }
+
   const acquireRecoveryMarker = (): OwnedRecoveryMarker => {
     let ownedMarker: OwnedRecoveryMarker | undefined
     while (ownedMarker === undefined) {
@@ -290,8 +346,7 @@ export const withOperationLock = <Result>(
     let recovered = false
     if (recoveryMarkerIsOwned(ownedMarker)) {
       try {
-        beginGateTransaction(true)
-        recovered = true
+        recovered = beginGateWhileRecoveryOwned(ownedMarker)
       } catch (error) {
         const category = sqliteFailureCategory(error)
         if (category === 'busy' || category === 'locked') {
@@ -303,8 +358,7 @@ export const withOperationLock = <Result>(
           if (recoveryMarkerIsOwned(ownedMarker)) {
             quarantineCorruptGate(error)
             if (recoveryMarkerIsOwned(ownedMarker)) {
-              beginGateTransaction(true)
-              recovered = true
+              recovered = beginGateWhileRecoveryOwned(ownedMarker)
             }
           }
         } else {
@@ -328,7 +382,9 @@ export const withOperationLock = <Result>(
       let cleanupError: unknown
       try {
         releaseOwnedLock(location, ownedMarker.directory, ownedMarker.token)
+        abandonedRecoveryMarkers.delete(ownedMarker.directory.path)
       } catch (error) {
+        abandonedRecoveryMarkers.set(ownedMarker.directory.path, ownedMarker)
         cleanupError = error
       }
       if (recoveryError !== undefined) {
@@ -394,14 +450,7 @@ export const withOperationLock = <Result>(
     }
     return wrapIo('Unable to coordinate Encephalon cache access.', error)
   } finally {
-    if (gateTransaction) {
-      try {
-        gate?.exec('ROLLBACK')
-      } catch {
-        // Closing the connection below releases its operating-system lock.
-      }
-    }
-    gate?.close()
+    releaseGate()
     try {
       const remainingCandidate = candidateDirectory ?? inspectCacheOwnedDirectory(location, candidateName)
       if (remainingCandidate !== undefined) {

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -36,11 +36,17 @@ type LockTestHooks = {
   afterRecoveryStaleObservation?: (() => void) | undefined
   afterStaleObservation?: (() => void) | undefined
   duringRecoveryObservation?: (() => void) | undefined
+  now?: (() => number) | undefined
 }
 
 type RecoveryMarkerObservation =
   | { kind: 'absent' }
-  | { kind: 'observed'; directory: CacheOwnedDirectory; stale: boolean }
+  | {
+      kind: 'observed'
+      directory: CacheOwnedDirectory
+      owner: Pick<LockOwner, 'pid' | 'token'> | undefined
+      stale: boolean
+    }
   | { kind: 'retry' }
 
 type OwnedRecoveryMarker = {
@@ -49,6 +55,7 @@ type OwnedRecoveryMarker = {
 }
 
 const MAX_OWNER_BYTES = 4096
+const MAX_OWNER_PID = 2_147_483_647
 const MAX_OWNER_TIMESTAMP_LENGTH = 64
 const MAX_OWNER_TOKEN_LENGTH = 128
 
@@ -62,6 +69,7 @@ const readOwner = (location: CacheLocation, directory: CacheOwnedDirectory): Loc
       value.token.length <= MAX_OWNER_TOKEN_LENGTH &&
       Number.isSafeInteger(value.pid) &&
       (value.pid ?? 0) > 0 &&
+      (value.pid ?? 0) <= MAX_OWNER_PID &&
       typeof value.acquiredAt === 'string' &&
       value.acquiredAt.length > 0 &&
       value.acquiredAt.length <= MAX_OWNER_TIMESTAMP_LENGTH
@@ -106,13 +114,14 @@ export const withOperationLock = <Result>(
   const recoveryName = 'operation-lock.recovery'
   const token = randomUUID()
   const candidateName = `operation.lock.${token}`
-  const startedAt = Date.now()
+  const now = testHooks.now ?? Date.now
+  const startedAt = now()
   let gate: DatabaseSync | undefined
   let gateTransaction = false
   let candidateDirectory: CacheOwnedDirectory | undefined
   let ownedLockDirectory: CacheOwnedDirectory | undefined
 
-  const remainingMilliseconds = () => Math.max(0, LOCK_WAIT_MILLISECONDS - (Date.now() - startedAt))
+  const remainingMilliseconds = () => Math.max(0, LOCK_WAIT_MILLISECONDS - (now() - startedAt))
 
   const wait = (milliseconds: number) => {
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds)
@@ -134,14 +143,15 @@ export const withOperationLock = <Result>(
         return {
           directory: recoveryDirectory,
           kind: 'observed',
+          owner: { pid: owner.pid, token: owner.token },
           stale: !processIsRunning(owner.pid),
         }
       }
       return {
         directory: recoveryDirectory,
         kind: 'observed',
-        stale:
-          Date.now() - cacheOwnedDirectoryMtimeMilliseconds(location, recoveryDirectory) > RECOVERY_STALE_MILLISECONDS,
+        owner: undefined,
+        stale: now() - cacheOwnedDirectoryMtimeMilliseconds(location, recoveryDirectory) > RECOVERY_STALE_MILLISECONDS,
       }
     } catch (error) {
       if (cacheOwnedDirectoryIsCurrent(location, recoveryDirectory)) {
@@ -151,10 +161,25 @@ export const withOperationLock = <Result>(
     }
   }
 
-  const reclaimRecoveryMarker = (recoveryDirectory: CacheOwnedDirectory) => {
+  const recoveryMarkerRemainsStale = (observation: Extract<RecoveryMarkerObservation, { kind: 'observed' }>) => {
+    const currentOwner = readOwner(location, observation.directory)
+    if (observation.owner !== undefined) {
+      return (
+        currentOwner?.token === observation.owner.token &&
+        currentOwner.pid === observation.owner.pid &&
+        !processIsRunning(currentOwner.pid)
+      )
+    }
+    return (
+      currentOwner === undefined &&
+      now() - cacheOwnedDirectoryMtimeMilliseconds(location, observation.directory) > RECOVERY_STALE_MILLISECONDS
+    )
+  }
+
+  const reclaimRecoveryMarker = (observation: Extract<RecoveryMarkerObservation, { kind: 'observed' }>) => {
     testHooks.afterRecoveryStaleObservation?.()
-    if (cacheOwnedDirectoryIsCurrent(location, recoveryDirectory)) {
-      quarantineCacheOwnedDirectory(location, recoveryDirectory)
+    if (cacheOwnedDirectoryIsCurrent(location, observation.directory)) {
+      quarantineCacheOwnedDirectory(location, observation.directory, () => recoveryMarkerRemainsStale(observation))
     }
   }
 
@@ -181,7 +206,7 @@ export const withOperationLock = <Result>(
         })
       }
       if (observation.kind === 'observed' && observation.stale) {
-        reclaimRecoveryMarker(observation.directory)
+        reclaimRecoveryMarker(observation)
       }
       if (observation.kind === 'observed') {
         wait(Math.min(RECOVERY_POLL_MILLISECONDS, remainingMilliseconds()))
@@ -218,6 +243,11 @@ export const withOperationLock = <Result>(
   const acquireRecoveryMarker = (): OwnedRecoveryMarker => {
     let ownedMarker: OwnedRecoveryMarker | undefined
     while (ownedMarker === undefined) {
+      if (remainingMilliseconds() === 0) {
+        return fail('CACHE_BUSY', 'Timed out waiting for the Encephalon operation lock.', {
+          timeoutMilliseconds: LOCK_WAIT_MILLISECONDS,
+        })
+      }
       try {
         const recoveryDirectory = createCacheOwnedDirectory(location, recoveryName)
         writeCacheOwner(
@@ -233,6 +263,8 @@ export const withOperationLock = <Result>(
         const candidate = { directory: recoveryDirectory, token }
         if (recoveryMarkerIsOwned(candidate)) {
           ownedMarker = candidate
+        } else {
+          wait(Math.min(RECOVERY_POLL_MILLISECONDS, remainingMilliseconds()))
         }
       } catch (error) {
         const existingRecovery = (error as NodeJS.ErrnoException).code === 'EEXIST'
@@ -246,7 +278,7 @@ export const withOperationLock = <Result>(
         }
         const observation = recoveryMarkerObservation()
         if (observation.kind === 'observed' && observation.stale) {
-          reclaimRecoveryMarker(observation.directory)
+          reclaimRecoveryMarker(observation)
         }
         wait(Math.min(RECOVERY_POLL_MILLISECONDS, remainingMilliseconds()))
       }
@@ -287,14 +319,23 @@ export const withOperationLock = <Result>(
     let recovered = false
     while (!recovered) {
       const ownedMarker = acquireRecoveryMarker()
+      let recoveryError: unknown
       try {
         recovered = recoverGateWhileOwned(ownedMarker)
-      } finally {
-        try {
-          releaseOwnedLock(location, ownedMarker.directory, ownedMarker.token)
-        } catch {
-          // Recovery-marker cleanup cannot replace the gate recovery result.
-        }
+      } catch (error) {
+        recoveryError = error
+      }
+      let cleanupError: unknown
+      try {
+        releaseOwnedLock(location, ownedMarker.directory, ownedMarker.token)
+      } catch (error) {
+        cleanupError = error
+      }
+      if (recoveryError !== undefined) {
+        throw recoveryError
+      }
+      if (cleanupError !== undefined) {
+        throw cleanupError
       }
     }
   }

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1914,6 +1914,104 @@ describe('SQLite cache and reads', () => {
     assert.equal(existsSync(recoveryPath), false)
   })
 
+  test('waits for an old recovery marker while its owner process remains live', () => {
+    const root = createRoot()
+    const recoveryPath = join(cacheDirectoryPath(root), 'operation-lock.recovery')
+    mkdirSync(recoveryPath, { recursive: true })
+    writeFileSync(
+      join(recoveryPath, 'owner.json'),
+      `${JSON.stringify({ acquiredAt: '2026-08-06T10:00:00.000Z', pid: process.pid, token: 'live-owner' })}\n`,
+    )
+    let observations = 0
+
+    assert.equal(
+      withOperationLock(root, () => 'entered', {
+        duringRecoveryObservation: () => {
+          observations += 1
+          if (observations === 2) {
+            rmSync(recoveryPath, { recursive: true })
+          }
+        },
+      }),
+      'entered',
+    )
+    assert.equal(observations, 2)
+  })
+
+  test('reacquires recovery ownership when its owner token is replaced before gate recovery', () => {
+    const root = createRoot()
+    const cachePath = cacheDirectoryPath(root)
+    const recoveryPath = join(cachePath, 'operation-lock.recovery')
+    mkdirSync(cachePath, { recursive: true })
+    writeFileSync(join(cachePath, 'operation-lock.sqlite'), 'not a sqlite database')
+    let recoveryCreations = 0
+    let replacementObservations = 0
+
+    assert.equal(
+      withOperationLock(root, () => 'entered', {
+        afterRecoveryCreation: () => {
+          recoveryCreations += 1
+          if (recoveryCreations === 1) {
+            writeFileSync(
+              join(recoveryPath, 'owner.json'),
+              `${JSON.stringify({ acquiredAt: new Date().toISOString(), pid: process.pid, token: 'replacement' })}\n`,
+            )
+          }
+        },
+        duringRecoveryObservation: () => {
+          replacementObservations += 1
+          rmSync(recoveryPath, { recursive: true })
+        },
+      }),
+      'entered',
+    )
+    assert.equal(recoveryCreations, 2)
+    assert.equal(replacementObservations, 1)
+  })
+
+  test('preserves a replacement recovery token installed immediately before cleanup', () => {
+    const root = createRoot()
+    const cachePath = cacheDirectoryPath(root)
+    const recoveryPath = join(cachePath, 'operation-lock.recovery')
+    const replacementOwner = `${JSON.stringify({
+      acquiredAt: new Date().toISOString(),
+      pid: process.pid,
+      token: 'cleanup-replacement',
+    })}\n`
+    mkdirSync(cachePath, { recursive: true })
+    writeFileSync(join(cachePath, 'operation-lock.sqlite'), 'not a sqlite database')
+    cacheLocationTestHooks.beforeQuarantineRename = path => {
+      if (basename(path) === 'operation-lock.recovery') {
+        cacheLocationTestHooks.beforeQuarantineRename = undefined
+        writeFileSync(join(path, 'owner.json'), replacementOwner)
+      }
+    }
+
+    assert.equal(
+      withOperationLock(root, () => 'entered'),
+      'entered',
+    )
+    assert.equal(readFileSync(join(recoveryPath, 'owner.json'), 'utf8'), replacementOwner)
+  })
+
+  test('does not replace a successful operation result with recovery-marker cleanup failure', () => {
+    const root = createRoot()
+    const cachePath = cacheDirectoryPath(root)
+    mkdirSync(cachePath, { recursive: true })
+    writeFileSync(join(cachePath, 'operation-lock.sqlite'), 'not a sqlite database')
+    cacheLocationTestHooks.beforeQuarantineRename = path => {
+      if (basename(path) === 'operation-lock.recovery') {
+        cacheLocationTestHooks.beforeQuarantineRename = undefined
+        throw new Error('recovery cleanup fault')
+      }
+    }
+
+    assert.equal(
+      withOperationLock(root, () => 'primary result'),
+      'primary result',
+    )
+  })
+
   test('reobserves a recovery marker that disappears between directory lstat and realpath', () => {
     const root = createRoot()
     const recoveryPath = join(cacheDirectoryPath(root), 'operation-lock.recovery')

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1984,14 +1984,35 @@ describe('SQLite cache and reads', () => {
     const root = createRoot()
     const recoveryPath = join(cacheDirectoryPath(root), 'operation-lock.recovery')
     mkdirSync(recoveryPath, { recursive: true })
-    writeFileSync(join(recoveryPath, 'owner.json'), 'x'.repeat(4097))
+    const oversizedOwner = `${JSON.stringify({
+      acquiredAt: new Date().toISOString(),
+      padding: 'x'.repeat(4096),
+      pid: process.pid,
+      token: 'oversized-live-owner',
+    })}\n`
+    assert.ok(Buffer.byteLength(oversizedOwner) > 4096)
+    writeFileSync(join(recoveryPath, 'owner.json'), oversizedOwner)
     const oldTimestamp = new Date('2026-08-06T10:00:00.000Z')
     utimesSync(recoveryPath, oldTimestamp, oldTimestamp)
+    let observations = 0
+    let staleCallbacks = 0
 
     assert.equal(
-      withOperationLock(root, () => 'entered'),
+      withOperationLock(root, () => 'entered', {
+        afterRecoveryStaleObservation: () => {
+          staleCallbacks += 1
+        },
+        duringRecoveryObservation: () => {
+          observations += 1
+          if (observations === 2) {
+            rmSync(recoveryPath, { recursive: true })
+          }
+        },
+      }),
       'entered',
     )
+    assert.equal(observations, 1)
+    assert.equal(staleCallbacks, 1)
   })
 
   test('reacquires recovery ownership when its owner token is replaced before gate recovery', () => {
@@ -2085,6 +2106,68 @@ describe('SQLite cache and reads', () => {
       }),
       'entered on retry',
     )
+  })
+
+  test('preserves live token and identity replacements for an abandoned recovery marker', () => {
+    const cases = ['replacement-token', 'replacement-identity'] as const
+    for (const replacement of cases) {
+      const root = createRoot()
+      const cachePath = cacheDirectoryPath(root)
+      const recoveryPath = join(cachePath, 'operation-lock.recovery')
+      const displacedAbandonedPath = join(root, `${replacement}-abandoned`)
+      const preservedReplacementPath = join(root, `${replacement}-preserved`)
+      mkdirSync(cachePath, { recursive: true })
+      writeFileSync(join(cachePath, 'operation-lock.sqlite'), 'not a sqlite database')
+      cacheLocationTestHooks.beforeQuarantineRename = path => {
+        if (basename(path) === 'operation-lock.recovery') {
+          cacheLocationTestHooks.beforeQuarantineRename = undefined
+          throw new Error('recovery cleanup fault')
+        }
+      }
+
+      assert.throws(() => withOperationLock(root, () => 'not entered'))
+      const abandonedIdentity = statSync(recoveryPath, { bigint: true })
+      const abandonedOwner = JSON.parse(readFileSync(join(recoveryPath, 'owner.json'), 'utf8')) as {
+        acquiredAt: string
+        pid: number
+        token: string
+      }
+      const replacementOwner =
+        replacement === 'replacement-token' ? { ...abandonedOwner, token: 'live-replacement-token' } : abandonedOwner
+      if (replacement === 'replacement-identity') {
+        renameSync(recoveryPath, displacedAbandonedPath)
+        mkdirSync(recoveryPath)
+      }
+      writeFileSync(join(recoveryPath, 'owner.json'), `${JSON.stringify(replacementOwner)}\n`)
+      const replacementIdentity = statSync(recoveryPath, { bigint: true })
+      assert.equal(sameCacheEntryIdentity(abandonedIdentity, replacementIdentity), replacement === 'replacement-token')
+      let observations = 0
+      let staleCallbacks = 0
+
+      assert.equal(
+        withOperationLock(root, () => 'entered', {
+          afterRecoveryStaleObservation: () => {
+            staleCallbacks += 1
+          },
+          duringRecoveryObservation: () => {
+            observations += 1
+            assert.deepEqual(JSON.parse(readFileSync(join(recoveryPath, 'owner.json'), 'utf8')), replacementOwner)
+            assert.equal(sameCacheEntryIdentity(replacementIdentity, statSync(recoveryPath, { bigint: true })), true)
+            if (observations === 2) {
+              renameSync(recoveryPath, preservedReplacementPath)
+            }
+          },
+        }),
+        'entered',
+      )
+      assert.equal(observations, 2, replacement)
+      assert.equal(staleCallbacks, 0, replacement)
+      assert.equal(
+        sameCacheEntryIdentity(replacementIdentity, statSync(preservedReplacementPath, { bigint: true })),
+        true,
+      )
+      assert.deepEqual(JSON.parse(readFileSync(join(preservedReplacementPath, 'owner.json'), 'utf8')), replacementOwner)
+    }
   })
 
   test('reobserves a recovery marker that disappears between directory lstat and realpath', () => {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1919,12 +1919,17 @@ describe('SQLite cache and reads', () => {
     const ownerCases = [
       { acquiredAt: '2026-08-06T10:00:00.000Z', expectedObservations: 2, token: 'old-live-owner' },
       { acquiredAt: 'not-a-date', expectedObservations: 2, token: 'unparseable-date-live-owner' },
+      { acquiredAt: 'x'.repeat(64), expectedObservations: 2, token: 'timestamp-boundary' },
+      { acquiredAt: '2026-08-06T10:00:00.000Z', expectedObservations: 2, token: 'x'.repeat(128) },
+      { acquiredAt: '', expectedObservations: 1, token: 'empty-timestamp' },
+      { acquiredAt: 'x'.repeat(65), expectedObservations: 1, token: 'long-timestamp' },
+      { acquiredAt: '2026-08-06T10:00:00.000Z', expectedObservations: 1, token: '' },
       { acquiredAt: '2026-08-06T10:00:00.000Z', expectedObservations: 1, token: 'x'.repeat(129) },
       {
         acquiredAt: '2026-08-06T10:00:00.000Z',
         expectedObservations: 1,
-        pid: Number.MAX_SAFE_INTEGER + 1,
-        token: 'unsafe-pid',
+        pid: 2_147_483_648,
+        token: 'unsupported-pid',
       },
     ] as const
 
@@ -2015,11 +2020,12 @@ describe('SQLite cache and reads', () => {
     assert.equal(readFileSync(join(recoveryPath, 'owner.json'), 'utf8'), replacementOwner)
   })
 
-  test('does not replace a successful operation result with recovery-marker cleanup failure', () => {
+  test('does not enter the protected operation after recovery-marker cleanup fails', () => {
     const root = createRoot()
     const cachePath = cacheDirectoryPath(root)
     mkdirSync(cachePath, { recursive: true })
     writeFileSync(join(cachePath, 'operation-lock.sqlite'), 'not a sqlite database')
+    let operationEntered = false
     cacheLocationTestHooks.beforeQuarantineRename = path => {
       if (basename(path) === 'operation-lock.recovery') {
         cacheLocationTestHooks.beforeQuarantineRename = undefined
@@ -2027,10 +2033,18 @@ describe('SQLite cache and reads', () => {
       }
     }
 
-    assert.equal(
-      withOperationLock(root, () => 'primary result'),
-      'primary result',
+    assert.throws(
+      () =>
+        withOperationLock(root, () => {
+          operationEntered = true
+          return 'primary result'
+        }),
+      (error: unknown) => {
+        assert.equal((error as { cause?: { message?: unknown } }).cause?.message, 'recovery cleanup fault')
+        return true
+      },
     )
+    assert.equal(operationEntered, false)
   })
 
   test('reobserves a recovery marker that disappears between directory lstat and realpath', () => {
@@ -2208,38 +2222,63 @@ describe('SQLite cache and reads', () => {
     assert.match(readFileSync(join(displacedPath, 'owner.json'), 'utf8'), /observed-predecessor/u)
   })
 
-  test('reobserves a replacement recovery marker before reclaiming it', async () => {
+  test('reobserves a live owner token installed before stale-marker reclaim', () => {
     const root = createRoot()
     const recoveryPath = join(root, 'node_modules', '.cache', 'encephalon', 'operation-lock.recovery')
-    const displacedPath = join(root, 'displaced-recovery-predecessor')
-    const removalResult = join(root, 'recovery-successor-removal')
-    const fixture = join(import.meta.dirname, 'fixtures', 'remove-path-after-delay.ts')
     mkdirSync(recoveryPath, { recursive: true })
     writeFileSync(
       join(recoveryPath, 'owner.json'),
       `${JSON.stringify({ acquiredAt: new Date().toISOString(), pid: 2_147_483_647, token: 'predecessor' })}\n`,
     )
-    let remover: ReturnType<typeof spawn> | undefined
+    let observations = 0
 
     assert.equal(
       withOperationLock(root, () => 'entered', {
         afterRecoveryStaleObservation: () => {
-          renameSync(recoveryPath, displacedPath)
-          mkdirSync(recoveryPath)
           writeFileSync(
             join(recoveryPath, 'owner.json'),
             `${JSON.stringify({ acquiredAt: new Date().toISOString(), pid: process.pid, token: 'successor' })}\n`,
           )
-          remover = spawn(process.execPath, [fixture, recoveryPath, removalResult, '100'], { stdio: 'inherit' })
+        },
+        duringRecoveryObservation: () => {
+          observations += 1
+          if (observations === 2) {
+            rmSync(recoveryPath, { recursive: true })
+          }
         },
       }),
       'entered',
     )
-    assert.ok(remover !== undefined)
-    if (remover.exitCode === null) {
-      await once(remover, 'exit')
+    assert.equal(observations, 2)
+  })
+
+  test('applies the total deadline after recovery ownership is repeatedly lost', () => {
+    const root = createRoot()
+    const cachePath = cacheDirectoryPath(root)
+    const recoveryPath = join(cachePath, 'operation-lock.recovery')
+    mkdirSync(cachePath, { recursive: true })
+    writeFileSync(join(cachePath, 'operation-lock.sqlite'), 'not a sqlite database')
+    let recoveryCreations = 0
+    const clock = [0, 0, 0, 60_000]
+    const hooks = {
+      afterRecoveryCreation: () => {
+        recoveryCreations += 1
+        rmSync(recoveryPath, { recursive: true })
+        if (recoveryCreations === 3) {
+          throw new Error('recovery deadline was not applied')
+        }
+      },
+      now: () => clock.shift() ?? 60_000,
     }
-    assert.equal(readFileSync(removalResult, 'utf8'), 'removed')
+
+    assert.throws(
+      () => withOperationLock(root, () => 'entered', hooks),
+      (error: unknown) => {
+        assert.equal((error as { code?: unknown }).code, 'CACHE_BUSY')
+        return true
+      },
+    )
+    assert.equal(recoveryCreations, 1)
   })
 
   test('cleans only the captured recovery directory identity', () => {
@@ -2247,25 +2286,81 @@ describe('SQLite cache and reads', () => {
     const cachePath = cacheDirectoryPath(root)
     const recoveryPath = join(cachePath, 'operation-lock.recovery')
     const displacedPath = join(root, 'displaced-owned-recovery')
+    const completedSuccessorPath = join(root, 'completed-successor-recovery')
     mkdirSync(cachePath, { recursive: true })
     writeFileSync(join(cachePath, 'operation-lock.sqlite'), 'not a sqlite database')
+    let predecessorIdentity: { dev: bigint; ino: bigint } | undefined
+    let successorIdentity: { dev: bigint; ino: bigint } | undefined
+    let recoveryCreations = 0
 
-    assert.throws(
-      () =>
-        withOperationLock(root, () => 'entered', {
-          afterRecoveryCreation: () => {
+    assert.equal(
+      withOperationLock(root, () => 'entered', {
+        afterRecoveryCreation: () => {
+          recoveryCreations += 1
+          if (recoveryCreations === 1) {
+            predecessorIdentity = statSync(recoveryPath, { bigint: true })
             renameSync(recoveryPath, displacedPath)
             mkdirSync(recoveryPath)
-            writeFileSync(join(recoveryPath, 'owner.json'), readFileSync(join(displacedPath, 'owner.json')))
+            writeFileSync(
+              join(recoveryPath, 'owner.json'),
+              `${JSON.stringify({
+                acquiredAt: new Date().toISOString(),
+                pid: process.pid,
+                token: 'identity-successor',
+              })}\n`,
+            )
             writeFileSync(join(recoveryPath, 'successor-sentinel'), 'successor recovery')
-          },
-        }),
-      (error: unknown) => {
-        assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED')
-        return true
-      },
+            successorIdentity = statSync(recoveryPath, { bigint: true })
+          }
+        },
+        duringRecoveryObservation: () => {
+          renameSync(recoveryPath, completedSuccessorPath)
+        },
+      }),
+      'entered',
     )
-    assert.equal(readFileSync(join(recoveryPath, 'successor-sentinel'), 'utf8'), 'successor recovery')
+    assert.equal(recoveryCreations, 2)
+    assert.ok(predecessorIdentity !== undefined)
+    assert.ok(successorIdentity !== undefined)
+    assert.equal(sameCacheEntryIdentity(predecessorIdentity, statSync(displacedPath, { bigint: true })), true)
+    assert.equal(sameCacheEntryIdentity(successorIdentity, statSync(completedSuccessorPath, { bigint: true })), true)
+    assert.equal(readFileSync(join(completedSuccessorPath, 'successor-sentinel'), 'utf8'), 'successor recovery')
+  })
+
+  test('reacquires recovery ownership lost while quarantining the corrupt gate', () => {
+    const root = createRoot()
+    const cachePath = cacheDirectoryPath(root)
+    const recoveryPath = join(cachePath, 'operation-lock.recovery')
+    mkdirSync(cachePath, { recursive: true })
+    writeFileSync(join(cachePath, 'operation-lock.sqlite'), 'not a sqlite database')
+    let recoveryCreations = 0
+    let replacementObservations = 0
+    let recoveryLost = false
+    cacheLocationTestHooks.afterQuarantineRename = path => {
+      if (!recoveryLost && basename(path).includes('.operation-lock.sqlite.')) {
+        recoveryLost = true
+        writeFileSync(
+          join(recoveryPath, 'owner.json'),
+          `${JSON.stringify({ acquiredAt: new Date().toISOString(), pid: process.pid, token: 'gate-successor' })}\n`,
+        )
+      }
+    }
+
+    assert.equal(
+      withOperationLock(root, () => 'entered', {
+        afterRecoveryCreation: () => {
+          recoveryCreations += 1
+        },
+        duringRecoveryObservation: () => {
+          replacementObservations += 1
+          rmSync(recoveryPath, { recursive: true })
+        },
+      }),
+      'entered',
+    )
+    assert.equal(recoveryLost, true)
+    assert.equal(recoveryCreations, 2)
+    assert.equal(replacementObservations, 1)
   })
 
   test('preserves directory replacements at lock and recovery quarantine paths', () => {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1964,6 +1964,36 @@ describe('SQLite cache and reads', () => {
     }
   })
 
+  test('reclaims stale owner metadata with non-record JSON shapes', () => {
+    for (const owner of [null, [], 42]) {
+      const root = createRoot()
+      const recoveryPath = join(cacheDirectoryPath(root), 'operation-lock.recovery')
+      mkdirSync(recoveryPath, { recursive: true })
+      writeFileSync(join(recoveryPath, 'owner.json'), `${JSON.stringify(owner)}\n`)
+      const oldTimestamp = new Date('2026-08-06T10:00:00.000Z')
+      utimesSync(recoveryPath, oldTimestamp, oldTimestamp)
+
+      assert.equal(
+        withOperationLock(root, () => 'entered'),
+        'entered',
+      )
+    }
+  })
+
+  test('reclaims a stale oversized recovery owner without reading it', () => {
+    const root = createRoot()
+    const recoveryPath = join(cacheDirectoryPath(root), 'operation-lock.recovery')
+    mkdirSync(recoveryPath, { recursive: true })
+    writeFileSync(join(recoveryPath, 'owner.json'), 'x'.repeat(4097))
+    const oldTimestamp = new Date('2026-08-06T10:00:00.000Z')
+    utimesSync(recoveryPath, oldTimestamp, oldTimestamp)
+
+    assert.equal(
+      withOperationLock(root, () => 'entered'),
+      'entered',
+    )
+  })
+
   test('reacquires recovery ownership when its owner token is replaced before gate recovery', () => {
     const root = createRoot()
     const cachePath = cacheDirectoryPath(root)
@@ -2020,7 +2050,7 @@ describe('SQLite cache and reads', () => {
     assert.equal(readFileSync(join(recoveryPath, 'owner.json'), 'utf8'), replacementOwner)
   })
 
-  test('does not enter the protected operation after recovery-marker cleanup fails', () => {
+  test('reclaims an exact recovery marker after its cleanup fails', () => {
     const root = createRoot()
     const cachePath = cacheDirectoryPath(root)
     mkdirSync(cachePath, { recursive: true })
@@ -2045,6 +2075,16 @@ describe('SQLite cache and reads', () => {
       },
     )
     assert.equal(operationEntered, false)
+    let clockReads = 0
+    assert.equal(
+      withOperationLock(root, () => 'entered on retry', {
+        now: () => {
+          clockReads += 1
+          return clockReads <= 10 ? 0 : 60_000
+        },
+      }),
+      'entered on retry',
+    )
   })
 
   test('reobserves a recovery marker that disappears between directory lstat and realpath', () => {
@@ -2225,16 +2265,22 @@ describe('SQLite cache and reads', () => {
   test('reobserves a live owner token installed before stale-marker reclaim', () => {
     const root = createRoot()
     const recoveryPath = join(root, 'node_modules', '.cache', 'encephalon', 'operation-lock.recovery')
+    const completedProcess = spawnSync(process.execPath, ['-e', ''])
+    assert.equal(completedProcess.status, 0)
+    assert.ok(completedProcess.pid !== undefined)
     mkdirSync(recoveryPath, { recursive: true })
     writeFileSync(
       join(recoveryPath, 'owner.json'),
-      `${JSON.stringify({ acquiredAt: new Date().toISOString(), pid: 2_147_483_647, token: 'predecessor' })}\n`,
+      `${JSON.stringify({ acquiredAt: new Date().toISOString(), pid: completedProcess.pid, token: 'predecessor' })}\n`,
     )
     let observations = 0
+    let staleCallbacks = 0
 
     assert.equal(
       withOperationLock(root, () => 'entered', {
         afterRecoveryStaleObservation: () => {
+          staleCallbacks += 1
+          assert.equal(staleCallbacks, 1)
           writeFileSync(
             join(recoveryPath, 'owner.json'),
             `${JSON.stringify({ acquiredAt: new Date().toISOString(), pid: process.pid, token: 'successor' })}\n`,
@@ -2243,6 +2289,7 @@ describe('SQLite cache and reads', () => {
         duringRecoveryObservation: () => {
           observations += 1
           if (observations === 2) {
+            assert.match(readFileSync(join(recoveryPath, 'owner.json'), 'utf8'), /successor/u)
             rmSync(recoveryPath, { recursive: true })
           }
         },
@@ -2250,6 +2297,7 @@ describe('SQLite cache and reads', () => {
       'entered',
     )
     assert.equal(observations, 2)
+    assert.equal(staleCallbacks, 1)
   })
 
   test('applies the total deadline after recovery ownership is repeatedly lost', () => {
@@ -2342,6 +2390,42 @@ describe('SQLite cache and reads', () => {
         writeFileSync(
           join(recoveryPath, 'owner.json'),
           `${JSON.stringify({ acquiredAt: new Date().toISOString(), pid: process.pid, token: 'gate-successor' })}\n`,
+        )
+      }
+    }
+
+    assert.equal(
+      withOperationLock(root, () => 'entered', {
+        afterRecoveryCreation: () => {
+          recoveryCreations += 1
+        },
+        duringRecoveryObservation: () => {
+          replacementObservations += 1
+          rmSync(recoveryPath, { recursive: true })
+        },
+      }),
+      'entered',
+    )
+    assert.equal(recoveryLost, true)
+    assert.equal(recoveryCreations, 2)
+    assert.equal(replacementObservations, 1)
+  })
+
+  test('reacquires recovery ownership lost after the recovered gate begins', () => {
+    const root = createRoot()
+    const cachePath = cacheDirectoryPath(root)
+    const recoveryPath = join(cachePath, 'operation-lock.recovery')
+    mkdirSync(cachePath, { recursive: true })
+    writeFileSync(join(cachePath, 'operation-lock.sqlite'), 'not a sqlite database')
+    let recoveryCreations = 0
+    let replacementObservations = 0
+    let recoveryLost = false
+    cacheLocationTestHooks.afterDatabaseLockInitialisation = database => {
+      if (!recoveryLost && database.name === 'operation-lock.sqlite' && existsSync(recoveryPath)) {
+        recoveryLost = true
+        writeFileSync(
+          join(recoveryPath, 'owner.json'),
+          `${JSON.stringify({ acquiredAt: new Date().toISOString(), pid: process.pid, token: 'initialisation-successor' })}\n`,
         )
       }
     }

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -14,6 +14,7 @@ import {
   rmSync,
   statSync,
   symlinkSync,
+  utimesSync,
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -1914,28 +1915,48 @@ describe('SQLite cache and reads', () => {
     assert.equal(existsSync(recoveryPath), false)
   })
 
-  test('waits for an old recovery marker while its owner process remains live', () => {
-    const root = createRoot()
-    const recoveryPath = join(cacheDirectoryPath(root), 'operation-lock.recovery')
-    mkdirSync(recoveryPath, { recursive: true })
-    writeFileSync(
-      join(recoveryPath, 'owner.json'),
-      `${JSON.stringify({ acquiredAt: '2026-08-06T10:00:00.000Z', pid: process.pid, token: 'live-owner' })}\n`,
-    )
-    let observations = 0
+  test('waits for bounded live recovery owners and reclaims stale malformed metadata', () => {
+    const ownerCases = [
+      { acquiredAt: '2026-08-06T10:00:00.000Z', expectedObservations: 2, token: 'old-live-owner' },
+      { acquiredAt: 'not-a-date', expectedObservations: 2, token: 'unparseable-date-live-owner' },
+      { acquiredAt: '2026-08-06T10:00:00.000Z', expectedObservations: 1, token: 'x'.repeat(129) },
+      {
+        acquiredAt: '2026-08-06T10:00:00.000Z',
+        expectedObservations: 1,
+        pid: Number.MAX_SAFE_INTEGER + 1,
+        token: 'unsafe-pid',
+      },
+    ] as const
 
-    assert.equal(
-      withOperationLock(root, () => 'entered', {
-        duringRecoveryObservation: () => {
-          observations += 1
-          if (observations === 2) {
-            rmSync(recoveryPath, { recursive: true })
-          }
-        },
-      }),
-      'entered',
-    )
-    assert.equal(observations, 2)
+    for (const ownerCase of ownerCases) {
+      const root = createRoot()
+      const recoveryPath = join(cacheDirectoryPath(root), 'operation-lock.recovery')
+      mkdirSync(recoveryPath, { recursive: true })
+      writeFileSync(
+        join(recoveryPath, 'owner.json'),
+        `${JSON.stringify({
+          acquiredAt: ownerCase.acquiredAt,
+          pid: 'pid' in ownerCase ? ownerCase.pid : process.pid,
+          token: ownerCase.token,
+        })}\n`,
+      )
+      const oldTimestamp = new Date('2026-08-06T10:00:00.000Z')
+      utimesSync(recoveryPath, oldTimestamp, oldTimestamp)
+      let observations = 0
+
+      assert.equal(
+        withOperationLock(root, () => 'entered', {
+          duringRecoveryObservation: () => {
+            observations += 1
+            if (observations === 2) {
+              rmSync(recoveryPath, { recursive: true })
+            }
+          },
+        }),
+        'entered',
+      )
+      assert.equal(observations, ownerCase.expectedObservations)
+    }
   })
 
   test('reacquires recovery ownership when its owner token is replaced before gate recovery', () => {

--- a/test/sqlite-policy.test.ts
+++ b/test/sqlite-policy.test.ts
@@ -182,4 +182,33 @@ describe('SQLite consumer policies', () => {
       cacheLocationTestHooks.afterDatabaseLockInitialisation = undefined
     }
   })
+
+  test('operation gate reports contention after one corrupt recovery retry', () => {
+    const contentionCases = policyCases.filter(entry => entry.category === 'busy' || entry.category === 'locked')
+    for (const entry of contentionCases) {
+      const root = createRoot()
+      let gateInitialisations = 0
+      cacheLocationTestHooks.afterDatabaseLockInitialisation = () => {
+        gateInitialisations += 1
+        if (gateInitialisations <= 2) {
+          throw corruptRecoveryError
+        }
+        if (gateInitialisations === 3) {
+          throw entry.error
+        }
+      }
+
+      assert.throws(
+        () => withOperationLock(root, () => 'entered'),
+        (error: unknown) => {
+          assert.ok(error instanceof EncephalonError)
+          assert.equal(error.code, 'CACHE_BUSY', entry.category)
+          assert.deepEqual(error.details, { timeoutMilliseconds: 60_000 }, entry.category)
+          return true
+        },
+      )
+      assert.equal(gateInitialisations, 3, entry.category)
+      cacheLocationTestHooks.afterDatabaseLockInitialisation = undefined
+    }
+  })
 })


### PR DESCRIPTION
## Human summary

Corrupt cache-lock recovery can no longer overlap or delete another process's recovery marker, even when recovery is delayed, ownership changes, or cleanup fails.

## Summary

- Treat a valid live recovery owner as owned regardless of marker age, while retaining bounded recovery for dead, malformed, oversized, or ownerless markers.
- Revalidate the captured directory identity and random owner token immediately before every recovery action, successful gate initialisation, reclaim, and cleanup.
- Preserve one total acquisition deadline and stable `CACHE_BUSY` behaviour across initial and retried SQLite gate contention.
- Bound and validate owner metadata, including JSON shape, byte size, timestamp/token lengths, and supported PID range.
- Prevent cleanup failures from entering the protected operation, while allowing only the exact abandoned in-process identity and token to be reclaimed on a later call.
- Add deterministic ownership-loss, replacement, deadline, cleanup, malformed-owner, and real cross-process contention coverage.
- Document the maintained recovery and atomic-publication contract.

Linear: https://linear.app/marcoappio/issue/MAR-2546/locking-make-gate-recovery-ownership-token-safe
