### PR TITLE
[MAR-2570] Verify repository identity files

### DIFF
--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-12 for audited snapshot `eaff22439ae593b4d38a5a801a7d56704b9b5754`.
+Last reviewed: 2026-08-12 for audited snapshot `1c7c219ed52c23e56da060ae4082dc5eca9e3e78`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 
@@ -12,8 +12,8 @@ This document is the concise contract maintainers should update when public beha
 - API failures that users can reasonably handle throw `EncephalonError` with a stable code from `src/types.ts`.
 - CLI success writes one JSON value to stdout for JSON commands and exits `0`. Expected user errors write one structured JSON error to stderr and exit `2`. Validation failures print the validation result to stdout and exit `2`.
 - User and agent command examples use the installed package manager binary form, `npx --no-install encephalon ...`, after the package has been installed at the repository root. Runtime execution still verifies that the executing package is the root `node_modules/encephalon` installation.
-- Git marker files and package manifests used for repository or executing-package identity are read through bounded, no-follow regular-file descriptors with stable identity and fatal UTF-8 decoding. Worktree administration targets are accepted only when their real-directory identity remains stable across native realpath resolution.
-- Executing package identity is cached only after its manifest has been verified successfully. Each repository root still reverifies its installed Encephalon manifest on every resolution.
+- Git marker files and package manifests used for repository or executing-package identity are read through bounded, no-follow regular-file descriptors with stable identity and fatal UTF-8 decoding. Their input and canonical directory generations must remain stable around the dependent read. Worktree administration targets are accepted only when their real-directory identity remains stable across native realpath resolution.
+- Executing package identity is cached only after its manifest and directory generation have been verified successfully. Each repository root still reverifies its installed Encephalon manifest and directory generation on every resolution; unsafe installed manifests use the generic root-install-required failure.
 
 ## Canonical Storage
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-12 for audited snapshot `925ca345bd3bdf1e9c3b30d4364ebd09ef0ab90e`.
+Last reviewed: 2026-08-12 for audited snapshot `34c8394af3a3f54729c56ebf5b3394e5bdf3e11c`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 
@@ -12,8 +12,8 @@ This document is the concise contract maintainers should update when public beha
 - API failures that users can reasonably handle throw `EncephalonError` with a stable code from `src/types.ts`.
 - CLI success writes one JSON value to stdout for JSON commands and exits `0`. Expected user errors write one structured JSON error to stderr and exit `2`. Validation failures print the validation result to stdout and exit `2`.
 - User and agent command examples use the installed package manager binary form, `npx --no-install encephalon ...`, after the package has been installed at the repository root. Runtime execution still verifies that the executing package is the root `node_modules/encephalon` installation.
-- Git marker files and package manifests used for repository or executing-package identity are read through bounded, no-follow regular-file descriptors with stable identity and fatal UTF-8 decoding. Their input and canonical directory generations must remain stable around the dependent read. Worktree administration targets are accepted only when their real-directory identity remains stable across native realpath resolution. Repository and executing-package ascent also revalidate each child generation after capturing its parent.
-- Executing package identity is cached only after its manifest and exact canonical directory generation have been verified successfully. Each repository root still reverifies its installed Encephalon manifest and directory generation on every resolution, and the installed generation must match the cached executing generation. The discovered repository generation remains verified through root-installation acceptance. Unsafe or malformed installed manifests use the generic root-install-required failure; operational filesystem failures retain the stable I/O error classification.
+- Git marker files and package manifests used for repository or executing-package identity are read through bounded, no-follow regular-file descriptors with stable identity and fatal UTF-8 decoding. Worktree targets must be non-empty and NUL-free, and are accepted only when their real-directory identity remains stable across native realpath resolution. Repository and executing-package ascent also revalidate each child generation after capturing its parent.
+- Executing package identity is cached only after its manifest and exact canonical directory generation have been verified successfully. Each repository root still reverifies its installed Encephalon manifest and directory generation on every resolution, and the installed generation must match the cached executing generation. The discovered repository generation remains verified through root-installation acceptance. Unsafe or malformed installed manifests use the generic root-install-required failure; path-generation changes use the stable repository classification while operational filesystem failures retain the stable I/O error classification.
 
 ## Canonical Storage
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-12 for audited snapshot `1c7c219ed52c23e56da060ae4082dc5eca9e3e78`.
+Last reviewed: 2026-08-12 for audited snapshot `925ca345bd3bdf1e9c3b30d4364ebd09ef0ab90e`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 
@@ -12,8 +12,8 @@ This document is the concise contract maintainers should update when public beha
 - API failures that users can reasonably handle throw `EncephalonError` with a stable code from `src/types.ts`.
 - CLI success writes one JSON value to stdout for JSON commands and exits `0`. Expected user errors write one structured JSON error to stderr and exit `2`. Validation failures print the validation result to stdout and exit `2`.
 - User and agent command examples use the installed package manager binary form, `npx --no-install encephalon ...`, after the package has been installed at the repository root. Runtime execution still verifies that the executing package is the root `node_modules/encephalon` installation.
-- Git marker files and package manifests used for repository or executing-package identity are read through bounded, no-follow regular-file descriptors with stable identity and fatal UTF-8 decoding. Their input and canonical directory generations must remain stable around the dependent read. Worktree administration targets are accepted only when their real-directory identity remains stable across native realpath resolution.
-- Executing package identity is cached only after its manifest and directory generation have been verified successfully. Each repository root still reverifies its installed Encephalon manifest and directory generation on every resolution; unsafe installed manifests use the generic root-install-required failure.
+- Git marker files and package manifests used for repository or executing-package identity are read through bounded, no-follow regular-file descriptors with stable identity and fatal UTF-8 decoding. Their input and canonical directory generations must remain stable around the dependent read. Worktree administration targets are accepted only when their real-directory identity remains stable across native realpath resolution. Repository and executing-package ascent also revalidate each child generation after capturing its parent.
+- Executing package identity is cached only after its manifest and exact canonical directory generation have been verified successfully. Each repository root still reverifies its installed Encephalon manifest and directory generation on every resolution, and the installed generation must match the cached executing generation. The discovered repository generation remains verified through root-installation acceptance. Unsafe or malformed installed manifests use the generic root-install-required failure; operational filesystem failures retain the stable I/O error classification.
 
 ## Canonical Storage
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -12,6 +12,8 @@ This document is the concise contract maintainers should update when public beha
 - API failures that users can reasonably handle throw `EncephalonError` with a stable code from `src/types.ts`.
 - CLI success writes one JSON value to stdout for JSON commands and exits `0`. Expected user errors write one structured JSON error to stderr and exit `2`. Validation failures print the validation result to stdout and exit `2`.
 - User and agent command examples use the installed package manager binary form, `npx --no-install encephalon ...`, after the package has been installed at the repository root. Runtime execution still verifies that the executing package is the root `node_modules/encephalon` installation.
+- Git marker files and package manifests used for repository or executing-package identity are read through bounded, no-follow regular-file descriptors with stable identity and fatal UTF-8 decoding. Worktree administration targets are accepted only when their real-directory identity remains stable across native realpath resolution.
+- Executing package identity is cached only after its manifest has been verified successfully. Each repository root still reverifies its installed Encephalon manifest on every resolution.
 
 ## Canonical Storage
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "check:publish": "bun run scripts/check-publish.ts",
     "lint": "ultracite check",
     "prepack": "bun run build && bun run check:package",
-    "test": "node --test test/*.test.ts",
+    "test": "bun run build && node --test test/*.test.ts",
     "typecheck": "tsc --project tsconfig.src.json --noEmit && tsc --project tsconfig.scripts.json --noEmit && tsc --project tsconfig.test.json --noEmit && tsc --project tsconfig.runtime-guard.json --noEmit"
   },
   "devDependencies": {

--- a/src/directory-witness.ts
+++ b/src/directory-witness.ts
@@ -1,0 +1,70 @@
+import type { BigIntStats } from 'node:fs'
+import { lstatSync, realpathSync } from 'node:fs'
+import { sameStableFileMetadata } from './file-identity.ts'
+
+type CaptureDirectoryOptions = {
+  afterCanonicalisation?: (() => void) | undefined
+  allowLink: boolean
+}
+
+export type DirectoryWitness = {
+  canonicalMetadata: BigIntStats
+  canonicalPath: string
+  path: string
+  pathMetadata: BigIntStats
+}
+
+export class DirectoryWitnessError extends Error {
+  constructor() {
+    super('The directory changed while it was being verified.')
+    this.name = 'DirectoryWitnessError'
+  }
+}
+
+const validPathEntry = (metadata: BigIntStats, allowLink: boolean) =>
+  metadata.isDirectory() || (allowLink && metadata.isSymbolicLink())
+
+const changed = (): never => {
+  throw new DirectoryWitnessError()
+}
+
+export const captureDirectoryWitness = (path: string, options: CaptureDirectoryOptions): DirectoryWitness => {
+  const pathMetadata = lstatSync(path, { bigint: true })
+  if (!validPathEntry(pathMetadata, options.allowLink)) {
+    return changed()
+  }
+  const canonicalPath = realpathSync.native(path)
+  const canonicalMetadata = lstatSync(canonicalPath, { bigint: true })
+  if (!canonicalMetadata.isDirectory() || canonicalMetadata.isSymbolicLink()) {
+    return changed()
+  }
+  options.afterCanonicalisation?.()
+  const finalPathMetadata = lstatSync(path, { bigint: true })
+  const finalCanonicalPath = realpathSync.native(path)
+  const finalCanonicalMetadata = lstatSync(canonicalPath, { bigint: true })
+  if (
+    !(
+      validPathEntry(finalPathMetadata, options.allowLink) && sameStableFileMetadata(pathMetadata, finalPathMetadata)
+    ) ||
+    finalCanonicalPath !== canonicalPath ||
+    !finalCanonicalMetadata.isDirectory() ||
+    finalCanonicalMetadata.isSymbolicLink() ||
+    !sameStableFileMetadata(canonicalMetadata, finalCanonicalMetadata)
+  ) {
+    return changed()
+  }
+  return { canonicalMetadata, canonicalPath, path, pathMetadata }
+}
+
+export const directoryWitnessIsCurrent = (witness: DirectoryWitness) => {
+  const pathMetadata = lstatSync(witness.path, { bigint: true })
+  const canonicalPath = realpathSync.native(witness.path)
+  const canonicalMetadata = lstatSync(witness.canonicalPath, { bigint: true })
+  return (
+    sameStableFileMetadata(witness.pathMetadata, pathMetadata) &&
+    canonicalPath === witness.canonicalPath &&
+    canonicalMetadata.isDirectory() &&
+    !canonicalMetadata.isSymbolicLink() &&
+    sameStableFileMetadata(witness.canonicalMetadata, canonicalMetadata)
+  )
+}

--- a/src/directory-witness.ts
+++ b/src/directory-witness.ts
@@ -73,7 +73,7 @@ export const revalidateDirectoryWitness = (witness: DirectoryWitness, options: R
     allowLink: witness.allowLink,
   })
   if (witnessMatches(witness, current)) {
-    return current
+    return
   }
   return changed()
 }

--- a/src/directory-witness.ts
+++ b/src/directory-witness.ts
@@ -1,13 +1,18 @@
 import type { BigIntStats } from 'node:fs'
 import { lstatSync, realpathSync } from 'node:fs'
-import { sameStableFileMetadata } from './file-identity.ts'
+import { sameStableEntryMetadata } from './filesystem-entry.ts'
 
 type CaptureDirectoryOptions = {
   afterCanonicalisation?: (() => void) | undefined
   allowLink: boolean
 }
 
+type RevalidateDirectoryOptions = {
+  afterCanonicalisation?: (() => void) | undefined
+}
+
 export type DirectoryWitness = {
+  allowLink: boolean
   canonicalMetadata: BigIntStats
   canonicalPath: string
   path: string
@@ -28,6 +33,12 @@ const changed = (): never => {
   throw new DirectoryWitnessError()
 }
 
+const witnessMatches = (expected: DirectoryWitness, current: DirectoryWitness) =>
+  expected.allowLink === current.allowLink &&
+  expected.canonicalPath === current.canonicalPath &&
+  sameStableEntryMetadata(expected.pathMetadata, current.pathMetadata) &&
+  sameStableEntryMetadata(expected.canonicalMetadata, current.canonicalMetadata)
+
 export const captureDirectoryWitness = (path: string, options: CaptureDirectoryOptions): DirectoryWitness => {
   const pathMetadata = lstatSync(path, { bigint: true })
   if (!validPathEntry(pathMetadata, options.allowLink)) {
@@ -44,27 +55,25 @@ export const captureDirectoryWitness = (path: string, options: CaptureDirectoryO
   const finalCanonicalMetadata = lstatSync(canonicalPath, { bigint: true })
   if (
     !(
-      validPathEntry(finalPathMetadata, options.allowLink) && sameStableFileMetadata(pathMetadata, finalPathMetadata)
+      validPathEntry(finalPathMetadata, options.allowLink) && sameStableEntryMetadata(pathMetadata, finalPathMetadata)
     ) ||
     finalCanonicalPath !== canonicalPath ||
     !finalCanonicalMetadata.isDirectory() ||
     finalCanonicalMetadata.isSymbolicLink() ||
-    !sameStableFileMetadata(canonicalMetadata, finalCanonicalMetadata)
+    !sameStableEntryMetadata(canonicalMetadata, finalCanonicalMetadata)
   ) {
     return changed()
   }
-  return { canonicalMetadata, canonicalPath, path, pathMetadata }
+  return { allowLink: options.allowLink, canonicalMetadata, canonicalPath, path, pathMetadata }
 }
 
-export const directoryWitnessIsCurrent = (witness: DirectoryWitness) => {
-  const pathMetadata = lstatSync(witness.path, { bigint: true })
-  const canonicalPath = realpathSync.native(witness.path)
-  const canonicalMetadata = lstatSync(witness.canonicalPath, { bigint: true })
-  return (
-    sameStableFileMetadata(witness.pathMetadata, pathMetadata) &&
-    canonicalPath === witness.canonicalPath &&
-    canonicalMetadata.isDirectory() &&
-    !canonicalMetadata.isSymbolicLink() &&
-    sameStableFileMetadata(witness.canonicalMetadata, canonicalMetadata)
-  )
+export const revalidateDirectoryWitness = (witness: DirectoryWitness, options: RevalidateDirectoryOptions = {}) => {
+  const current = captureDirectoryWitness(witness.path, {
+    afterCanonicalisation: options.afterCanonicalisation,
+    allowLink: witness.allowLink,
+  })
+  if (witnessMatches(witness, current)) {
+    return current
+  }
+  return changed()
 }

--- a/src/file-identity.ts
+++ b/src/file-identity.ts
@@ -1,0 +1,12 @@
+import type { BigIntStats } from 'node:fs'
+
+export const sameFileIdentity = (first: BigIntStats, second: BigIntStats) =>
+  first.dev === second.dev && first.ino === second.ino
+
+export const sameStableFileMetadata = (first: BigIntStats, second: BigIntStats) =>
+  sameFileIdentity(first, second) &&
+  first.size === second.size &&
+  first.mode === second.mode &&
+  first.birthtimeNs === second.birthtimeNs &&
+  first.mtimeNs === second.mtimeNs &&
+  first.ctimeNs === second.ctimeNs

--- a/src/filesystem-entry.ts
+++ b/src/filesystem-entry.ts
@@ -1,10 +1,10 @@
 import type { BigIntStats } from 'node:fs'
 
-export const sameFileIdentity = (first: BigIntStats, second: BigIntStats) =>
+export const sameEntryIdentity = (first: BigIntStats, second: BigIntStats) =>
   first.dev === second.dev && first.ino === second.ino
 
-export const sameStableFileMetadata = (first: BigIntStats, second: BigIntStats) =>
-  sameFileIdentity(first, second) &&
+export const sameStableEntryMetadata = (first: BigIntStats, second: BigIntStats) =>
+  sameEntryIdentity(first, second) &&
   first.size === second.size &&
   first.mode === second.mode &&
   first.birthtimeNs === second.birthtimeNs &&

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -19,7 +19,6 @@ export type DiscoverRepositoryInput = {
 type PackageIdentity = {
   directory: DirectoryWitness
   name: string
-  root: string
   version: string
 }
 
@@ -32,6 +31,7 @@ type RepositoryTestHooks = {
   afterExecutingManifestRead?: ((path: string) => void) | undefined
   afterExecutingParentCapture?: ((path: string) => void) | undefined
   afterGitDirectoryLstat?: ((path: string) => void) | undefined
+  afterGitMarkerDecision?: (() => void) | undefined
   afterInstalledManifestRead?: ((path: string) => void) | undefined
   afterRepositoryParentCapture?: ((path: string) => void) | undefined
   afterRootInstallation?: (() => void) | undefined
@@ -49,6 +49,10 @@ const isMissingOrNotDirectory = (error: unknown) => {
   const { code } = error as NodeJS.ErrnoException
   return code === 'ENOENT' || code === 'ENOTDIR'
 }
+const isPathReplacement = (error: unknown) =>
+  error instanceof DirectoryWitnessError ||
+  isMissingOrNotDirectory(error) ||
+  (error as NodeJS.ErrnoException).code === 'ELOOP'
 
 const captureLinkedDirectory = (path: string) => captureDirectoryWitness(path, { allowLink: true })
 const captureRealDirectory = (path: string, afterCanonicalisation?: () => void) =>
@@ -71,15 +75,18 @@ const validGitMarker = (directory: DirectoryWitness) => {
         const match = /^gitdir:\s*(.+)$/i.exec(decodeVerifiedUtf8(bytes).trim())
         if (match?.[1] !== undefined) {
           const target = match[1].trim()
-          const gitDirectory = isAbsolute(target) ? target : resolve(directory.canonicalPath, target)
-          const administrationDirectory = captureRealDirectory(gitDirectory, () =>
-            repositoryTestHooks.afterGitDirectoryLstat?.(gitDirectory),
-          )
-          revalidateDirectoryWitness(administrationDirectory)
-          markerValid = true
+          if (target.length > 0 && !target.includes('\0')) {
+            const gitDirectory = isAbsolute(target) ? target : resolve(directory.canonicalPath, target)
+            const administrationDirectory = captureRealDirectory(gitDirectory, () =>
+              repositoryTestHooks.afterGitDirectoryLstat?.(gitDirectory),
+            )
+            revalidateDirectoryWitness(administrationDirectory)
+            markerValid = true
+          }
         }
       }
     }
+    repositoryTestHooks.afterGitMarkerDecision?.()
     revalidateDirectoryWitness(directory)
     return markerValid
   } catch (error) {
@@ -90,11 +97,11 @@ const validGitMarker = (directory: DirectoryWitness) => {
   }
 }
 
-const captureRepositoryDirectory = (path: string, explicit: boolean) => {
+const captureRepositoryDirectory = (path: string, options: { explicit: boolean }) => {
   try {
     return captureLinkedDirectory(resolve(path))
   } catch (error) {
-    if (explicit && error instanceof DirectoryWitnessError) {
+    if (options.explicit && error instanceof DirectoryWitnessError) {
       return fail('INVALID_REPOSITORY', 'The explicit root is not a Git repository.')
     }
     return wrapIo('Unable to resolve the repository path.', error)
@@ -103,14 +110,14 @@ const captureRepositoryDirectory = (path: string, explicit: boolean) => {
 
 const discoverRepositoryWitness = (input: DiscoverRepositoryInput = {}) => {
   if (input.root !== undefined) {
-    const explicitRoot = captureRepositoryDirectory(input.root, true)
+    const explicitRoot = captureRepositoryDirectory(input.root, { explicit: true })
     if (validGitMarker(explicitRoot)) {
       return explicitRoot
     }
     return fail('INVALID_REPOSITORY', 'The explicit root is not a Git repository.')
   }
 
-  let current = captureRepositoryDirectory(input.start ?? process.cwd(), false)
+  let current = captureRepositoryDirectory(input.start ?? process.cwd(), { explicit: false })
   for (;;) {
     if (validGitMarker(current)) {
       return current
@@ -119,12 +126,15 @@ const discoverRepositoryWitness = (input: DiscoverRepositoryInput = {}) => {
     if (parentPath === current.canonicalPath) {
       return fail('REPOSITORY_NOT_FOUND', 'No Git repository was found.')
     }
-    const parent = captureRepositoryDirectory(parentPath, false)
-    repositoryTestHooks.afterRepositoryParentCapture?.(current.path)
+    const parent = captureRepositoryDirectory(parentPath, { explicit: false })
     try {
+      repositoryTestHooks.afterRepositoryParentCapture?.(current.path)
       revalidateDirectoryWitness(current)
-    } catch {
-      return fail('INVALID_REPOSITORY', 'The repository path changed during discovery.')
+    } catch (error) {
+      if (isPathReplacement(error)) {
+        return fail('INVALID_REPOSITORY', 'The repository path changed during discovery.')
+      }
+      return wrapIo('Unable to verify the repository path during discovery.', error)
     }
     current = parent
   }
@@ -145,7 +155,12 @@ const findExecutingPackage = (): PackageIdentity => {
   if (executingPackageIdentity !== undefined) {
     return executingPackageIdentity
   }
-  let current = captureLinkedDirectory(dirname(fileURLToPath(import.meta.url)))
+  let current: DirectoryWitness
+  try {
+    current = captureLinkedDirectory(dirname(fileURLToPath(import.meta.url)))
+  } catch (error) {
+    return wrapIo('Unable to inspect the executing package.', error)
+  }
   for (;;) {
     let packageJson: PackageManifest | undefined
     try {
@@ -164,7 +179,6 @@ const findExecutingPackage = (): PackageIdentity => {
         const identity = {
           directory: current,
           name: packageJson.name,
-          root: current.canonicalPath,
           version: packageJson.version,
         }
         executingPackageIdentity = identity
@@ -199,7 +213,8 @@ const installedVerificationError = (error: unknown): never => {
     error instanceof DirectoryWitnessError ||
     error instanceof VerifiedFileError ||
     error instanceof SyntaxError ||
-    isMissingOrNotDirectory(error)
+    isMissingOrNotDirectory(error) ||
+    (error as NodeJS.ErrnoException).code === 'ELOOP'
   ) {
     return rootInstallationRequired()
   }
@@ -217,7 +232,7 @@ const assertRootInstallationWitness = (root: DirectoryWitness) => {
 
   const executingPackage = findExecutingPackage()
   if (
-    comparablePath(installedDirectory.canonicalPath) === comparablePath(executingPackage.root) &&
+    comparablePath(installedDirectory.canonicalPath) === comparablePath(executingPackage.directory.canonicalPath) &&
     sameStableEntryMetadata(installedDirectory.canonicalMetadata, executingPackage.directory.canonicalMetadata)
   ) {
     let packageJson: PackageManifest
@@ -256,11 +271,14 @@ export const assertRootInstallation = (root: string) => assertRootInstallationWi
 export const resolveRepository = (input: { root?: string } = {}) => {
   const root = discoverRepositoryWitness(input)
   assertRootInstallationWitness(root)
-  repositoryTestHooks.afterRootInstallation?.()
   try {
+    repositoryTestHooks.afterRootInstallation?.()
     revalidateDirectoryWitness(root)
-  } catch {
-    return fail('INVALID_REPOSITORY', 'The repository path changed while its installation was verified.')
+  } catch (error) {
+    if (isPathReplacement(error)) {
+      return fail('INVALID_REPOSITORY', 'The repository path changed while its installation was verified.')
+    }
+    return wrapIo('Unable to verify the repository path after installation.', error)
   }
   return root.canonicalPath
 }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -4,9 +4,10 @@ import {
   captureDirectoryWitness,
   type DirectoryWitness,
   DirectoryWitnessError,
-  directoryWitnessIsCurrent,
+  revalidateDirectoryWitness,
 } from './directory-witness.ts'
 import { fail, wrapIo } from './errors.ts'
+import { sameStableEntryMetadata } from './filesystem-entry.ts'
 import { PACKAGE_VERSION } from './generated/version.ts'
 import { decodeVerifiedUtf8, readVerifiedRegularFile, VerifiedFileError } from './verified-file.ts'
 
@@ -16,6 +17,7 @@ export type DiscoverRepositoryInput = {
 }
 
 type PackageIdentity = {
+  directory: DirectoryWitness
   name: string
   root: string
   version: string
@@ -28,8 +30,11 @@ type PackageManifest = {
 
 type RepositoryTestHooks = {
   afterExecutingManifestRead?: ((path: string) => void) | undefined
+  afterExecutingParentCapture?: ((path: string) => void) | undefined
   afterGitDirectoryLstat?: ((path: string) => void) | undefined
   afterInstalledManifestRead?: ((path: string) => void) | undefined
+  afterRepositoryParentCapture?: ((path: string) => void) | undefined
+  afterRootInstallation?: (() => void) | undefined
 }
 
 export const repositoryTestHooks: RepositoryTestHooks = {}
@@ -40,17 +45,23 @@ const installRequiredMessage = 'Install Encephalon at the Git repository root be
 let executingPackageIdentity: PackageIdentity | undefined
 
 const isMissing = (error: unknown) => (error as NodeJS.ErrnoException).code === 'ENOENT'
+const isMissingOrNotDirectory = (error: unknown) => {
+  const { code } = error as NodeJS.ErrnoException
+  return code === 'ENOENT' || code === 'ENOTDIR'
+}
 
-const captureCanonicalDirectory = (path: string, allowLink: boolean, afterCanonicalisation?: () => void) =>
-  captureDirectoryWitness(path, { afterCanonicalisation, allowLink })
+const captureLinkedDirectory = (path: string) => captureDirectoryWitness(path, { allowLink: true })
+const captureRealDirectory = (path: string, afterCanonicalisation?: () => void) =>
+  captureDirectoryWitness(path, { afterCanonicalisation, allowLink: false })
 
 const validGitMarker = (directory: DirectoryWitness) => {
   const marker = resolve(directory.canonicalPath, '.git')
   try {
     let markerValid = false
     try {
-      const markerDirectory = captureCanonicalDirectory(marker, false)
-      markerValid = directoryWitnessIsCurrent(markerDirectory)
+      const markerDirectory = captureRealDirectory(marker)
+      revalidateDirectoryWitness(markerDirectory)
+      markerValid = true
     } catch (error) {
       if (!(error instanceof DirectoryWitnessError || isMissing(error))) {
         throw error
@@ -61,14 +72,16 @@ const validGitMarker = (directory: DirectoryWitness) => {
         if (match?.[1] !== undefined) {
           const target = match[1].trim()
           const gitDirectory = isAbsolute(target) ? target : resolve(directory.canonicalPath, target)
-          const administrationDirectory = captureCanonicalDirectory(gitDirectory, false, () =>
+          const administrationDirectory = captureRealDirectory(gitDirectory, () =>
             repositoryTestHooks.afterGitDirectoryLstat?.(gitDirectory),
           )
-          markerValid = directoryWitnessIsCurrent(administrationDirectory)
+          revalidateDirectoryWitness(administrationDirectory)
+          markerValid = true
         }
       }
     }
-    return directoryWitnessIsCurrent(directory) && markerValid
+    revalidateDirectoryWitness(directory)
+    return markerValid
   } catch (error) {
     if (error instanceof DirectoryWitnessError || error instanceof VerifiedFileError || isMissing(error)) {
       return false
@@ -77,35 +90,48 @@ const validGitMarker = (directory: DirectoryWitness) => {
   }
 }
 
-const canonicalDirectory = (path: string) => {
+const captureRepositoryDirectory = (path: string, explicit: boolean) => {
   try {
-    return captureCanonicalDirectory(resolve(path), true)
+    return captureLinkedDirectory(resolve(path))
   } catch (error) {
+    if (explicit && error instanceof DirectoryWitnessError) {
+      return fail('INVALID_REPOSITORY', 'The explicit root is not a Git repository.')
+    }
     return wrapIo('Unable to resolve the repository path.', error)
   }
 }
 
-export const discoverRepository = (input: DiscoverRepositoryInput = {}) => {
+const discoverRepositoryWitness = (input: DiscoverRepositoryInput = {}) => {
   if (input.root !== undefined) {
-    const explicitRoot = canonicalDirectory(input.root)
+    const explicitRoot = captureRepositoryDirectory(input.root, true)
     if (validGitMarker(explicitRoot)) {
-      return explicitRoot.canonicalPath
+      return explicitRoot
     }
     return fail('INVALID_REPOSITORY', 'The explicit root is not a Git repository.')
   }
 
-  let current = canonicalDirectory(input.start ?? process.cwd())
+  let current = captureRepositoryDirectory(input.start ?? process.cwd(), false)
   for (;;) {
     if (validGitMarker(current)) {
-      return current.canonicalPath
+      return current
     }
-    const parent = dirname(current.canonicalPath)
-    if (parent === current.canonicalPath) {
+    const parentPath = dirname(current.canonicalPath)
+    if (parentPath === current.canonicalPath) {
       return fail('REPOSITORY_NOT_FOUND', 'No Git repository was found.')
     }
-    current = canonicalDirectory(parent)
+    const parent = captureRepositoryDirectory(parentPath, false)
+    repositoryTestHooks.afterRepositoryParentCapture?.(current.path)
+    try {
+      revalidateDirectoryWitness(current)
+    } catch {
+      return fail('INVALID_REPOSITORY', 'The repository path changed during discovery.')
+    }
+    current = parent
   }
 }
+
+export const discoverRepository = (input: DiscoverRepositoryInput = {}) =>
+  discoverRepositoryWitness(input).canonicalPath
 
 const parsePackageManifest = (bytes: Buffer): PackageManifest => {
   const parsed = JSON.parse(decodeVerifiedUtf8(bytes)) as unknown
@@ -115,45 +141,49 @@ const parsePackageManifest = (bytes: Buffer): PackageManifest => {
   throw new VerifiedFileError('The package manifest must contain a JSON object.')
 }
 
-const packageRootFromModule = (): PackageIdentity => {
+const findExecutingPackage = (): PackageIdentity => {
   if (executingPackageIdentity !== undefined) {
     return executingPackageIdentity
   }
-  let current = dirname(fileURLToPath(import.meta.url))
+  let current = captureLinkedDirectory(dirname(fileURLToPath(import.meta.url)))
   for (;;) {
-    let parent: string
+    let packageJson: PackageManifest | undefined
     try {
-      const directory = captureCanonicalDirectory(current, true)
-      const packagePath = resolve(directory.canonicalPath, 'package.json')
+      const packagePath = resolve(current.canonicalPath, 'package.json')
       const bytes = readVerifiedRegularFile(packagePath, MAX_PACKAGE_MANIFEST_BYTES)
-      let packageJson: PackageManifest | undefined
       if (bytes !== undefined) {
         packageJson = parsePackageManifest(bytes)
         repositoryTestHooks.afterExecutingManifestRead?.(packagePath)
       }
-      if (!directoryWitnessIsCurrent(directory)) {
-        throw new DirectoryWitnessError()
-      }
-      if (packageJson?.name === 'encephalon') {
-        if (typeof packageJson.version === 'string') {
-          const identity = {
-            name: packageJson.name,
-            root: directory.canonicalPath,
-            version: packageJson.version,
-          }
-          executingPackageIdentity = identity
-          return identity
-        }
-        throw new VerifiedFileError('The executing package version is invalid.')
-      }
-      parent = dirname(directory.canonicalPath)
-      if (parent === directory.canonicalPath) {
-        return fail('ROOT_INSTALL_REQUIRED', 'Unable to locate the executing Encephalon package.')
-      }
+      revalidateDirectoryWitness(current)
     } catch (error) {
       return wrapIo('Unable to inspect the executing package.', error)
     }
-    current = parent
+    if (packageJson?.name === 'encephalon') {
+      if (typeof packageJson.version === 'string') {
+        const identity = {
+          directory: current,
+          name: packageJson.name,
+          root: current.canonicalPath,
+          version: packageJson.version,
+        }
+        executingPackageIdentity = identity
+        return identity
+      }
+      return wrapIo('Unable to inspect the executing package.', new VerifiedFileError())
+    }
+    const parentPath = dirname(current.canonicalPath)
+    if (parentPath === current.canonicalPath) {
+      return fail('ROOT_INSTALL_REQUIRED', 'Unable to locate the executing Encephalon package.')
+    }
+    try {
+      const parent = captureLinkedDirectory(parentPath)
+      repositoryTestHooks.afterExecutingParentCapture?.(current.path)
+      revalidateDirectoryWitness(current)
+      current = parent
+    } catch (error) {
+      return wrapIo('Unable to inspect the executing package.', error)
+    }
   }
 }
 
@@ -164,17 +194,32 @@ const comparablePath = (path: string) => {
 
 const rootInstallationRequired = (): never => fail('ROOT_INSTALL_REQUIRED', installRequiredMessage)
 
-export const assertRootInstallation = (root: string) => {
-  const installedPath = resolve(root, 'node_modules', 'encephalon')
-  let installedDirectory: DirectoryWitness
-  try {
-    installedDirectory = captureCanonicalDirectory(installedPath, true)
-  } catch {
+const installedVerificationError = (error: unknown): never => {
+  if (
+    error instanceof DirectoryWitnessError ||
+    error instanceof VerifiedFileError ||
+    error instanceof SyntaxError ||
+    isMissingOrNotDirectory(error)
+  ) {
     return rootInstallationRequired()
   }
+  return wrapIo('Unable to verify the root Encephalon installation.', error)
+}
 
-  const executingPackage = packageRootFromModule()
-  if (comparablePath(installedDirectory.canonicalPath) === comparablePath(executingPackage.root)) {
+const assertRootInstallationWitness = (root: DirectoryWitness) => {
+  const installedPath = resolve(root.canonicalPath, 'node_modules', 'encephalon')
+  let installedDirectory: DirectoryWitness
+  try {
+    installedDirectory = captureLinkedDirectory(installedPath)
+  } catch (error) {
+    return installedVerificationError(error)
+  }
+
+  const executingPackage = findExecutingPackage()
+  if (
+    comparablePath(installedDirectory.canonicalPath) === comparablePath(executingPackage.root) &&
+    sameStableEntryMetadata(installedDirectory.canonicalMetadata, executingPackage.directory.canonicalMetadata)
+  ) {
     let packageJson: PackageManifest
     try {
       const packagePath = resolve(installedDirectory.canonicalPath, 'package.json')
@@ -184,11 +229,9 @@ export const assertRootInstallation = (root: string) => {
       }
       packageJson = parsePackageManifest(bytes)
       repositoryTestHooks.afterInstalledManifestRead?.(packagePath)
-      if (!directoryWitnessIsCurrent(installedDirectory)) {
-        return rootInstallationRequired()
-      }
-    } catch {
-      return rootInstallationRequired()
+      revalidateDirectoryWitness(installedDirectory)
+    } catch (error) {
+      return installedVerificationError(error)
     }
     if (
       packageJson.name === executingPackage.name &&
@@ -208,8 +251,16 @@ export const assertRootInstallation = (root: string) => {
   return rootInstallationRequired()
 }
 
+export const assertRootInstallation = (root: string) => assertRootInstallationWitness(captureLinkedDirectory(root))
+
 export const resolveRepository = (input: { root?: string } = {}) => {
-  const root = discoverRepository(input)
-  assertRootInstallation(root)
-  return root
+  const root = discoverRepositoryWitness(input)
+  assertRootInstallationWitness(root)
+  repositoryTestHooks.afterRootInstallation?.()
+  try {
+    revalidateDirectoryWitness(root)
+  } catch {
+    return fail('INVALID_REPOSITORY', 'The repository path changed while its installation was verified.')
+  }
+  return root.canonicalPath
 }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1,40 +1,107 @@
-import { existsSync, lstatSync, readFileSync, realpathSync } from 'node:fs'
+import type { BigIntStats } from 'node:fs'
+import { lstatSync, realpathSync } from 'node:fs'
 import { dirname, isAbsolute, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { fail, wrapIo } from './errors.ts'
+import { EncephalonError, fail, wrapIo } from './errors.ts'
 import { PACKAGE_VERSION } from './generated/version.ts'
+import { decodeVerifiedUtf8, readVerifiedRegularFile, VerifiedFileError } from './verified-file.ts'
 
 export type DiscoverRepositoryInput = {
   root?: string
   start?: string
 }
 
-const validGitMarker = (directory: string) => {
-  const marker = resolve(directory, '.git')
-  if (existsSync(marker)) {
-    try {
-      const metadata = lstatSync(marker)
-      if (metadata.isDirectory() && !metadata.isSymbolicLink()) {
-        return true
-      }
-      if (metadata.isFile() && !metadata.isSymbolicLink() && metadata.size <= 16_384) {
-        const content = readFileSync(marker, 'utf8').trim()
-        const match = /^gitdir:\s*(.+)$/i.exec(content)
-        if (match?.[1] !== undefined) {
-          const target = match[1].trim()
-          const gitDirectory = isAbsolute(target) ? target : resolve(directory, target)
-          if (existsSync(gitDirectory)) {
-            const targetMetadata = lstatSync(gitDirectory)
-            return targetMetadata.isDirectory() && !targetMetadata.isSymbolicLink()
-          }
-        }
-      }
+type PackageIdentity = {
+  name: string
+  root: string
+  version: string
+}
+
+type PackageManifest = {
+  name?: unknown
+  version?: unknown
+}
+
+type RepositoryTestHooks = {
+  afterGitDirectoryLstat?: ((path: string) => void) | undefined
+}
+
+export const repositoryTestHooks: RepositoryTestHooks = {}
+
+const MAX_GIT_MARKER_BYTES = 16_384
+const MAX_PACKAGE_MANIFEST_BYTES = 1024 * 1024
+let executingPackageIdentity: PackageIdentity | undefined
+
+const isMissing = (error: unknown) => (error as NodeJS.ErrnoException).code === 'ENOENT'
+
+const sameIdentity = (first: BigIntStats, second: BigIntStats) => first.dev === second.dev && first.ino === second.ino
+
+const verifiedRealDirectory = (path: string, observe = false) => {
+  let initialMetadata: BigIntStats
+  try {
+    initialMetadata = lstatSync(path, { bigint: true })
+  } catch (error) {
+    if (isMissing(error)) {
       return false
+    }
+    throw error
+  }
+  if (initialMetadata.isDirectory() && !initialMetadata.isSymbolicLink()) {
+    if (observe) {
+      repositoryTestHooks.afterGitDirectoryLstat?.(path)
+    }
+    try {
+      realpathSync.native(path)
+      const finalMetadata = lstatSync(path, { bigint: true })
+      return (
+        finalMetadata.isDirectory() && !finalMetadata.isSymbolicLink() && sameIdentity(initialMetadata, finalMetadata)
+      )
     } catch (error) {
-      return wrapIo('Unable to inspect the repository marker.', error)
+      if (isMissing(error)) {
+        return false
+      }
+      throw error
     }
   }
   return false
+}
+
+const gitMarkerMetadata = (path: string) => {
+  try {
+    return lstatSync(path, { bigint: true })
+  } catch (error) {
+    if (isMissing(error)) {
+      return
+    }
+    throw error
+  }
+}
+
+const validGitMarker = (directory: string) => {
+  const marker = resolve(directory, '.git')
+  try {
+    const metadata = gitMarkerMetadata(marker)
+    if (metadata?.isDirectory() && !metadata.isSymbolicLink()) {
+      return verifiedRealDirectory(marker)
+    }
+    if (metadata?.isFile() && !metadata.isSymbolicLink()) {
+      const bytes = readVerifiedRegularFile(marker, MAX_GIT_MARKER_BYTES)
+      if (bytes !== undefined) {
+        const match = /^gitdir:\s*(.+)$/i.exec(decodeVerifiedUtf8(bytes).trim())
+        if (match?.[1] !== undefined) {
+          const target = match[1].trim()
+          const gitDirectory = isAbsolute(target) ? target : resolve(directory, target)
+          return verifiedRealDirectory(gitDirectory, true)
+        }
+      }
+    }
+    return false
+  } catch (error) {
+    if (error instanceof VerifiedFileError) {
+      return false
+    }
+    return wrapIo('Unable to inspect the repository marker.', error)
+  }
 }
 
 const canonicalDirectory = (path: string) => {
@@ -67,21 +134,40 @@ export const discoverRepository = (input: DiscoverRepositoryInput = {}) => {
   }
 }
 
-const packageRootFromModule = () => {
+const parsePackageManifest = (bytes: Buffer): PackageManifest => {
+  const parsed = JSON.parse(decodeVerifiedUtf8(bytes)) as unknown
+  if (parsed !== null && !Array.isArray(parsed) && typeof parsed === 'object') {
+    return parsed as PackageManifest
+  }
+  throw new VerifiedFileError('The package manifest must contain a JSON object.')
+}
+
+const packageRootFromModule = (): PackageIdentity => {
+  if (executingPackageIdentity !== undefined) {
+    return executingPackageIdentity
+  }
   let current = dirname(fileURLToPath(import.meta.url))
   for (;;) {
     const packagePath = resolve(current, 'package.json')
-    if (existsSync(packagePath)) {
-      try {
-        const packageJson = JSON.parse(readFileSync(packagePath, 'utf8')) as {
-          name?: unknown
-        }
+    try {
+      const bytes = readVerifiedRegularFile(packagePath, MAX_PACKAGE_MANIFEST_BYTES)
+      if (bytes !== undefined) {
+        const packageJson = parsePackageManifest(bytes)
         if (packageJson.name === 'encephalon') {
-          return realpathSync.native(current)
+          if (typeof packageJson.version === 'string') {
+            const identity = {
+              name: packageJson.name,
+              root: realpathSync.native(current),
+              version: packageJson.version,
+            }
+            executingPackageIdentity = identity
+            return identity
+          }
+          throw new VerifiedFileError('The executing package version is invalid.')
         }
-      } catch (error) {
-        return wrapIo('Unable to inspect the executing package.', error)
       }
+    } catch (error) {
+      return wrapIo('Unable to inspect the executing package.', error)
     }
     const parent = dirname(current)
     if (parent === current) {
@@ -98,27 +184,35 @@ const comparablePath = (path: string) => {
 
 export const assertRootInstallation = (root: string) => {
   const installedPath = resolve(root, 'node_modules', 'encephalon')
-  if (existsSync(installedPath)) {
-    try {
-      const installedRoot = realpathSync.native(installedPath)
-      const executingRoot = packageRootFromModule()
-      if (comparablePath(installedRoot) === comparablePath(executingRoot)) {
-        const packageJson = JSON.parse(readFileSync(resolve(installedRoot, 'package.json'), 'utf8')) as {
-          name?: unknown
-          version?: unknown
-        }
-        if (packageJson.name === 'encephalon' && packageJson.version === PACKAGE_VERSION) {
-          return installedRoot
-        }
-        if (packageJson.name === 'encephalon') {
-          const installedVersion = typeof packageJson.version === 'string' ? packageJson.version : 'unknown'
-          return fail(
-            'ROOT_INSTALL_REQUIRED',
-            `Root Encephalon package version ${installedVersion} does not match executing version ${PACKAGE_VERSION}. Rebuild or reinstall Encephalon at the repository root before running this command.`,
-          )
-        }
+  try {
+    const installedRoot = realpathSync.native(installedPath)
+    const executingPackage = packageRootFromModule()
+    if (comparablePath(installedRoot) === comparablePath(executingPackage.root)) {
+      const bytes = readVerifiedRegularFile(resolve(installedRoot, 'package.json'), MAX_PACKAGE_MANIFEST_BYTES)
+      if (bytes === undefined) {
+        throw new VerifiedFileError('The installed package manifest is missing.')
       }
-    } catch (error) {
+      const packageJson = parsePackageManifest(bytes)
+      if (
+        packageJson.name === executingPackage.name &&
+        packageJson.version === executingPackage.version &&
+        executingPackage.version === PACKAGE_VERSION
+      ) {
+        return installedRoot
+      }
+      if (packageJson.name === executingPackage.name) {
+        const installedVersion = typeof packageJson.version === 'string' ? packageJson.version : 'unknown'
+        return fail(
+          'ROOT_INSTALL_REQUIRED',
+          `Root Encephalon package version ${installedVersion} does not match executing version ${PACKAGE_VERSION}. Rebuild or reinstall Encephalon at the repository root before running this command.`,
+        )
+      }
+    }
+  } catch (error) {
+    if (error instanceof EncephalonError) {
+      throw error
+    }
+    if (!isMissing(error)) {
       return wrapIo('Unable to verify the root Encephalon installation.', error)
     }
   }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1,8 +1,12 @@
-import type { BigIntStats } from 'node:fs'
-import { lstatSync, realpathSync } from 'node:fs'
 import { dirname, isAbsolute, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { EncephalonError, fail, wrapIo } from './errors.ts'
+import {
+  captureDirectoryWitness,
+  type DirectoryWitness,
+  DirectoryWitnessError,
+  directoryWitnessIsCurrent,
+} from './directory-witness.ts'
+import { fail, wrapIo } from './errors.ts'
 import { PACKAGE_VERSION } from './generated/version.ts'
 import { decodeVerifiedUtf8, readVerifiedRegularFile, VerifiedFileError } from './verified-file.ts'
 
@@ -23,81 +27,50 @@ type PackageManifest = {
 }
 
 type RepositoryTestHooks = {
+  afterExecutingManifestRead?: ((path: string) => void) | undefined
   afterGitDirectoryLstat?: ((path: string) => void) | undefined
+  afterInstalledManifestRead?: ((path: string) => void) | undefined
 }
 
 export const repositoryTestHooks: RepositoryTestHooks = {}
 
 const MAX_GIT_MARKER_BYTES = 16_384
 const MAX_PACKAGE_MANIFEST_BYTES = 1024 * 1024
+const installRequiredMessage = 'Install Encephalon at the Git repository root before running this command.'
 let executingPackageIdentity: PackageIdentity | undefined
 
 const isMissing = (error: unknown) => (error as NodeJS.ErrnoException).code === 'ENOENT'
 
-const sameIdentity = (first: BigIntStats, second: BigIntStats) => first.dev === second.dev && first.ino === second.ino
+const captureCanonicalDirectory = (path: string, allowLink: boolean, afterCanonicalisation?: () => void) =>
+  captureDirectoryWitness(path, { afterCanonicalisation, allowLink })
 
-const verifiedRealDirectory = (path: string, observe = false) => {
-  let initialMetadata: BigIntStats
+const validGitMarker = (directory: DirectoryWitness) => {
+  const marker = resolve(directory.canonicalPath, '.git')
   try {
-    initialMetadata = lstatSync(path, { bigint: true })
-  } catch (error) {
-    if (isMissing(error)) {
-      return false
-    }
-    throw error
-  }
-  if (initialMetadata.isDirectory() && !initialMetadata.isSymbolicLink()) {
-    if (observe) {
-      repositoryTestHooks.afterGitDirectoryLstat?.(path)
-    }
+    let markerValid = false
     try {
-      realpathSync.native(path)
-      const finalMetadata = lstatSync(path, { bigint: true })
-      return (
-        finalMetadata.isDirectory() && !finalMetadata.isSymbolicLink() && sameIdentity(initialMetadata, finalMetadata)
-      )
+      const markerDirectory = captureCanonicalDirectory(marker, false)
+      markerValid = directoryWitnessIsCurrent(markerDirectory)
     } catch (error) {
-      if (isMissing(error)) {
-        return false
+      if (!(error instanceof DirectoryWitnessError || isMissing(error))) {
+        throw error
       }
-      throw error
-    }
-  }
-  return false
-}
-
-const gitMarkerMetadata = (path: string) => {
-  try {
-    return lstatSync(path, { bigint: true })
-  } catch (error) {
-    if (isMissing(error)) {
-      return
-    }
-    throw error
-  }
-}
-
-const validGitMarker = (directory: string) => {
-  const marker = resolve(directory, '.git')
-  try {
-    const metadata = gitMarkerMetadata(marker)
-    if (metadata?.isDirectory() && !metadata.isSymbolicLink()) {
-      return verifiedRealDirectory(marker)
-    }
-    if (metadata?.isFile() && !metadata.isSymbolicLink()) {
       const bytes = readVerifiedRegularFile(marker, MAX_GIT_MARKER_BYTES)
       if (bytes !== undefined) {
         const match = /^gitdir:\s*(.+)$/i.exec(decodeVerifiedUtf8(bytes).trim())
         if (match?.[1] !== undefined) {
           const target = match[1].trim()
-          const gitDirectory = isAbsolute(target) ? target : resolve(directory, target)
-          return verifiedRealDirectory(gitDirectory, true)
+          const gitDirectory = isAbsolute(target) ? target : resolve(directory.canonicalPath, target)
+          const administrationDirectory = captureCanonicalDirectory(gitDirectory, false, () =>
+            repositoryTestHooks.afterGitDirectoryLstat?.(gitDirectory),
+          )
+          markerValid = directoryWitnessIsCurrent(administrationDirectory)
         }
       }
     }
-    return false
+    return directoryWitnessIsCurrent(directory) && markerValid
   } catch (error) {
-    if (error instanceof VerifiedFileError) {
+    if (error instanceof DirectoryWitnessError || error instanceof VerifiedFileError || isMissing(error)) {
       return false
     }
     return wrapIo('Unable to inspect the repository marker.', error)
@@ -106,7 +79,7 @@ const validGitMarker = (directory: string) => {
 
 const canonicalDirectory = (path: string) => {
   try {
-    return realpathSync.native(resolve(path))
+    return captureCanonicalDirectory(resolve(path), true)
   } catch (error) {
     return wrapIo('Unable to resolve the repository path.', error)
   }
@@ -116,7 +89,7 @@ export const discoverRepository = (input: DiscoverRepositoryInput = {}) => {
   if (input.root !== undefined) {
     const explicitRoot = canonicalDirectory(input.root)
     if (validGitMarker(explicitRoot)) {
-      return explicitRoot
+      return explicitRoot.canonicalPath
     }
     return fail('INVALID_REPOSITORY', 'The explicit root is not a Git repository.')
   }
@@ -124,13 +97,13 @@ export const discoverRepository = (input: DiscoverRepositoryInput = {}) => {
   let current = canonicalDirectory(input.start ?? process.cwd())
   for (;;) {
     if (validGitMarker(current)) {
-      return current
+      return current.canonicalPath
     }
-    const parent = dirname(current)
-    if (parent === current) {
+    const parent = dirname(current.canonicalPath)
+    if (parent === current.canonicalPath) {
       return fail('REPOSITORY_NOT_FOUND', 'No Git repository was found.')
     }
-    current = parent
+    current = canonicalDirectory(parent)
   }
 }
 
@@ -148,30 +121,37 @@ const packageRootFromModule = (): PackageIdentity => {
   }
   let current = dirname(fileURLToPath(import.meta.url))
   for (;;) {
-    const packagePath = resolve(current, 'package.json')
+    let parent: string
     try {
+      const directory = captureCanonicalDirectory(current, true)
+      const packagePath = resolve(directory.canonicalPath, 'package.json')
       const bytes = readVerifiedRegularFile(packagePath, MAX_PACKAGE_MANIFEST_BYTES)
+      let packageJson: PackageManifest | undefined
       if (bytes !== undefined) {
-        const packageJson = parsePackageManifest(bytes)
-        if (packageJson.name === 'encephalon') {
-          if (typeof packageJson.version === 'string') {
-            const identity = {
-              name: packageJson.name,
-              root: realpathSync.native(current),
-              version: packageJson.version,
-            }
-            executingPackageIdentity = identity
-            return identity
+        packageJson = parsePackageManifest(bytes)
+        repositoryTestHooks.afterExecutingManifestRead?.(packagePath)
+      }
+      if (!directoryWitnessIsCurrent(directory)) {
+        throw new DirectoryWitnessError()
+      }
+      if (packageJson?.name === 'encephalon') {
+        if (typeof packageJson.version === 'string') {
+          const identity = {
+            name: packageJson.name,
+            root: directory.canonicalPath,
+            version: packageJson.version,
           }
-          throw new VerifiedFileError('The executing package version is invalid.')
+          executingPackageIdentity = identity
+          return identity
         }
+        throw new VerifiedFileError('The executing package version is invalid.')
+      }
+      parent = dirname(directory.canonicalPath)
+      if (parent === directory.canonicalPath) {
+        return fail('ROOT_INSTALL_REQUIRED', 'Unable to locate the executing Encephalon package.')
       }
     } catch (error) {
       return wrapIo('Unable to inspect the executing package.', error)
-    }
-    const parent = dirname(current)
-    if (parent === current) {
-      return fail('ROOT_INSTALL_REQUIRED', 'Unable to locate the executing Encephalon package.')
     }
     current = parent
   }
@@ -182,41 +162,50 @@ const comparablePath = (path: string) => {
   return process.platform === 'win32' ? normalized.toLowerCase() : normalized
 }
 
+const rootInstallationRequired = (): never => fail('ROOT_INSTALL_REQUIRED', installRequiredMessage)
+
 export const assertRootInstallation = (root: string) => {
   const installedPath = resolve(root, 'node_modules', 'encephalon')
+  let installedDirectory: DirectoryWitness
   try {
-    const installedRoot = realpathSync.native(installedPath)
-    const executingPackage = packageRootFromModule()
-    if (comparablePath(installedRoot) === comparablePath(executingPackage.root)) {
-      const bytes = readVerifiedRegularFile(resolve(installedRoot, 'package.json'), MAX_PACKAGE_MANIFEST_BYTES)
+    installedDirectory = captureCanonicalDirectory(installedPath, true)
+  } catch {
+    return rootInstallationRequired()
+  }
+
+  const executingPackage = packageRootFromModule()
+  if (comparablePath(installedDirectory.canonicalPath) === comparablePath(executingPackage.root)) {
+    let packageJson: PackageManifest
+    try {
+      const packagePath = resolve(installedDirectory.canonicalPath, 'package.json')
+      const bytes = readVerifiedRegularFile(packagePath, MAX_PACKAGE_MANIFEST_BYTES)
       if (bytes === undefined) {
-        throw new VerifiedFileError('The installed package manifest is missing.')
+        return rootInstallationRequired()
       }
-      const packageJson = parsePackageManifest(bytes)
-      if (
-        packageJson.name === executingPackage.name &&
-        packageJson.version === executingPackage.version &&
-        executingPackage.version === PACKAGE_VERSION
-      ) {
-        return installedRoot
+      packageJson = parsePackageManifest(bytes)
+      repositoryTestHooks.afterInstalledManifestRead?.(packagePath)
+      if (!directoryWitnessIsCurrent(installedDirectory)) {
+        return rootInstallationRequired()
       }
-      if (packageJson.name === executingPackage.name) {
-        const installedVersion = typeof packageJson.version === 'string' ? packageJson.version : 'unknown'
-        return fail(
-          'ROOT_INSTALL_REQUIRED',
-          `Root Encephalon package version ${installedVersion} does not match executing version ${PACKAGE_VERSION}. Rebuild or reinstall Encephalon at the repository root before running this command.`,
-        )
-      }
+    } catch {
+      return rootInstallationRequired()
     }
-  } catch (error) {
-    if (error instanceof EncephalonError) {
-      throw error
+    if (
+      packageJson.name === executingPackage.name &&
+      packageJson.version === executingPackage.version &&
+      executingPackage.version === PACKAGE_VERSION
+    ) {
+      return installedDirectory.canonicalPath
     }
-    if (!isMissing(error)) {
-      return wrapIo('Unable to verify the root Encephalon installation.', error)
+    if (packageJson.name === executingPackage.name) {
+      const installedVersion = typeof packageJson.version === 'string' ? packageJson.version : 'unknown'
+      return fail(
+        'ROOT_INSTALL_REQUIRED',
+        `Root Encephalon package version ${installedVersion} does not match executing version ${PACKAGE_VERSION}. Rebuild or reinstall Encephalon at the repository root before running this command.`,
+      )
     }
   }
-  return fail('ROOT_INSTALL_REQUIRED', 'Install Encephalon at the Git repository root before running this command.')
+  return rootInstallationRequired()
 }
 
 export const resolveRepository = (input: { root?: string } = {}) => {

--- a/src/verified-file.ts
+++ b/src/verified-file.ts
@@ -1,8 +1,9 @@
 import type { BigIntStats } from 'node:fs'
 import { closeSync, constants, fstatSync, lstatSync, openSync, readSync } from 'node:fs'
 import { TextDecoder } from 'node:util'
+import { sameFileIdentity, sameStableFileMetadata } from './file-identity.ts'
 
-type VerifiedFileFault = 'after-fstat' | 'after-lstat'
+type VerifiedFileFault = 'after-fstat' | 'after-lstat' | 'before-final-path-lstat'
 
 type VerifiedFileOptions = {
   fault?: (point: VerifiedFileFault) => void
@@ -10,16 +11,6 @@ type VerifiedFileOptions = {
 
 const noFollowFlag = constants.O_NOFOLLOW ?? 0
 const decoder = new TextDecoder('utf-8', { fatal: true })
-
-const sameIdentity = (first: BigIntStats, second: BigIntStats) => first.dev === second.dev && first.ino === second.ino
-
-const sameStableMetadata = (first: BigIntStats, second: BigIntStats) =>
-  sameIdentity(first, second) &&
-  first.size === second.size &&
-  first.mode === second.mode &&
-  first.birthtimeNs === second.birthtimeNs &&
-  first.mtimeNs === second.mtimeNs &&
-  first.ctimeNs === second.ctimeNs
 
 const isMissing = (error: unknown) => (error as NodeJS.ErrnoException).code === 'ENOENT'
 
@@ -63,12 +54,13 @@ const readVerifiedDescriptor = (
   options: VerifiedFileOptions,
 ) => {
   const metadata = fstatSync(descriptor, { bigint: true })
-  if (!(metadata.isFile() && sameIdentity(pathMetadata, metadata)) || metadata.size > BigInt(maximumBytes)) {
+  if (!(metadata.isFile() && sameFileIdentity(pathMetadata, metadata)) || metadata.size > BigInt(maximumBytes)) {
     return changed()
   }
   options.fault?.('after-fstat')
   const bytes = readExactBytes(descriptor, Number(metadata.size))
   const finalMetadata = fstatSync(descriptor, { bigint: true })
+  options.fault?.('before-final-path-lstat')
   let finalPathMetadata: BigIntStats
   try {
     finalPathMetadata = lstatSync(path, { bigint: true })
@@ -81,8 +73,8 @@ const readVerifiedDescriptor = (
   if (
     !finalPathMetadata.isFile() ||
     finalPathMetadata.isSymbolicLink() ||
-    !sameIdentity(finalPathMetadata, finalMetadata) ||
-    !sameStableMetadata(metadata, finalMetadata)
+    !sameStableFileMetadata(finalPathMetadata, finalMetadata) ||
+    !sameStableFileMetadata(metadata, finalMetadata)
   ) {
     return changed()
   }

--- a/src/verified-file.ts
+++ b/src/verified-file.ts
@@ -1,7 +1,7 @@
 import type { BigIntStats } from 'node:fs'
 import { closeSync, constants, fstatSync, lstatSync, openSync, readSync } from 'node:fs'
 import { TextDecoder } from 'node:util'
-import { sameFileIdentity, sameStableFileMetadata } from './file-identity.ts'
+import { sameEntryIdentity, sameStableEntryMetadata } from './filesystem-entry.ts'
 
 type VerifiedFileFault = 'after-fstat' | 'after-lstat' | 'before-final-path-lstat'
 
@@ -54,7 +54,7 @@ const readVerifiedDescriptor = (
   options: VerifiedFileOptions,
 ) => {
   const metadata = fstatSync(descriptor, { bigint: true })
-  if (!(metadata.isFile() && sameFileIdentity(pathMetadata, metadata)) || metadata.size > BigInt(maximumBytes)) {
+  if (!(metadata.isFile() && sameEntryIdentity(pathMetadata, metadata)) || metadata.size > BigInt(maximumBytes)) {
     return changed()
   }
   options.fault?.('after-fstat')
@@ -73,8 +73,8 @@ const readVerifiedDescriptor = (
   if (
     !finalPathMetadata.isFile() ||
     finalPathMetadata.isSymbolicLink() ||
-    !sameStableFileMetadata(finalPathMetadata, finalMetadata) ||
-    !sameStableFileMetadata(metadata, finalMetadata)
+    !sameStableEntryMetadata(finalPathMetadata, finalMetadata) ||
+    !sameStableEntryMetadata(metadata, finalMetadata)
   ) {
     return changed()
   }

--- a/src/verified-file.ts
+++ b/src/verified-file.ts
@@ -1,0 +1,149 @@
+import type { BigIntStats } from 'node:fs'
+import { closeSync, constants, fstatSync, lstatSync, openSync, readSync } from 'node:fs'
+import { TextDecoder } from 'node:util'
+
+type VerifiedFileFault = 'after-fstat' | 'after-lstat'
+
+type VerifiedFileOptions = {
+  fault?: (point: VerifiedFileFault) => void
+}
+
+const noFollowFlag = constants.O_NOFOLLOW ?? 0
+const decoder = new TextDecoder('utf-8', { fatal: true })
+
+const sameIdentity = (first: BigIntStats, second: BigIntStats) => first.dev === second.dev && first.ino === second.ino
+
+const sameStableMetadata = (first: BigIntStats, second: BigIntStats) =>
+  sameIdentity(first, second) &&
+  first.size === second.size &&
+  first.mode === second.mode &&
+  first.birthtimeNs === second.birthtimeNs &&
+  first.mtimeNs === second.mtimeNs &&
+  first.ctimeNs === second.ctimeNs
+
+const isMissing = (error: unknown) => (error as NodeJS.ErrnoException).code === 'ENOENT'
+
+const isReplacementOpenError = (error: unknown) => {
+  const { code } = error as NodeJS.ErrnoException
+  return code === 'ELOOP' || code === 'ENOENT' || code === 'ENOTDIR'
+}
+
+export class VerifiedFileError extends Error {
+  constructor(message = 'The file is not a stable bounded regular file.', options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'VerifiedFileError'
+  }
+}
+
+const changed = (): never => {
+  throw new VerifiedFileError()
+}
+
+const readExactBytes = (descriptor: number, size: number) => {
+  const bytes = Buffer.alloc(size)
+  let offset = 0
+  while (offset < size) {
+    const bytesRead = readSync(descriptor, bytes, offset, size - offset, offset)
+    if (bytesRead === 0) {
+      changed()
+    }
+    offset += bytesRead
+  }
+  if (readSync(descriptor, Buffer.alloc(1), 0, 1, size) > 0) {
+    changed()
+  }
+  return bytes
+}
+
+const readVerifiedDescriptor = (
+  descriptor: number,
+  path: string,
+  pathMetadata: BigIntStats,
+  maximumBytes: number,
+  options: VerifiedFileOptions,
+) => {
+  const metadata = fstatSync(descriptor, { bigint: true })
+  if (!(metadata.isFile() && sameIdentity(pathMetadata, metadata)) || metadata.size > BigInt(maximumBytes)) {
+    return changed()
+  }
+  options.fault?.('after-fstat')
+  const bytes = readExactBytes(descriptor, Number(metadata.size))
+  const finalMetadata = fstatSync(descriptor, { bigint: true })
+  let finalPathMetadata: BigIntStats
+  try {
+    finalPathMetadata = lstatSync(path, { bigint: true })
+  } catch (error) {
+    if (isMissing(error)) {
+      return changed()
+    }
+    throw error
+  }
+  if (
+    !finalPathMetadata.isFile() ||
+    finalPathMetadata.isSymbolicLink() ||
+    !sameIdentity(finalPathMetadata, finalMetadata) ||
+    !sameStableMetadata(metadata, finalMetadata)
+  ) {
+    return changed()
+  }
+  return bytes
+}
+
+export const readVerifiedRegularFile = (
+  path: string,
+  maximumBytes: number,
+  options: VerifiedFileOptions = {},
+): Buffer | undefined => {
+  let pathMetadata: BigIntStats
+  try {
+    pathMetadata = lstatSync(path, { bigint: true })
+  } catch (error) {
+    if (isMissing(error)) {
+      return
+    }
+    throw error
+  }
+  if (!pathMetadata.isFile() || pathMetadata.isSymbolicLink()) {
+    return changed()
+  }
+  options.fault?.('after-lstat')
+
+  let descriptor: number
+  try {
+    descriptor = openSync(path, constants.O_RDONLY | noFollowFlag)
+  } catch (error) {
+    if (isReplacementOpenError(error)) {
+      return changed()
+    }
+    throw error
+  }
+
+  let bytes: Buffer | undefined
+  let primaryError: unknown
+  try {
+    bytes = readVerifiedDescriptor(descriptor, path, pathMetadata, maximumBytes, options)
+  } catch (error) {
+    primaryError = error
+  }
+  let closeError: unknown
+  try {
+    closeSync(descriptor)
+  } catch (error) {
+    closeError = error
+  }
+  if (primaryError !== undefined) {
+    throw primaryError
+  }
+  if (closeError !== undefined) {
+    throw closeError
+  }
+  return bytes
+}
+
+export const decodeVerifiedUtf8 = (bytes: Buffer) => {
+  try {
+    return decoder.decode(bytes)
+  } catch (error) {
+    throw new VerifiedFileError('The file is not valid UTF-8.', { cause: error })
+  }
+}

--- a/src/verified-file.ts
+++ b/src/verified-file.ts
@@ -3,7 +3,7 @@ import { closeSync, constants, fstatSync, lstatSync, openSync, readSync } from '
 import { TextDecoder } from 'node:util'
 import { sameEntryIdentity, sameStableEntryMetadata } from './filesystem-entry.ts'
 
-type VerifiedFileFault = 'after-fstat' | 'after-lstat' | 'before-final-path-lstat'
+type VerifiedFileFault = 'after-fstat' | 'after-lstat' | 'before-allocation' | 'before-final-path-lstat'
 
 type VerifiedFileOptions = {
   fault?: (point: VerifiedFileFault) => void
@@ -58,6 +58,7 @@ const readVerifiedDescriptor = (
     return changed()
   }
   options.fault?.('after-fstat')
+  options.fault?.('before-allocation')
   const bytes = readExactBytes(descriptor, Number(metadata.size))
   const finalMetadata = fstatSync(descriptor, { bigint: true })
   options.fault?.('before-final-path-lstat')

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -3,7 +3,7 @@ import { spawnSync } from 'node:child_process'
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
-import { afterEach, before, describe, test } from 'node:test'
+import { afterEach, describe, test } from 'node:test'
 import { PACKAGE_VERSION } from '../src/generated/version.ts'
 import { createTestRepository, removeTestRepository } from '../test/helpers.ts'
 
@@ -19,14 +19,6 @@ const createRoot = () => {
 
 afterEach(() => {
   roots.splice(0).forEach(removeTestRepository)
-})
-
-before(() => {
-  const result = spawnSync('bun', ['run', 'build'], {
-    cwd: projectRoot,
-    encoding: 'utf8',
-  })
-  assert.equal(result.status, 0, result.stderr)
 })
 
 const run = (root: string, arguments_: string[]) =>

--- a/test/directory-witness.test.ts
+++ b/test/directory-witness.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, renameSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { captureDirectoryWitness, DirectoryWitnessError, revalidateDirectoryWitness } from '../src/directory-witness.ts'
+
+test('revalidation rejects replacement at its final input boundary', () => {
+  const root = mkdtempSync(join(tmpdir(), 'encephalon-directory-witness-test-'))
+  try {
+    const directory = join(root, 'directory')
+    const captured = join(root, 'captured')
+    mkdirSync(directory)
+    const witness = captureDirectoryWitness(directory, { allowLink: false })
+
+    assert.throws(
+      () =>
+        revalidateDirectoryWitness(witness, {
+          afterCanonicalisation: () => {
+            renameSync(directory, captured)
+            mkdirSync(directory)
+          },
+        }),
+      DirectoryWitnessError,
+    )
+  } finally {
+    rmSync(root, { force: true, recursive: true })
+  }
+})

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -39,7 +39,7 @@ const createIsolatedPackage = (options: { packageManifest?: boolean } = {}) => {
     join(executingRoot, 'src', 'generated', 'version.ts'),
   )
   if (options.packageManifest !== false) {
-    writeFileSync(join(executingRoot, 'package.json'), '{"name":"encephalon","version":"0.2.0"}\n')
+    writeFileSync(join(executingRoot, 'package.json'), '{"name":"encephalon","type":"module","version":"0.2.0"}\n')
   }
 
   const repositoryRoot = join(testRoot, 'repository')
@@ -55,6 +55,7 @@ const createIsolatedPackage = (options: { packageManifest?: boolean } = {}) => {
 
 afterEach(() => {
   repositoryTestHooks.afterGitDirectoryLstat = undefined
+  repositoryTestHooks.afterGitMarkerDecision = undefined
   repositoryTestHooks.afterExecutingManifestRead = undefined
   repositoryTestHooks.afterExecutingParentCapture = undefined
   repositoryTestHooks.afterInstalledManifestRead = undefined
@@ -105,6 +106,25 @@ test('rejects a child generation change while ascending to a repository parent',
   assert.equal(replaced, true)
 })
 
+test('preserves operational failures while revalidating a repository ascent', () => {
+  const root = createTestRepository()
+  temporaryRoots.push(root)
+  const child = join(root, 'packages', 'app')
+  mkdirSync(child, { recursive: true })
+  repositoryTestHooks.afterRepositoryParentCapture = () => {
+    throw Object.assign(new Error('simulated input/output failure'), { code: 'EIO' })
+  }
+
+  assert.throws(
+    () => discoverRepository({ start: child }),
+    (error: unknown) => {
+      assert.equal((error as { code?: unknown }).code, 'IO_ERROR')
+      assert.equal((error as Error).message.includes(root), false)
+      return true
+    },
+  )
+})
+
 test('rejects a worktree target replaced after inspection', () => {
   const root = mkdtempSync(join(tmpdir(), 'encephalon-worktree-test-'))
   temporaryRoots.push(root)
@@ -153,6 +173,14 @@ test('rejects a worktree target replaced after inspection', () => {
 test('rejects unsafe Git marker inputs with the stable explicit-root error', () => {
   const cases = [
     {
+      name: 'empty target',
+      write: (root: string) => writeFileSync(join(root, '.git'), 'gitdir: \n'),
+    },
+    {
+      name: 'NUL target',
+      write: (root: string) => writeFileSync(join(root, '.git'), 'gitdir: administration\0\n'),
+    },
+    {
       name: 'oversized',
       write: (root: string) =>
         writeFileSync(join(root, '.git'), `gitdir: ${join(root, 'administration')}${' '.repeat(16_384)}\n`),
@@ -195,6 +223,29 @@ test('rejects unsafe Git marker inputs with the stable explicit-root error', () 
       )
     }
   }
+})
+
+test('rejects a repository generation replaced after its Git marker decision', () => {
+  const root = createTestRepository()
+  const captured = `${root}-captured`
+  temporaryRoots.push(root, captured)
+  let replaced = false
+  repositoryTestHooks.afterGitMarkerDecision = () => {
+    if (!replaced) {
+      replaced = true
+      renameSync(root, captured)
+      mkdirSync(root)
+    }
+  }
+
+  assert.throws(
+    () => discoverRepository({ root }),
+    (error: unknown) => {
+      assert.equal((error as { code?: unknown }).code, 'INVALID_REPOSITORY')
+      return true
+    },
+  )
+  assert.equal(replaced, true)
 })
 
 test('memoizes verified executing package identity but reverifies the installed manifest', async () => {
@@ -253,8 +304,9 @@ test('does not memoize executing identity across a package-directory generation 
     if (!replaced && path === expectedManifest) {
       replaced = true
       renameSync(executingRoot, capturedRoot)
-      mkdirSync(executingRoot)
+      mkdirSync(join(executingRoot, 'src'), { recursive: true })
       writeFileSync(join(executingRoot, 'package.json'), '{"name":"encephalon","version":"0.2.0"}\n')
+      writeFileSync(join(executingRoot, 'src', 'package.json'), '{"name":"unrelated","type":"module"}\n')
     }
   }
 
@@ -267,13 +319,7 @@ test('does not memoize executing identity across a package-directory generation 
   )
   assert.equal(replaced, true)
   repositoryModule.repositoryTestHooks.afterExecutingManifestRead = undefined
-  assert.throws(
-    () => repositoryModule.assertRootInstallation(repositoryRoot),
-    (error: unknown) => {
-      assert.notEqual((error as { code?: unknown }).code, undefined)
-      return true
-    },
-  )
+  assert.equal(repositoryModule.assertRootInstallation(repositoryRoot), executingRoot)
 })
 
 test('rejects an executing child generation change while accepting its package parent', async () => {
@@ -316,6 +362,53 @@ test('preserves root-install-required when no executing package can be found', a
       return true
     },
   )
+})
+
+test('normalises an initial executing-directory failure', async () => {
+  const { executingRoot, repositoryRoot } = createIsolatedPackage()
+  const sourceDirectory = join(executingRoot, 'src')
+  const capturedSource = join(executingRoot, 'captured-src')
+  const repositoryModule = await import(
+    `${pathToFileURL(join(sourceDirectory, 'repository.ts')).href}?initial-executing=${Date.now()}`
+  )
+  renameSync(sourceDirectory, capturedSource)
+
+  assert.throws(
+    () => repositoryModule.assertRootInstallation(repositoryRoot),
+    (error: unknown) => {
+      assert.equal((error as { code?: unknown }).code, 'IO_ERROR')
+      assert.equal((error as Error).message.includes(executingRoot), false)
+      return true
+    },
+  )
+})
+
+test('treats a looping installed package link as a malformed installation', async () => {
+  const { executingRoot, repositoryRoot } = createIsolatedPackage()
+  const repositoryModule = await import(
+    `${pathToFileURL(join(executingRoot, 'src', 'repository.ts')).href}?installed-loop=${Date.now()}`
+  )
+  const installedPath = join(repositoryRoot, 'node_modules', 'encephalon')
+  rmSync(installedPath)
+  let linkCreated = false
+  try {
+    symlinkSync(installedPath, installedPath, process.platform === 'win32' ? 'junction' : 'dir')
+    linkCreated = true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EPERM') {
+      throw error
+    }
+  }
+
+  if (linkCreated) {
+    assert.throws(
+      () => repositoryModule.assertRootInstallation(repositoryRoot),
+      (error: unknown) => {
+        assert.equal((error as { code?: unknown }).code, 'ROOT_INSTALL_REQUIRED')
+        return true
+      },
+    )
+  }
 })
 
 test('requires the installed root to retain the memoized executing generation between calls', async () => {
@@ -401,6 +494,23 @@ test('revalidates the discovered repository generation after installation succee
     () => resolveRepository({ root }),
     (error: unknown) => {
       assert.equal((error as { code?: unknown }).code, 'INVALID_REPOSITORY')
+      return true
+    },
+  )
+})
+
+test('preserves operational failures while revalidating the resolved repository', () => {
+  const root = createTestRepository()
+  temporaryRoots.push(root)
+  repositoryTestHooks.afterRootInstallation = () => {
+    throw Object.assign(new Error('simulated input/output failure'), { code: 'EIO' })
+  }
+
+  assert.throws(
+    () => resolveRepository({ root }),
+    (error: unknown) => {
+      assert.equal((error as { code?: unknown }).code, 'IO_ERROR')
+      assert.equal((error as Error).message.includes(root), false)
       return true
     },
   )

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict'
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { afterEach, test } from 'node:test'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { discoverRepository, repositoryTestHooks } from '../src/repository.ts'
+
+const sourceRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const temporaryRoots: string[] = []
+
+const createIsolatedPackage = () => {
+  const testRoot = mkdtempSync(join(tmpdir(), 'encephalon-repository-test-'))
+  const executingRoot = join(testRoot, 'executing')
+  mkdirSync(join(executingRoot, 'src', 'generated'), { recursive: true })
+  for (const file of ['errors.ts', 'repository.ts', 'sqlite-error.ts', 'verified-file.ts']) {
+    copyFileSync(join(sourceRoot, 'src', file), join(executingRoot, 'src', file))
+  }
+  copyFileSync(
+    join(sourceRoot, 'src', 'generated', 'version.ts'),
+    join(executingRoot, 'src', 'generated', 'version.ts'),
+  )
+  writeFileSync(join(executingRoot, 'package.json'), '{"name":"encephalon","version":"0.2.0"}\n')
+
+  const repositoryRoot = join(testRoot, 'repository')
+  mkdirSync(join(repositoryRoot, 'node_modules'), { recursive: true })
+  symlinkSync(
+    executingRoot,
+    join(repositoryRoot, 'node_modules', 'encephalon'),
+    process.platform === 'win32' ? 'junction' : 'dir',
+  )
+  temporaryRoots.push(testRoot)
+  return { executingRoot, repositoryRoot }
+}
+
+afterEach(() => {
+  repositoryTestHooks.afterGitDirectoryLstat = undefined
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true })
+  }
+})
+
+test('rejects a worktree target replaced after inspection', () => {
+  const root = mkdtempSync(join(tmpdir(), 'encephalon-worktree-test-'))
+  temporaryRoots.push(root)
+  const administrationDirectory = join(root, 'administration')
+  const capturedDirectory = join(root, 'captured-administration')
+  const outsideDirectory = join(root, 'outside')
+  mkdirSync(administrationDirectory)
+  mkdirSync(outsideDirectory)
+  writeFileSync(join(root, '.git'), 'gitdir: administration\n')
+
+  assert.equal(discoverRepository({ root }), realpathSync.native(root))
+  let symlinksSupported = false
+  try {
+    symlinkSync(outsideDirectory, join(root, 'symlink-check'), process.platform === 'win32' ? 'junction' : 'dir')
+    rmSync(join(root, 'symlink-check'))
+    symlinksSupported = true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EPERM') {
+      throw error
+    }
+  }
+
+  let replaced = false
+  if (symlinksSupported) {
+    repositoryTestHooks.afterGitDirectoryLstat = path => {
+      if (!replaced && path.endsWith('/administration')) {
+        replaced = true
+        renameSync(administrationDirectory, capturedDirectory)
+        symlinkSync(outsideDirectory, administrationDirectory, process.platform === 'win32' ? 'junction' : 'dir')
+      }
+    }
+
+    assert.throws(
+      () => discoverRepository({ root }),
+      (error: unknown) => {
+        assert.equal((error as { code?: unknown }).code, 'INVALID_REPOSITORY')
+        return true
+      },
+    )
+    assert.equal(replaced, true)
+  }
+})
+
+test('rejects unsafe Git marker inputs with the stable explicit-root error', () => {
+  const cases = [
+    {
+      name: 'oversized',
+      write: (root: string) => writeFileSync(join(root, '.git'), `gitdir: ${'a'.repeat(16_384)}\n`),
+    },
+    {
+      name: 'invalid UTF-8',
+      write: (root: string) => writeFileSync(join(root, '.git'), Buffer.from([0x67, 0x69, 0x74, 0xc3, 0x28])),
+    },
+    {
+      name: 'symlink',
+      write: (root: string) => {
+        const target = join(root, 'marker-target')
+        writeFileSync(target, 'gitdir: administration\n')
+        symlinkSync(target, join(root, '.git'), 'file')
+      },
+    },
+  ]
+
+  for (const markerCase of cases) {
+    const root = mkdtempSync(join(tmpdir(), `encephalon-marker-${markerCase.name.replaceAll(' ', '-')}-`))
+    temporaryRoots.push(root)
+    mkdirSync(join(root, 'administration'))
+    let markerCreated = false
+    try {
+      markerCase.write(root)
+      markerCreated = true
+    } catch (error) {
+      if (!(markerCase.name === 'symlink' && (error as NodeJS.ErrnoException).code === 'EPERM')) {
+        throw error
+      }
+    }
+    if (markerCreated) {
+      assert.throws(
+        () => discoverRepository({ root }),
+        (error: unknown) => {
+          assert.equal((error as { code?: unknown }).code, 'INVALID_REPOSITORY')
+          assert.equal((error as Error).message.includes(root), false)
+          return true
+        },
+      )
+    }
+  }
+})
+
+test('memoizes verified executing package identity but reverifies the installed manifest', async () => {
+  const { executingRoot, repositoryRoot } = createIsolatedPackage()
+  writeFileSync(join(executingRoot, 'src', 'package.json'), '{"name":"unrelated","type":"module","version":"1.0.0"}\n')
+  const repositoryModule = await import(
+    `${pathToFileURL(join(executingRoot, 'src', 'repository.ts')).href}?test=${Date.now()}`
+  )
+
+  assert.equal(repositoryModule.assertRootInstallation(repositoryRoot), realpathSync.native(executingRoot))
+
+  writeFileSync(join(executingRoot, 'src', 'package.json'), '{not-json')
+  assert.equal(repositoryModule.assertRootInstallation(repositoryRoot), realpathSync.native(executingRoot))
+
+  writeFileSync(join(executingRoot, 'package.json'), '{not-json')
+  assert.throws(
+    () => repositoryModule.assertRootInstallation(repositoryRoot),
+    (error: unknown) => {
+      assert.equal((error as { code?: unknown }).code, 'INTERNAL_ERROR')
+      return true
+    },
+  )
+})

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -159,3 +159,62 @@ test('memoizes verified executing package identity but reverifies the installed 
     },
   )
 })
+
+test('rejects unsafe executing package manifests with a stable internal error', async () => {
+  const cases = [
+    {
+      name: 'invalid JSON',
+      write: (path: string) => writeFileSync(path, '{not-json'),
+    },
+    {
+      name: 'invalid UTF-8',
+      write: (path: string) => writeFileSync(path, Buffer.from([0x7b, 0xc3, 0x28, 0x7d])),
+    },
+    {
+      name: 'oversized',
+      write: (path: string) =>
+        writeFileSync(path, JSON.stringify({ name: 'encephalon', padding: 'x'.repeat(1024 * 1024), version: '0.2.0' })),
+    },
+    {
+      name: 'symlink',
+      write: (path: string) => {
+        const target = `${path}.target`
+        writeFileSync(target, '{"name":"encephalon","version":"0.2.0"}\n')
+        rmSync(path)
+        symlinkSync(target, path, 'file')
+      },
+    },
+  ]
+
+  await Promise.all(
+    cases.map(async manifestCase => {
+      const { executingRoot, repositoryRoot } = createIsolatedPackage()
+      writeFileSync(
+        join(executingRoot, 'src', 'package.json'),
+        '{"name":"unrelated","type":"module","version":"1.0.0"}\n',
+      )
+      let manifestWritten = false
+      try {
+        manifestCase.write(join(executingRoot, 'package.json'))
+        manifestWritten = true
+      } catch (error) {
+        if (!(manifestCase.name === 'symlink' && (error as NodeJS.ErrnoException).code === 'EPERM')) {
+          throw error
+        }
+      }
+      if (manifestWritten) {
+        const repositoryModule = await import(
+          `${pathToFileURL(join(executingRoot, 'src', 'repository.ts')).href}?unsafe=${manifestCase.name}`
+        )
+        assert.throws(
+          () => repositoryModule.assertRootInstallation(repositoryRoot),
+          (error: unknown) => {
+            assert.equal((error as { code?: unknown }).code, 'INTERNAL_ERROR')
+            assert.equal((error as Error).message.includes(executingRoot), false)
+            return true
+          },
+        )
+      }
+    }),
+  )
+})

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -22,7 +22,14 @@ const createIsolatedPackage = () => {
   const testRoot = mkdtempSync(join(tmpdir(), 'encephalon-repository-test-'))
   const executingRoot = join(testRoot, 'executing')
   mkdirSync(join(executingRoot, 'src', 'generated'), { recursive: true })
-  for (const file of ['errors.ts', 'repository.ts', 'sqlite-error.ts', 'verified-file.ts']) {
+  for (const file of [
+    'directory-witness.ts',
+    'errors.ts',
+    'file-identity.ts',
+    'repository.ts',
+    'sqlite-error.ts',
+    'verified-file.ts',
+  ]) {
     copyFileSync(join(sourceRoot, 'src', file), join(executingRoot, 'src', file))
   }
   copyFileSync(
@@ -44,6 +51,8 @@ const createIsolatedPackage = () => {
 
 afterEach(() => {
   repositoryTestHooks.afterGitDirectoryLstat = undefined
+  repositoryTestHooks.afterExecutingManifestRead = undefined
+  repositoryTestHooks.afterInstalledManifestRead = undefined
   for (const root of temporaryRoots.splice(0)) {
     rmSync(root, { force: true, recursive: true })
   }
@@ -52,12 +61,14 @@ afterEach(() => {
 test('rejects a worktree target replaced after inspection', () => {
   const root = mkdtempSync(join(tmpdir(), 'encephalon-worktree-test-'))
   temporaryRoots.push(root)
-  const administrationDirectory = join(root, 'administration')
+  const administrationRoot = mkdtempSync(join(tmpdir(), 'encephalon-worktree-administration-test-'))
+  temporaryRoots.push(administrationRoot)
+  const administrationDirectory = join(administrationRoot, 'administration')
   const capturedDirectory = join(root, 'captured-administration')
   const outsideDirectory = join(root, 'outside')
   mkdirSync(administrationDirectory)
   mkdirSync(outsideDirectory)
-  writeFileSync(join(root, '.git'), 'gitdir: administration\n')
+  writeFileSync(join(root, '.git'), `gitdir: ${administrationDirectory}\n`)
 
   assert.equal(discoverRepository({ root }), realpathSync.native(root))
   let symlinksSupported = false
@@ -74,7 +85,7 @@ test('rejects a worktree target replaced after inspection', () => {
   let replaced = false
   if (symlinksSupported) {
     repositoryTestHooks.afterGitDirectoryLstat = path => {
-      if (!replaced && path.endsWith('/administration')) {
+      if (!replaced && path === administrationDirectory) {
         replaced = true
         renameSync(administrationDirectory, capturedDirectory)
         symlinkSync(outsideDirectory, administrationDirectory, process.platform === 'win32' ? 'junction' : 'dir')
@@ -96,7 +107,8 @@ test('rejects unsafe Git marker inputs with the stable explicit-root error', () 
   const cases = [
     {
       name: 'oversized',
-      write: (root: string) => writeFileSync(join(root, '.git'), `gitdir: ${'a'.repeat(16_384)}\n`),
+      write: (root: string) =>
+        writeFileSync(join(root, '.git'), `gitdir: ${join(root, 'administration')}${' '.repeat(16_384)}\n`),
     },
     {
       name: 'invalid UTF-8',
@@ -154,10 +166,86 @@ test('memoizes verified executing package identity but reverifies the installed 
   assert.throws(
     () => repositoryModule.assertRootInstallation(repositoryRoot),
     (error: unknown) => {
+      assert.equal((error as { code?: unknown }).code, 'ROOT_INSTALL_REQUIRED')
+      return true
+    },
+  )
+})
+
+test('rejects an oversized installed manifest after executing identity is cached', async () => {
+  const { executingRoot, repositoryRoot } = createIsolatedPackage()
+  writeFileSync(join(executingRoot, 'src', 'package.json'), '{"name":"unrelated","type":"module"}\n')
+  const repositoryModule = await import(
+    `${pathToFileURL(join(executingRoot, 'src', 'repository.ts')).href}?installed-bound=${Date.now()}`
+  )
+  assert.equal(repositoryModule.assertRootInstallation(repositoryRoot), realpathSync.native(executingRoot))
+
+  writeFileSync(
+    join(executingRoot, 'package.json'),
+    JSON.stringify({ name: 'encephalon', padding: 'x'.repeat(1024 * 1024), version: '0.2.0' }),
+  )
+  assert.throws(
+    () => repositoryModule.assertRootInstallation(repositoryRoot),
+    (error: unknown) => {
+      assert.equal((error as { code?: unknown }).code, 'ROOT_INSTALL_REQUIRED')
+      return true
+    },
+  )
+})
+
+test('does not memoize executing identity across a package-directory generation change', async () => {
+  const { executingRoot, repositoryRoot } = createIsolatedPackage()
+  writeFileSync(join(executingRoot, 'src', 'package.json'), '{"name":"unrelated","type":"module"}\n')
+  const repositoryModule = await import(
+    `${pathToFileURL(join(executingRoot, 'src', 'repository.ts')).href}?executing-generation=${Date.now()}`
+  )
+  const capturedRoot = `${executingRoot}-captured`
+  let replaced = false
+  repositoryModule.repositoryTestHooks.afterExecutingManifestRead = (path: string) => {
+    if (!replaced && path.endsWith('/executing/package.json')) {
+      replaced = true
+      renameSync(executingRoot, capturedRoot)
+      mkdirSync(executingRoot)
+      writeFileSync(join(executingRoot, 'package.json'), '{"name":"encephalon","version":"0.2.0"}\n')
+    }
+  }
+
+  assert.throws(
+    () => repositoryModule.assertRootInstallation(repositoryRoot),
+    (error: unknown) => {
       assert.equal((error as { code?: unknown }).code, 'INTERNAL_ERROR')
       return true
     },
   )
+  assert.equal(replaced, true)
+})
+
+test('rejects an installed package-directory generation change after its manifest read', async () => {
+  const { executingRoot, repositoryRoot } = createIsolatedPackage()
+  writeFileSync(join(executingRoot, 'src', 'package.json'), '{"name":"unrelated","type":"module"}\n')
+  const repositoryModule = await import(
+    `${pathToFileURL(join(executingRoot, 'src', 'repository.ts')).href}?installed-generation=${Date.now()}`
+  )
+  assert.equal(repositoryModule.assertRootInstallation(repositoryRoot), realpathSync.native(executingRoot))
+  const capturedRoot = `${executingRoot}-captured`
+  let replaced = false
+  repositoryModule.repositoryTestHooks.afterInstalledManifestRead = () => {
+    if (!replaced) {
+      replaced = true
+      renameSync(executingRoot, capturedRoot)
+      mkdirSync(executingRoot)
+      writeFileSync(join(executingRoot, 'package.json'), '{"name":"encephalon","version":"0.2.0"}\n')
+    }
+  }
+
+  assert.throws(
+    () => repositoryModule.assertRootInstallation(repositoryRoot),
+    (error: unknown) => {
+      assert.equal((error as { code?: unknown }).code, 'ROOT_INSTALL_REQUIRED')
+      return true
+    },
+  )
+  assert.equal(replaced, true)
 })
 
 test('rejects unsafe executing package manifests with a stable internal error', async () => {

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -13,19 +13,21 @@ import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { afterEach, test } from 'node:test'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-import { discoverRepository, repositoryTestHooks } from '../src/repository.ts'
+import { discoverRepository, repositoryTestHooks, resolveRepository } from '../src/repository.ts'
+import { createTestRepository } from './helpers.ts'
 
 const sourceRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const temporaryRoots: string[] = []
 
-const createIsolatedPackage = () => {
+const createIsolatedPackage = (options: { packageManifest?: boolean } = {}) => {
   const testRoot = mkdtempSync(join(tmpdir(), 'encephalon-repository-test-'))
-  const executingRoot = join(testRoot, 'executing')
-  mkdirSync(join(executingRoot, 'src', 'generated'), { recursive: true })
+  const executingPath = join(testRoot, 'executing')
+  mkdirSync(join(executingPath, 'src', 'generated'), { recursive: true })
+  const executingRoot = realpathSync.native(executingPath)
   for (const file of [
     'directory-witness.ts',
     'errors.ts',
-    'file-identity.ts',
+    'filesystem-entry.ts',
     'repository.ts',
     'sqlite-error.ts',
     'verified-file.ts',
@@ -36,7 +38,9 @@ const createIsolatedPackage = () => {
     join(sourceRoot, 'src', 'generated', 'version.ts'),
     join(executingRoot, 'src', 'generated', 'version.ts'),
   )
-  writeFileSync(join(executingRoot, 'package.json'), '{"name":"encephalon","version":"0.2.0"}\n')
+  if (options.packageManifest !== false) {
+    writeFileSync(join(executingRoot, 'package.json'), '{"name":"encephalon","version":"0.2.0"}\n')
+  }
 
   const repositoryRoot = join(testRoot, 'repository')
   mkdirSync(join(repositoryRoot, 'node_modules'), { recursive: true })
@@ -52,10 +56,53 @@ const createIsolatedPackage = () => {
 afterEach(() => {
   repositoryTestHooks.afterGitDirectoryLstat = undefined
   repositoryTestHooks.afterExecutingManifestRead = undefined
+  repositoryTestHooks.afterExecutingParentCapture = undefined
   repositoryTestHooks.afterInstalledManifestRead = undefined
+  repositoryTestHooks.afterRepositoryParentCapture = undefined
+  repositoryTestHooks.afterRootInstallation = undefined
   for (const root of temporaryRoots.splice(0)) {
     rmSync(root, { force: true, recursive: true })
   }
+})
+
+test('classifies an explicit regular-file root as an invalid repository', () => {
+  const root = mkdtempSync(join(tmpdir(), 'encephalon-regular-root-test-'))
+  temporaryRoots.push(root)
+  const file = join(root, 'root-file')
+  writeFileSync(file, 'not a directory')
+
+  assert.throws(
+    () => discoverRepository({ root: file }),
+    (error: unknown) => {
+      assert.equal((error as { code?: unknown }).code, 'INVALID_REPOSITORY')
+      return true
+    },
+  )
+})
+
+test('rejects a child generation change while ascending to a repository parent', () => {
+  const root = createTestRepository()
+  temporaryRoots.push(root)
+  const child = join(root, 'packages', 'app')
+  const captured = join(root, 'packages', 'captured-app')
+  mkdirSync(child, { recursive: true })
+  let replaced = false
+  repositoryTestHooks.afterRepositoryParentCapture = (path: string) => {
+    if (!replaced && path === child) {
+      replaced = true
+      renameSync(child, captured)
+      mkdirSync(child)
+    }
+  }
+
+  assert.throws(
+    () => discoverRepository({ start: child }),
+    (error: unknown) => {
+      assert.equal((error as { code?: unknown }).code, 'INVALID_REPOSITORY')
+      return true
+    },
+  )
+  assert.equal(replaced, true)
 })
 
 test('rejects a worktree target replaced after inspection', () => {
@@ -200,9 +247,10 @@ test('does not memoize executing identity across a package-directory generation 
     `${pathToFileURL(join(executingRoot, 'src', 'repository.ts')).href}?executing-generation=${Date.now()}`
   )
   const capturedRoot = `${executingRoot}-captured`
+  const expectedManifest = join(executingRoot, 'package.json')
   let replaced = false
   repositoryModule.repositoryTestHooks.afterExecutingManifestRead = (path: string) => {
-    if (!replaced && path.endsWith('/executing/package.json')) {
+    if (!replaced && path === expectedManifest) {
       replaced = true
       renameSync(executingRoot, capturedRoot)
       mkdirSync(executingRoot)
@@ -218,6 +266,78 @@ test('does not memoize executing identity across a package-directory generation 
     },
   )
   assert.equal(replaced, true)
+  repositoryModule.repositoryTestHooks.afterExecutingManifestRead = undefined
+  assert.throws(
+    () => repositoryModule.assertRootInstallation(repositoryRoot),
+    (error: unknown) => {
+      assert.notEqual((error as { code?: unknown }).code, undefined)
+      return true
+    },
+  )
+})
+
+test('rejects an executing child generation change while accepting its package parent', async () => {
+  const { executingRoot, repositoryRoot } = createIsolatedPackage()
+  const sourceDirectory = join(executingRoot, 'src')
+  const capturedSource = join(executingRoot, 'captured-src')
+  writeFileSync(join(sourceDirectory, 'package.json'), '{"name":"unrelated","type":"module"}\n')
+  const repositoryModule = await import(
+    `${pathToFileURL(join(sourceDirectory, 'repository.ts')).href}?executing-transition=${Date.now()}`
+  )
+  let replaced = false
+  repositoryModule.repositoryTestHooks.afterExecutingParentCapture = (path: string) => {
+    if (!replaced && path === sourceDirectory) {
+      replaced = true
+      renameSync(sourceDirectory, capturedSource)
+      mkdirSync(sourceDirectory)
+    }
+  }
+
+  assert.throws(
+    () => repositoryModule.assertRootInstallation(repositoryRoot),
+    (error: unknown) => {
+      assert.equal((error as { code?: unknown }).code, 'INTERNAL_ERROR')
+      return true
+    },
+  )
+  assert.equal(replaced, true)
+})
+
+test('preserves root-install-required when no executing package can be found', async () => {
+  const { executingRoot, repositoryRoot } = createIsolatedPackage({ packageManifest: false })
+  const repositoryModule = await import(
+    `${pathToFileURL(join(executingRoot, 'src', 'repository.ts')).href}?missing-executing=${Date.now()}`
+  )
+
+  assert.throws(
+    () => repositoryModule.assertRootInstallation(repositoryRoot),
+    (error: unknown) => {
+      assert.equal((error as { code?: unknown }).code, 'ROOT_INSTALL_REQUIRED')
+      return true
+    },
+  )
+})
+
+test('requires the installed root to retain the memoized executing generation between calls', async () => {
+  const { executingRoot, repositoryRoot } = createIsolatedPackage()
+  writeFileSync(join(executingRoot, 'src', 'package.json'), '{"name":"unrelated","type":"module"}\n')
+  const repositoryModule = await import(
+    `${pathToFileURL(join(executingRoot, 'src', 'repository.ts')).href}?memo-generation=${Date.now()}`
+  )
+  assert.equal(repositoryModule.assertRootInstallation(repositoryRoot), executingRoot)
+
+  const capturedRoot = `${executingRoot}-captured`
+  renameSync(executingRoot, capturedRoot)
+  mkdirSync(executingRoot)
+  writeFileSync(join(executingRoot, 'package.json'), '{"name":"encephalon","version":"0.2.0"}\n')
+
+  assert.throws(
+    () => repositoryModule.assertRootInstallation(repositoryRoot),
+    (error: unknown) => {
+      assert.equal((error as { code?: unknown }).code, 'ROOT_INSTALL_REQUIRED')
+      return true
+    },
+  )
 })
 
 test('rejects an installed package-directory generation change after its manifest read', async () => {
@@ -246,6 +366,44 @@ test('rejects an installed package-directory generation change after its manifes
     },
   )
   assert.equal(replaced, true)
+})
+
+test('preserves operational installed-manifest failures as I/O errors', async () => {
+  const { executingRoot, repositoryRoot } = createIsolatedPackage()
+  writeFileSync(join(executingRoot, 'src', 'package.json'), '{"name":"unrelated","type":"module"}\n')
+  const repositoryModule = await import(
+    `${pathToFileURL(join(executingRoot, 'src', 'repository.ts')).href}?installed-io=${Date.now()}`
+  )
+  repositoryModule.repositoryTestHooks.afterInstalledManifestRead = () => {
+    throw Object.assign(new Error('simulated input/output failure'), { code: 'EIO' })
+  }
+
+  assert.throws(
+    () => repositoryModule.assertRootInstallation(repositoryRoot),
+    (error: unknown) => {
+      assert.equal((error as { code?: unknown }).code, 'IO_ERROR')
+      return true
+    },
+  )
+})
+
+test('revalidates the discovered repository generation after installation succeeds', () => {
+  const root = createTestRepository()
+  temporaryRoots.push(root)
+  const captured = `${root}-captured`
+  temporaryRoots.push(captured)
+  repositoryTestHooks.afterRootInstallation = () => {
+    renameSync(root, captured)
+    mkdirSync(root)
+  }
+
+  assert.throws(
+    () => resolveRepository({ root }),
+    (error: unknown) => {
+      assert.equal((error as { code?: unknown }).code, 'INVALID_REPOSITORY')
+      return true
+    },
+  )
 })
 
 test('rejects unsafe executing package manifests with a stable internal error', async () => {

--- a/test/verified-file.test.ts
+++ b/test/verified-file.test.ts
@@ -64,7 +64,7 @@ test('reads only bounded regular files and decodes UTF-8 fatally', () => {
   }
 })
 
-test('rejects a path replaced between lstat and descriptor verification', () => {
+test('rejects a regular file replacement before descriptor verification without reading it', () => {
   const root = createRoot()
   const marker = join(root, 'marker')
   const captured = join(root, 'captured')
@@ -72,40 +72,27 @@ test('rejects a path replaced between lstat and descriptor verification', () => 
   writeFileSync(marker, 'gitdir: expected\n')
   writeFileSync(outside, 'gitdir: attacker-controlled\n')
 
-  let symlinksSupported = false
-  try {
-    symlinkSync(outside, join(root, 'symlink-check'), 'file')
-    rmSync(join(root, 'symlink-check'))
-    symlinksSupported = true
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'EPERM') {
-      throw error
-    }
-  }
-
-  if (symlinksSupported) {
-    let descriptorReached = false
-    assert.throws(
-      () =>
-        readVerifiedRegularFile(marker, 64, {
-          fault: point => {
-            if (point === 'after-lstat') {
-              renameSync(marker, captured)
-              symlinkSync(outside, marker, 'file')
-            }
-            if (point === 'after-fstat') {
-              descriptorReached = true
-            }
-          },
-        }),
-      (error: unknown) => {
-        assert.equal(error instanceof VerifiedFileError, true)
-        assert.equal((error as Error).message.includes(root), false)
-        return true
-      },
-    )
-    assert.equal(descriptorReached, false)
-  }
+  let descriptorReached = false
+  assert.throws(
+    () =>
+      readVerifiedRegularFile(marker, 64, {
+        fault: point => {
+          if (point === 'after-lstat') {
+            renameSync(marker, captured)
+            renameSync(outside, marker)
+          }
+          if (point === 'after-fstat') {
+            descriptorReached = true
+          }
+        },
+      }),
+    (error: unknown) => {
+      assert.equal(error instanceof VerifiedFileError, true)
+      assert.equal((error as Error).message.includes(root), false)
+      return true
+    },
+  )
+  assert.equal(descriptorReached, false)
 })
 
 test('rejects a pathname replacement after the descriptor final metadata check', () => {

--- a/test/verified-file.test.ts
+++ b/test/verified-file.test.ts
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, renameSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, test } from 'node:test'
+import { decodeVerifiedUtf8, readVerifiedRegularFile, VerifiedFileError } from '../src/verified-file.ts'
+
+const temporaryRoots: string[] = []
+
+const createRoot = () => {
+  const root = mkdtempSync(join(tmpdir(), 'encephalon-verified-file-test-'))
+  temporaryRoots.push(root)
+  return root
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true })
+  }
+})
+
+test('reads only bounded regular files and decodes UTF-8 fatally', () => {
+  const root = createRoot()
+  const file = join(root, 'marker')
+  writeFileSync(file, 'gitdir: admin\n')
+
+  assert.equal(readVerifiedRegularFile(join(root, 'missing'), 64), undefined)
+  const bytes = readVerifiedRegularFile(file, 64)
+  if (bytes !== undefined) {
+    assert.equal(decodeVerifiedUtf8(bytes), 'gitdir: admin\n')
+  }
+  assert.notEqual(bytes, undefined)
+  assert.throws(() => readVerifiedRegularFile(file, 4), VerifiedFileError)
+
+  const directory = join(root, 'directory')
+  mkdirSync(directory)
+  assert.throws(() => readVerifiedRegularFile(directory, 64), VerifiedFileError)
+  assert.throws(() => decodeVerifiedUtf8(Buffer.from([0xc3, 0x28])), VerifiedFileError)
+
+  const link = join(root, 'link')
+  let linkCreated = false
+  try {
+    symlinkSync(file, link, 'file')
+    linkCreated = true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EPERM') {
+      throw error
+    }
+  }
+  if (linkCreated) {
+    assert.throws(() => readVerifiedRegularFile(link, 64), VerifiedFileError)
+  }
+})
+
+test('rejects a path replaced between lstat and descriptor verification', () => {
+  const root = createRoot()
+  const marker = join(root, 'marker')
+  const captured = join(root, 'captured')
+  const outside = join(root, 'outside')
+  writeFileSync(marker, 'gitdir: expected\n')
+  writeFileSync(outside, 'gitdir: attacker-controlled\n')
+
+  let symlinksSupported = false
+  try {
+    symlinkSync(outside, join(root, 'symlink-check'), 'file')
+    rmSync(join(root, 'symlink-check'))
+    symlinksSupported = true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EPERM') {
+      throw error
+    }
+  }
+
+  if (symlinksSupported) {
+    assert.throws(
+      () =>
+        readVerifiedRegularFile(marker, 64, {
+          fault: point => {
+            if (point === 'after-lstat') {
+              renameSync(marker, captured)
+              symlinkSync(outside, marker, 'file')
+            }
+          },
+        }),
+      (error: unknown) => {
+        assert.equal(error instanceof VerifiedFileError, true)
+        assert.equal((error as Error).message.includes(root), false)
+        return true
+      },
+    )
+  }
+})
+
+test('rejects a file whose descriptor changes after its initial metadata check', () => {
+  const root = createRoot()
+  const manifest = join(root, 'package.json')
+  writeFileSync(manifest, '{"name":"encephalon"}')
+
+  assert.throws(
+    () =>
+      readVerifiedRegularFile(manifest, 1024, {
+        fault: point => {
+          if (point === 'after-fstat') {
+            writeFileSync(manifest, '{"name":"encephalon","changed":true}')
+          }
+        },
+      }),
+    VerifiedFileError,
+  )
+})

--- a/test/verified-file.test.ts
+++ b/test/verified-file.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { linkSync, mkdirSync, mkdtempSync, renameSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, test } from 'node:test'
@@ -25,12 +25,21 @@ test('reads only bounded regular files and decodes UTF-8 fatally', () => {
   writeFileSync(file, 'gitdir: admin\n')
 
   assert.equal(readVerifiedRegularFile(join(root, 'missing'), 64), undefined)
-  const bytes = readVerifiedRegularFile(file, 64)
+  let allocationReached = false
+  const bytes = readVerifiedRegularFile(file, 64, {
+    fault: point => {
+      if (point === 'before-allocation') {
+        allocationReached = true
+      }
+    },
+  })
   if (bytes !== undefined) {
     assert.equal(decodeVerifiedUtf8(bytes), 'gitdir: admin\n')
   }
   assert.notEqual(bytes, undefined)
+  assert.equal(allocationReached, true)
   let oversizedDescriptorReached = false
+  allocationReached = false
   assert.throws(
     () =>
       readVerifiedRegularFile(file, 4, {
@@ -38,11 +47,15 @@ test('reads only bounded regular files and decodes UTF-8 fatally', () => {
           if (point === 'after-fstat') {
             oversizedDescriptorReached = true
           }
+          if (point === 'before-allocation') {
+            allocationReached = true
+          }
         },
       }),
     VerifiedFileError,
   )
   assert.equal(oversizedDescriptorReached, false)
+  assert.equal(allocationReached, false)
 
   const directory = join(root, 'directory')
   mkdirSync(directory)
@@ -99,7 +112,9 @@ test('rejects a pathname replacement after the descriptor final metadata check',
   const root = createRoot()
   const manifest = join(root, 'package.json')
   const captured = join(root, 'captured.json')
+  const successor = join(root, 'successor.json')
   writeFileSync(manifest, '{"name":"encephalon"}')
+  writeFileSync(successor, '{"name":"successor"}')
 
   assert.throws(
     () =>
@@ -107,12 +122,14 @@ test('rejects a pathname replacement after the descriptor final metadata check',
         fault: point => {
           if (point === 'before-final-path-lstat') {
             renameSync(manifest, captured)
-            linkSync(captured, manifest)
+            renameSync(successor, manifest)
           }
         },
       }),
     VerifiedFileError,
   )
+  assert.equal(readFileSync(captured, 'utf8'), '{"name":"encephalon"}')
+  assert.equal(readFileSync(manifest, 'utf8'), '{"name":"successor"}')
 })
 
 test('rejects a file whose descriptor changes after its initial metadata check', () => {

--- a/test/verified-file.test.ts
+++ b/test/verified-file.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdirSync, mkdtempSync, renameSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { linkSync, mkdirSync, mkdtempSync, renameSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, test } from 'node:test'
@@ -30,7 +30,19 @@ test('reads only bounded regular files and decodes UTF-8 fatally', () => {
     assert.equal(decodeVerifiedUtf8(bytes), 'gitdir: admin\n')
   }
   assert.notEqual(bytes, undefined)
-  assert.throws(() => readVerifiedRegularFile(file, 4), VerifiedFileError)
+  let oversizedDescriptorReached = false
+  assert.throws(
+    () =>
+      readVerifiedRegularFile(file, 4, {
+        fault: point => {
+          if (point === 'after-fstat') {
+            oversizedDescriptorReached = true
+          }
+        },
+      }),
+    VerifiedFileError,
+  )
+  assert.equal(oversizedDescriptorReached, false)
 
   const directory = join(root, 'directory')
   mkdirSync(directory)
@@ -72,6 +84,7 @@ test('rejects a path replaced between lstat and descriptor verification', () => 
   }
 
   if (symlinksSupported) {
+    let descriptorReached = false
     assert.throws(
       () =>
         readVerifiedRegularFile(marker, 64, {
@@ -79,6 +92,9 @@ test('rejects a path replaced between lstat and descriptor verification', () => 
             if (point === 'after-lstat') {
               renameSync(marker, captured)
               symlinkSync(outside, marker, 'file')
+            }
+            if (point === 'after-fstat') {
+              descriptorReached = true
             }
           },
         }),
@@ -88,7 +104,28 @@ test('rejects a path replaced between lstat and descriptor verification', () => 
         return true
       },
     )
+    assert.equal(descriptorReached, false)
   }
+})
+
+test('rejects a pathname replacement after the descriptor final metadata check', () => {
+  const root = createRoot()
+  const manifest = join(root, 'package.json')
+  const captured = join(root, 'captured.json')
+  writeFileSync(manifest, '{"name":"encephalon"}')
+
+  assert.throws(
+    () =>
+      readVerifiedRegularFile(manifest, 1024, {
+        fault: point => {
+          if (point === 'before-final-path-lstat') {
+            renameSync(manifest, captured)
+            linkSync(captured, manifest)
+          }
+        },
+      }),
+    VerifiedFileError,
+  )
 })
 
 test('rejects a file whose descriptor changes after its initial metadata check', () => {


### PR DESCRIPTION
## Human summary

Repository discovery now verifies Git markers, worktree targets, and package manifests through bounded filesystem identities, so concurrent path replacement or unsafe files cannot silently change which repository or installation Encephalon trusts.

## Summary

- Read Git marker files and package manifests through bounded, no-follow regular-file descriptors with fatal UTF-8 decoding and stable metadata checks.
- Capture and revalidate filesystem-directory generations across native realpath resolution, parent ascent, Git proof, package discovery, and root-installation verification.
- Cache the executing package identity only after its manifest and exact canonical directory generation are verified, while reverifying the installed package on every repository resolution.
- Require worktree targets to be non-empty and NUL-free while continuing to support legitimate absolute administration directories outside the worktree.
- Preserve actionable `INVALID_REPOSITORY`, `ROOT_INSTALL_REQUIRED`, and `IO_ERROR` classifications without leaking unsafe paths or file contents.
- Build the CLI once before the concurrent Node test suite to avoid test-induced directory-generation replacement.
- Add deterministic replacement, mutation, malformed-input, size-bound, UTF-8, symlink, worktree, memoisation, and error-policy coverage.
- Document the maintained repository-input and directory-generation contract.

## Validation

- `bun run test`: 238/238, twice consecutively
- `bun run lint`
- `bun run typecheck`
- `bun run benchmark`
- `bun run benchmark:check`
- `bun run build`
- `bun run check:package`
- `bun run check:publish`

Linear: https://linear.app/marcoappio/issue/MAR-2570/repository-read-git-and-package-markers-through-bounded-verified
