### PR TITLE
[MAR-2561] Centralise operation budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,11 @@ npx --no-install encephalon validate
 
 Active records are returned by default. Add `--include-superseded` to `list`, `search`, or `gather` when historical records are needed. Missing `show` results are `null`, and empty searches are `[]`.
 
-Search queries may contain at most 1,024 UTF-8 bytes and 32 literal terms. Full-record APIs return at most 50 records and stop once the aggregate JSON response would exceed 4 MiB; compact search returns at most 100 results. One `gather` request may include at most 16 searches and 64 shows. Narrow the kind/query or request compact results when a full-record response exceeds these budgets.
+### Operation budgets
+
+List and full search accept 1–50 results. Compact search and each gather search accept 1–100 results. A gather request accepts at most 16 searches and 64 shows, while an add request accepts at most 1,000 supersession targets. Search queries are limited to 1,024 UTF-8 bytes and 32 literal terms. Full-record responses from list, show, full search, and gather contain at most 4 MiB of aggregate record JSON.
+
+An oversized result limit, gather input count, or supersedes input count fails with `INVALID_ARGUMENT` before item validation, repository discovery, or cache I/O. Budget errors expose only the fixed details `{ field, budget, maximum }`; they do not include input arrays, individual values, queries, paths, or other input content. Cache checks retain the same limits as defence-in-depth for internal callers. Narrow the kind/query or request compact results when a full-record response exceeds these budgets.
 
 ## Add durable knowledge
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-13 for code and behavioural-test snapshot `2874874096bb7d327e084d7e17d5243564244c43`.
+Last reviewed: 2026-08-13 for code and behavioural-test snapshot `6dc60e13e8e99b05fef566d4b80aeb663328664c`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -15,6 +15,15 @@ This document is the concise contract maintainers should update when public beha
 - Git marker files and package manifests used for repository or executing-package identity are read through bounded, no-follow regular-file descriptors with stable identity and fatal UTF-8 decoding. Worktree targets must be non-empty and NUL-free, and are accepted only when their real-directory identity remains stable across native realpath resolution. Repository and executing-package ascent also revalidate each child generation after capturing its parent.
 - Executing package identity is cached only after its manifest and exact canonical directory generation have been verified successfully. Each repository root still reverifies its installed Encephalon manifest and directory generation on every resolution, and the installed generation must match the cached executing generation. The discovered repository generation remains verified through root-installation acceptance. Unsafe or malformed installed manifests use the generic root-install-required failure; path-generation changes use the stable repository classification while operational filesystem failures retain the stable I/O error classification.
 
+## Operation Budgets
+
+- `list` and full `search` accept result limits from 1 through 50. Compact `search` and each `gather` search accept result limits from 1 through 100. The default remains 20.
+- A `gather` input contains at most 16 searches and 64 shows. An add-record input contains at most 1,000 supersession targets.
+- Every search query contains at most 1,024 UTF-8 bytes and 32 literal terms. Full-record responses from list, show, full search, and gather contain at most 4 MiB of aggregate record JSON.
+- An oversized result limit, gather input count, or supersedes input count fails with `INVALID_ARGUMENT` before item validation, repository discovery, cache-location inspection, SQLite access, hydration, or other repository/cache hooks. Count checks run before mapping or uniqueness-set construction. Cache execution retains matching defensive checks for internal callers and future refactors.
+- Budget failures contain exactly the bounded details `{ field, budget, maximum }`. Stable budget names are `fullResultLimit`, `compactResultLimit`, `queryBytes`, `queryTerms`, `gatherSearches`, `gatherShows`, `supersessionEdges`, and `fullResponseBytes`; details exclude arrays, individual values, queries, paths, and other input content.
+- The fixed budget authority is internal. It is not exported by `src/index.ts` and does not change the public TypeScript input or result shapes.
+
 ## Canonical Storage
 
 - Canonical knowledge is append-only JSON under `encephalon/<kind>/<id>.json`.

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-13 for code and behavioural-test snapshot `6dc60e13e8e99b05fef566d4b80aeb663328664c`.
+Last reviewed: 2026-08-13 for code and behavioural-test snapshot `011360c808a61a94a98683cbecf059da46a18471`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 
@@ -20,7 +20,7 @@ This document is the concise contract maintainers should update when public beha
 - `list` and full `search` accept result limits from 1 through 50. Compact `search` and each `gather` search accept result limits from 1 through 100. The default remains 20.
 - A `gather` input contains at most 16 searches and 64 shows. An add-record input contains at most 1,000 supersession targets.
 - Every search query contains at most 1,024 UTF-8 bytes and 32 literal terms. Full-record responses from list, show, full search, and gather contain at most 4 MiB of aggregate record JSON.
-- An oversized result limit, gather input count, or supersedes input count fails with `INVALID_ARGUMENT` before item validation, repository discovery, cache-location inspection, SQLite access, hydration, or other repository/cache hooks. Count checks run before mapping or uniqueness-set construction. Cache execution retains matching defensive checks for internal callers and future refactors.
+- An oversized result limit, gather input count, or supersedes input count fails with `INVALID_ARGUMENT` before item validation, repository discovery, cache-location inspection, SQLite access, hydration, or other repository/cache hooks. Both gather arrays are structurally checked and count-checked before either array's items are validated or mapped. The CLI preflights raw repeated-option counts before option-value normalisation. Cache execution retains matching defensive checks for internal callers and future refactors.
 - Budget failures contain exactly the bounded details `{ field, budget, maximum }`. Stable budget names are `fullResultLimit`, `compactResultLimit`, `queryBytes`, `queryTerms`, `gatherSearches`, `gatherShows`, `supersessionEdges`, and `fullResponseBytes`; details exclude arrays, individual values, queries, paths, and other input content.
 - The fixed budget authority is internal. It is not exported by `src/index.ts` and does not change the public TypeScript input or result shapes.
 
@@ -126,7 +126,7 @@ When an implementation change intentionally alters this contract:
 | --- | --- |
 | The implementation plan claimed to be the authoritative specification. | Superseded by this maintained contract; the plan is now marked historical. |
 | Managed instruction files use atomic byte-preserving replacement rather than the original broad plan wording. | Implemented and tested by the instruction-file atomicity work tracked in MAR-2509, MAR-2511, and MAR-2512. |
-| CLI parsing is being moved to `node:util` `parseArgs`. | Owned by MAR-2536. Until that PR lands, current behaviour remains covered by CLI tests. |
+| CLI parsing moved from bespoke parsing to `node:util` `parseArgs`. | Completed under MAR-2536; current option semantics remain covered by CLI tests. |
 | Cache versioning and runtime package-version handling drifted from the original plan. | Owned by MAR-2524 and the cache compatibility tests. The maintained contract treats the cache as disposable derived state gated by explicit metadata. |
 | The packaged skill uses `npx --no-install encephalon ...` examples instead of direct `node ./node_modules/encephalon/dist/cli.mjs` examples. | Accepted current contract. Root-install verification prevents ephemeral package execution, and package tests assert the skill guidance. |
 | CI and release gates evolved after the original plan. | Owned by MAR-2527 for CI package gates. The maintained release contract remains the checked package scripts plus manual publishing. |

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-13 for code and behavioural-test snapshot `011360c808a61a94a98683cbecf059da46a18471`.
+Last reviewed: 2026-08-13 for code and behavioural-test snapshot `1e913807c20a332dc49a004be672205fbeabfe15`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 
@@ -19,7 +19,7 @@ This document is the concise contract maintainers should update when public beha
 
 - `list` and full `search` accept result limits from 1 through 50. Compact `search` and each `gather` search accept result limits from 1 through 100. The default remains 20.
 - A `gather` input contains at most 16 searches and 64 shows. An add-record input contains at most 1,000 supersession targets.
-- Every search query contains at most 1,024 UTF-8 bytes and 32 literal terms. Full-record responses from list, show, full search, and gather contain at most 4 MiB of aggregate record JSON.
+- Every search query contains at most 1,024 UTF-8 bytes and 32 literal terms. Full-record responses from list, show, and full search contain at most 4 MiB of aggregate record JSON. One gather shares that aggregate budget across all requested full shown records; its compact search results do not consume the full-response budget.
 - An oversized result limit, gather input count, or supersedes input count fails with `INVALID_ARGUMENT` before item validation, repository discovery, cache-location inspection, SQLite access, hydration, or other repository/cache hooks. Both gather arrays are structurally checked and count-checked before either array's items are validated or mapped. The CLI preflights raw repeated-option counts before option-value normalisation. Cache execution retains matching defensive checks for internal callers and future refactors.
 - Budget failures contain exactly the bounded details `{ field, budget, maximum }`. Stable budget names are `fullResultLimit`, `compactResultLimit`, `queryBytes`, `queryTerms`, `gatherSearches`, `gatherShows`, `supersessionEdges`, and `fullResponseBytes`; details exclude arrays, individual values, queries, paths, and other input content.
 - The fixed budget authority is internal. It is not exported by `src/index.ts` and does not change the public TypeScript input or result shapes.

--- a/docs/superpowers/plans/2026-08-13-operation-budgets.md
+++ b/docs/superpowers/plans/2026-08-13-operation-budgets.md
@@ -1,0 +1,351 @@
+# Operation Budgets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Centralise fixed operation budgets and reject over-limit result counts and arrays before item validation, repository discovery, or cache work.
+
+**Architecture:** A dependency-free `src/operation-budgets.ts` owns immutable budget specifications. API/schema parsers enforce them first, cache execution retains matching defensive checks, and CLI/help/package/docs consume the same values without expanding the public export surface.
+
+**Tech Stack:** TypeScript ESM, Node 24 test runner, Bun scripts, SQLite cache integration.
+
+## Global Constraints
+
+- Full list and full search accept result limits from 1 through 50; compact search and gather accept 1 through 100; all keep a default of 20.
+- Gather accepts at most 16 searches and 64 shows; supersedes accepts at most 1,000 entries before item validation.
+- Existing query limits remain 1,024 UTF-8 bytes and 32 literal terms; existing full-response limit remains 4 MiB.
+- Every budget failure is `INVALID_ARGUMENT` with bounded details `{ field, budget, maximum }` and no input contents.
+- Stable budget names are `fullResultLimit`, `compactResultLimit`, `queryBytes`, `queryTerms`, `gatherSearches`, `gatherShows`, `fullResponseBytes`, and `supersessionEdges`.
+- Public TypeScript input/result shapes and `src/index.ts` exports do not change.
+- Cache assertions remain as defence in depth and use the same specifications as parsing.
+- Use ordinary dense arrays in tests; sparse/accessor/proxy behaviour remains MAR-2572 scope.
+- `bunfig.toml` retains `telemetry = false`, `[install] exact = true`, and `saveTextLockfile = true`; `bun.lock` remains plaintext and unchanged.
+- Commit titles use `[MAR-2561] Plain English title` with British English prose.
+
+---
+
+### Task 1: Establish the authority and operation-specific API parsing
+
+**Files:**
+- Create: `src/operation-budgets.ts`
+- Modify: `src/errors.ts`
+- Modify: `src/api-input.ts`
+- Create: `test/api-input.test.ts`
+
+**Interfaces:**
+- Produces: `OPERATION_BUDGETS` with the exact keys and values in the design.
+- Produces: `failBudget(field: string, budget: string, maximum: number, message: string): never` in `src/errors.ts`.
+- Produces: `parseFullSearchRecordsInput(value): SearchRecordsInput` and `parseCompactSearchRecordsInput(value): SearchRecordsInput` backed by one private common parser.
+- Consumes: existing `fail('INVALID_ARGUMENT', ...)`; no imports are permitted in `src/operation-budgets.ts`.
+
+- [ ] **Step 1: Write the failing authority/parser test**
+
+Create `test/api-input.test.ts` with a table that imports the wished-for `OPERATION_BUDGETS`, `parseListRecordsInput`, `parseFullSearchRecordsInput`, `parseCompactSearchRecordsInput`, and `parseGatherInput`. Use literal expectations:
+
+```ts
+const limitCases = [
+  { accept: 50, budget: 'fullResultLimit', maximum: 50, parse: () => parseListRecordsInput({ limit: 50 }) },
+  {
+    accept: 50,
+    budget: 'fullResultLimit',
+    maximum: 50,
+    parse: () => parseFullSearchRecordsInput({ limit: 50, query: 'x' }),
+  },
+  {
+    accept: 100,
+    budget: 'compactResultLimit',
+    maximum: 100,
+    parse: () => parseCompactSearchRecordsInput({ limit: 100, query: 'x' }),
+  },
+  { accept: 100, budget: 'compactResultLimit', maximum: 100, parse: () => parseGatherInput({ limit: 100 }) },
+] as const
+```
+
+For each case assert the exact maximum succeeds, maximum + 1 throws `INVALID_ARGUMENT`, and details equal `{ field: 'limit', budget, maximum }`. The literal behavioural expectations protect the authority's values; do not add a separate constant-value change-detector test.
+
+Add dense oversized gather arrays whose first element is an ordinary invalid value:
+
+```ts
+assertBudget(
+  () => parseGatherInput({ searches: [42, ...Array.from({ length: 16 }, () => 'x')] }),
+  { budget: 'gatherSearches', field: 'searches', maximum: 16 },
+)
+assertBudget(
+  () => parseGatherInput({ shows: ['not a valid id!', ...Array.from({ length: 64 }, () => 'valid-id')] }),
+  { budget: 'gatherShows', field: 'shows', maximum: 64 },
+)
+```
+
+- [ ] **Step 2: Run the focused test and witness RED**
+
+Run: `node --test test/api-input.test.ts`
+
+Expected: FAIL because `src/operation-budgets.ts` and the full/compact parser split do not exist, the generic parser accepts one-over limits, and gather validates invalid items before count budgets.
+
+- [ ] **Step 3: Add the minimal authority and bounded error helper**
+
+Create the import-free authority:
+
+```ts
+export const OPERATION_BUDGETS = {
+  compactResultLimit: { default: 20, field: 'limit', maximum: 100, minimum: 1 },
+  fullResponseBytes: { field: 'response', maximum: 4 * 1024 * 1024 },
+  fullResultLimit: { default: 20, field: 'limit', maximum: 50, minimum: 1 },
+  gatherSearches: { field: 'searches', maximum: 16 },
+  gatherShows: { field: 'shows', maximum: 64 },
+  queryBytes: { field: 'query', maximum: 1024 },
+  queryTerms: { field: 'query', maximum: 32 },
+  supersessionEdges: { field: 'supersedes', maximum: 1000 },
+} as const
+```
+
+Add `failBudget` to `src/errors.ts` as the sole constructor for bounded budget details:
+
+```ts
+export const failBudget = (field: string, budget: string, maximum: number, message: string): never =>
+  fail('INVALID_ARGUMENT', message, { budget, field, maximum })
+```
+
+Do not export either symbol from `src/index.ts`.
+
+In `src/api-input.ts`:
+
+- replace `optionalLimit(value)` with a private helper receiving either the full or compact budget spec;
+- make `parseListRecordsInput` use full;
+- split search into full/compact wrappers around a private common parser;
+- make gather use compact;
+- replace eager `optionalStringArray` use for gather with a helper that checks array shape and `length > maximum` before `.every` and `.map`, then validates items.
+
+Every new failure uses `failBudget` with the exact names and details from Global Constraints.
+
+- [ ] **Step 4: Run focused/static verification**
+
+Run:
+
+```bash
+node --test test/api-input.test.ts
+bun run lint
+bun run typecheck
+```
+
+Expected: the focused parser test is GREEN; the new authority, error helper, and parsers compile and lint cleanly.
+
+- [ ] **Step 5: Commit the authority and parser tests**
+
+```bash
+git add src/operation-budgets.ts src/errors.ts src/api-input.ts test/api-input.test.ts
+git commit -m "[MAR-2561] Parse authoritative operation budgets"
+```
+
+### Task 2: Enforce record and cache budgets before repository access
+
+**Files:**
+- Modify: `src/schema.ts`
+- Modify: `src/records.ts`
+- Modify: `test/cache.test.ts`
+- Modify: `test/records.test.ts`
+
+**Interfaces:**
+- Consumes: `OPERATION_BUDGETS`, `failBudget` from Task 1.
+- Consumes: operation-specific parsers from Task 1.
+- Preserves: `validateAddRecordInput`, `parseRecordFile`, and public API type shapes.
+
+- [ ] **Step 1: Add failing count-before-item-validation tests**
+
+Add one `test/records.test.ts` public `addRecord` case with 1,001 supersedes whose first string is invalid. Set `repositoryTestHooks.afterGitMarkerDecision` to throw or increment a counter, then assert:
+
+- the failure is `INVALID_ARGUMENT`;
+- details equal `{ budget: 'supersessionEdges', field: 'supersedes', maximum: 1000 }`;
+- neither the invalid ID text nor any array contents appear in message/details;
+- repository hook count is zero and no `encephalon` or cache state exists.
+
+Strengthen `assertBudgetError` in `test/cache.test.ts` to accept literal `field`, `budget`, and `maximum`, and assert all three. Keep existing exact/max+1 and no-cache cases; add 17-search and 65-show cases with an invalid first ordinary element so the count budget wins.
+
+- [ ] **Step 2: Run focused tests and witness RED**
+
+Run:
+
+```bash
+node --test --test-name-pattern="request budget boundaries|supersedes count" test/cache.test.ts test/records.test.ts
+```
+
+Expected: FAIL because supersedes has no per-record count guard and cache budget assertions do not yet consume all exact shared details.
+
+- [ ] **Step 3: Implement supersedes count-before-map validation**
+
+In `src/schema.ts`, extend the string-array path used for supersedes with the shared maximum. Both candidate input and canonical record parsing must check array length before `map(validateId)` or `new Set`. Leave artifacts' existing 256-before-map behaviour local.
+
+In `src/records.ts`, remove the local numeric `MAX_SUPERSESSION_EDGES = 1000` definition and alias/import the shared `OPERATION_BUDGETS.supersessionEdges.maximum` so aggregate graph validation uses the same authority. Preserve the internal exported constant if tests or internal consumers import its name.
+
+Every new failure uses `failBudget` with the exact names and details from Global Constraints.
+
+- [ ] **Step 4: Retain cache defence-in-depth with the same values**
+
+Update `src/cache.ts` to import the authority and split parser names. Remove local request/query/response numeric declarations while retaining internal exported compatibility aliases where existing internal tests consume them. Replace local `budgetFailure` with `failBudget` and make all defensive checks use the shared values.
+
+Order remains parser/count checks, query checks, repository resolution, cache inspection, then SQLite work.
+
+- [ ] **Step 5: Run focused tests to verify GREEN**
+
+Run:
+
+```bash
+node --test --test-name-pattern="request budget boundaries|supersedes count" test/cache.test.ts test/records.test.ts
+bun run lint
+bun run typecheck
+```
+
+Expected: all selected tests pass; lint and all four TypeScript projects exit zero.
+
+- [ ] **Step 6: Run affected suites and commit**
+
+Run: `node --test test/api-input.test.ts test/cache.test.ts test/records.test.ts`
+
+Expected: zero failures, with only established capability skips if any.
+
+```bash
+git add src/schema.ts src/records.ts src/cache.ts test/cache.test.ts test/records.test.ts
+git commit -m "[MAR-2561] Reject oversized operations before mapping"
+```
+
+### Task 3: Align CLI and packed behaviour with the authority
+
+**Files:**
+- Modify: `src/cli.ts`
+- Modify: `test/cli.test.ts`
+- Modify: `scripts/check-package.ts`
+
+**Interfaces:**
+- Consumes: `OPERATION_BUDGETS` only; CLI does not import cache internals.
+- Produces: mode-specific CLI parsing/help and packed error behaviour.
+
+- [ ] **Step 1: Write failing CLI/help tests**
+
+Extend `test/cli.test.ts` so `--help` independently asserts literal fragments for:
+
+- list limit `1..50`;
+- full search limit `1..50`;
+- compact search limit `1..100`;
+- gather limit `1..100`, at most 16 searches, and at most 64 shows;
+- add at most 1,000 supersedes.
+
+Add a compact table using a real repository:
+
+```ts
+const cases = [
+  { accepted: ['list', '--limit=50'], rejected: ['list', '--limit=51'], budget: 'fullResultLimit', maximum: 50 },
+  { accepted: ['search', '--limit=50', 'x'], rejected: ['search', '--limit=51', 'x'], budget: 'fullResultLimit', maximum: 50 },
+  { accepted: ['search', '--compact', '--limit=100', 'x'], rejected: ['search', '--compact', '--limit=101', 'x'], budget: 'compactResultLimit', maximum: 100 },
+  { accepted: ['gather', '--limit=100'], rejected: ['gather', '--limit=101'], budget: 'compactResultLimit', maximum: 100 },
+] as const
+```
+
+For accepted cases assert status 0. For rejected cases assert status 2 and exact JSON `{ field: 'limit', budget, maximum }`; derive expectations from literals, not imported constants.
+
+Add two count-precedence CLI cases:
+
+- 17 `--search` values where the first query would independently exceed the query-term budget must fail as `gatherSearches`/16;
+- 1,001 `--supersedes` values combined with invalid `--data` JSON must fail as `supersessionEdges`/1,000 before payload parsing or API invocation.
+
+Assert exact bounded details and absence of input contents.
+
+- [ ] **Step 2: Run CLI tests and witness RED**
+
+Run: `bun run build && node --test --test-name-pattern="help and version|operation-specific limit" test/cli.test.ts`
+
+Expected: FAIL because help and CLI parsing still advertise/accept 1–1,000.
+
+- [ ] **Step 3: Implement shared CLI parsing and help**
+
+Import `OPERATION_BUDGETS` directly in `src/cli.ts`. Parameterise `parseLimit` with a budget key/spec and use `failBudget` so CLI/API details match. Select full for list and ordinary search; compact for `search --compact` and gather.
+
+Interpolate numeric help values from the authority while keeping readable command-specific lines. Count repeated gather searches/shows and add supersedes before parsing payload or invoking public APIs; use the same budget failures. Do not change unrelated option parsing.
+
+- [ ] **Step 4: Add packed behavioural checks**
+
+In `scripts/check-package.ts`, capture packed `--help` once and assert the same literal fragments. Add a helper that runs an expected failing CLI command without the existing success-only `run` wrapper. Exercise packed `list --limit=51` and packed compact search `--limit=101`; assert exit 2 and exact structured details for the full and compact budgets.
+
+- [ ] **Step 5: Verify and commit**
+
+Run:
+
+```bash
+bun run build
+node --test test/cli.test.ts
+bun run lint
+bun run typecheck
+bun run check:package
+```
+
+Expected: all commands exit zero and packed source behaviour matches installed behaviour.
+
+```bash
+git add src/cli.ts test/cli.test.ts scripts/check-package.ts
+git commit -m "[MAR-2561] Align CLI operation budgets"
+```
+
+### Task 4: Document, audit, and verify the complete branch
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/contract.md`
+- Modify: `docs/superpowers/specs/2026-08-13-operation-budgets-design.md`
+- Modify: `test/package.test.ts`
+
+**Interfaces:**
+- Consumes: exact code/test commit SHA from Tasks 1–3.
+- Produces: maintained human contract and exact reviewed provenance; no runtime or public declaration changes.
+
+- [ ] **Step 1: Add the provenance RED**
+
+Extend the existing maintained-contract package test to require a concise operation-budget section and the exact Tasks 1–3 code/test SHA. Do not duplicate the entire schema in the test; assert the maintained section and exact provenance marker.
+
+Run: `node --test test/package.test.ts`
+
+Expected: FAIL because the maintained documentation and provenance are absent.
+
+- [ ] **Step 2: Update maintained documentation**
+
+Update README and `docs/contract.md` with the mode-specific 50/100 result limits, 16/64 gather input counts, 1,000 supersedes input count, fixed query/full-response budgets, bounded error details, and count-before-item-validation/no-I/O guarantee. Do not edit historical plan statements that are already numerically accurate.
+
+Update the design's reviewed implementation provenance to the exact code/test SHA from Tasks 1–3.
+
+- [ ] **Step 3: Run the complete verification matrix sequentially**
+
+Run each command sequentially:
+
+```bash
+bun run lint
+bun run typecheck
+bun run test
+bun run benchmark
+bun run benchmark:check
+bun run build
+bun run check:package
+bun run check:publish
+bun install --frozen-lockfile
+git diff --check origin/main...HEAD
+git status --short
+```
+
+Expected: zero failures; the test suite reports only established capability skips; publish check exits zero while reporting the expected already-published-version refusal; frozen install changes nothing; worktree is clean except the intended documentation/test changes before commit.
+
+- [ ] **Step 4: Audit separation of concerns and package surface**
+
+Verify:
+
+- `src/operation-budgets.ts` has no imports and is absent from `src/index.ts`/public declarations;
+- no request maximum remains duplicated in API/cache/CLI code;
+- parsing/count failures precede repository/cache hooks;
+- cache keeps defensive checks;
+- no dead generic `optionalLimit`, stale 1–1,000 help, experimental hook, TODO, or unrelated refactor remains;
+- README, maintained contract, packed CLI, and code describe the same values;
+- `bunfig.toml` has the required plaintext-lock settings and `bun.lock` is unchanged plaintext JSON.
+
+- [ ] **Step 5: Commit documentation/provenance**
+
+```bash
+git add README.md docs/contract.md docs/superpowers/specs/2026-08-13-operation-budgets-design.md test/package.test.ts
+git commit -m "[MAR-2561] Document authoritative operation budgets"
+```
+
+Rerun `node --test test/package.test.ts`, `bun run check:package`, `git diff --check origin/main...HEAD`, and `git status --short --branch` after the commit.

--- a/docs/superpowers/specs/2026-08-13-operation-budgets-design.md
+++ b/docs/superpowers/specs/2026-08-13-operation-budgets-design.md
@@ -6,21 +6,21 @@ Make every public request budget authoritative at the first safe parsing boundar
 
 ## Chosen approach
 
-Add one dependency-free `src/operation-budgets.ts` module containing immutable budget specifications. Consumers import the same values rather than declaring local numeric maxima. This is preferred over keeping constants in `src/cache.ts`, which would preserve parser/cache coupling and invite dependency cycles, and over a configurable budget framework, which is outside the fixed-budget scope of MAR-2561.
+Add one dependency-free `src/operation-budgets.ts` module containing immutable budget specifications. The authority and every nested specification are frozen at runtime. Consumers import the same values rather than declaring local numeric maxima. This is preferred over keeping constants in `src/cache.ts`, which would preserve parser/cache coupling and invite dependency cycles, and over a configurable budget framework, which is outside the fixed-budget scope of MAR-2561.
 
 The authority contains:
 
 ```ts
-export const OPERATION_BUDGETS = {
-  compactResultLimit: { default: 20, field: 'limit', maximum: 100, minimum: 1 },
-  fullResponseBytes: { field: 'response', maximum: 4 * 1024 * 1024 },
-  fullResultLimit: { default: 20, field: 'limit', maximum: 50, minimum: 1 },
-  gatherSearches: { field: 'searches', maximum: 16 },
-  gatherShows: { field: 'shows', maximum: 64 },
-  queryBytes: { field: 'query', maximum: 1024 },
-  queryTerms: { field: 'query', maximum: 32 },
-  supersessionEdges: { field: 'supersedes', maximum: 1000 },
-} as const
+export const OPERATION_BUDGETS = Object.freeze({
+  compactResultLimit: Object.freeze({ default: 20, field: 'limit', maximum: 100, minimum: 1 }),
+  fullResponseBytes: Object.freeze({ field: 'response', maximum: 4 * 1024 * 1024 }),
+  fullResultLimit: Object.freeze({ default: 20, field: 'limit', maximum: 50, minimum: 1 }),
+  gatherSearches: Object.freeze({ field: 'searches', maximum: 16 }),
+  gatherShows: Object.freeze({ field: 'shows', maximum: 64 }),
+  queryBytes: Object.freeze({ field: 'query', maximum: 1024 }),
+  queryTerms: Object.freeze({ field: 'query', maximum: 32 }),
+  supersessionEdges: Object.freeze({ field: 'supersedes', maximum: 1000 }),
+} as const)
 ```
 
 The module imports nothing and is not re-exported through `src/index.ts`; it remains an internal authority and does not expand the package API. Artifact limits remain in `src/schema.ts`: artifacts already enforce their fixed count before mapping, and moving them is unnecessary for this ticket.
@@ -32,7 +32,7 @@ The module imports nothing and is not re-exported through `src/index.ts`; it rem
 - list and full search use `fullResultLimit`, accepting 1–50;
 - compact search and gather use `compactResultLimit`, accepting 1–100;
 - full and compact search have distinct internal parser entry points backed by one private common parser, preventing callers from pairing the wrong maximum with a mode;
-- gather checks `searches.length` against 16 and `shows.length` against 64 before `.every`, `.map`, query parsing, or ID validation.
+- gather structurally validates and count-checks both arrays before validating or mapping either array's items; `searches.length` is bounded at 16 and `shows.length` at 64 before `.every`, `.map`, query parsing, or ID validation.
 
 `src/schema.ts` checks `supersedes.length` against 1,000 before mapping IDs or constructing a uniqueness `Set`, for both candidate input and canonical record parsing. `src/records.ts` consumes the same numeric authority for the aggregate 1,000-edge corpus limit. Exactly 1,000 targets remains accepted by the per-record parser; aggregate graph validation remains independently authoritative for the complete corpus.
 
@@ -46,7 +46,7 @@ All request parsing and count checks occur before `resolveRepository`, cache-loc
 
 ## CLI and documentation
 
-`src/cli.ts` parameterises `parseLimit` by the shared budget specification. List and non-compact search use the full limit; `search --compact` and gather use the compact limit. Search selects its specification after parsing the `--compact` flag but before invoking the API.
+`src/cli.ts` parameterises `parseLimit` by the shared budget key. List and non-compact search use the full limit; `search --compact` and gather use the compact limit. Search selects its key after parsing the `--compact` flag but before invoking the API. Gather search/show counts and add supersedes counts are scanned from raw command arguments before `parseArgs` normalises, filters, or copies repeated values; public API parsing remains defence-in-depth.
 
 Help text interpolates the shared values and states:
 
@@ -59,7 +59,7 @@ README and the maintained contract describe the same public limits. Package chec
 
 ## Error contract
 
-Budget failures remain `INVALID_ARGUMENT`. A shared internal helper in `src/errors.ts` constructs details containing only:
+Budget failures remain `INVALID_ARGUMENT`. A shared internal helper in `src/errors.ts` accepts a typed operation-budget key and derives its field and maximum from the authority. It constructs details containing only:
 
 ```ts
 { field, budget, maximum }
@@ -86,10 +86,10 @@ No public input or result type changes. No pagination, configurable limits, stre
 The smallest complementary behavioural matrix covers:
 
 - pure full and compact parser boundaries at the maximum and one over, with exact bounded details;
-- 17 gather searches and 65 shows whose first ordinary element is invalid, proving the count error wins before item validation and before repository/cache access;
+- 17 gather searches and 65 shows whose first ordinary element is invalid, including one request with invalid searches and 65 shows, proving both count checks run before either item-validation pass and before repository/cache access;
 - 1,001 supersedes whose first ordinary element is invalid, proving the count error wins before ID validation, mapping, uniqueness allocation, or repository access;
-- strengthened existing cache budget assertions for exact field, budget, maximum, and no cache path;
-- CLI list/full-search and compact-search/gather boundaries, exact help ranges, exit status, and structured details;
+- strengthened existing cache budget assertions for exact field, budget, maximum, no cache path, and untouched repository/cache inspection hooks;
+- CLI list/full-search and compact-search/gather boundaries, exact help ranges, exit status, structured details, and raw empty repeated values at 17 searches, 65 shows, and 1,001 supersedes;
 - packed CLI help and representative full/compact over-limit failures;
 - unchanged query-byte, query-term, response-byte, empty-array, duplicate-order, public type, and package declaration regressions.
 
@@ -97,4 +97,4 @@ Tests use ordinary dense arrays. They do not add proxies, getters, sparse arrays
 
 ## Reviewed implementation provenance
 
-The exact reviewed code and behavioural-test snapshot implementing this design is `6dc60e13e8e99b05fef566d4b80aeb663328664c`. Documentation changes do not alter the runtime API, package exports, or generated declarations.
+The exact reviewed code and behavioural-test snapshot implementing this design is `011360c808a61a94a98683cbecf059da46a18471`. Documentation changes do not alter the runtime API, package exports, or generated declarations.

--- a/docs/superpowers/specs/2026-08-13-operation-budgets-design.md
+++ b/docs/superpowers/specs/2026-08-13-operation-budgets-design.md
@@ -1,0 +1,96 @@
+# Operation Budgets Design
+
+## Goal
+
+Make every public request budget authoritative at the first safe parsing boundary, while retaining cache defence-in-depth and preserving the public TypeScript input shapes. Oversized arrays must fail before item validation, repository discovery, cache inspection, or intermediate mapping and set allocation.
+
+## Chosen approach
+
+Add one dependency-free `src/operation-budgets.ts` module containing immutable budget specifications. Consumers import the same values rather than declaring local numeric maxima. This is preferred over keeping constants in `src/cache.ts`, which would preserve parser/cache coupling and invite dependency cycles, and over a configurable budget framework, which is outside the fixed-budget scope of MAR-2561.
+
+The authority contains:
+
+```ts
+export const OPERATION_BUDGETS = {
+  compactResultLimit: { default: 20, field: 'limit', maximum: 100, minimum: 1 },
+  fullResponseBytes: { field: 'response', maximum: 4 * 1024 * 1024 },
+  fullResultLimit: { default: 20, field: 'limit', maximum: 50, minimum: 1 },
+  gatherSearches: { field: 'searches', maximum: 16 },
+  gatherShows: { field: 'shows', maximum: 64 },
+  queryBytes: { field: 'query', maximum: 1024 },
+  queryTerms: { field: 'query', maximum: 32 },
+  supersessionEdges: { field: 'supersedes', maximum: 1000 },
+} as const
+```
+
+The module imports nothing and is not re-exported through `src/index.ts`; it remains an internal authority and does not expand the package API. Artifact limits remain in `src/schema.ts`: artifacts already enforce their fixed count before mapping, and moving them is unnecessary for this ticket.
+
+## Parsing and validation
+
+`src/api-input.ts` replaces the generic `optionalLimit` maximum of 1,000 with operation-specific parsing backed by the shared specifications:
+
+- list and full search use `fullResultLimit`, accepting 1–50;
+- compact search and gather use `compactResultLimit`, accepting 1–100;
+- full and compact search have distinct internal parser entry points backed by one private common parser, preventing callers from pairing the wrong maximum with a mode;
+- gather checks `searches.length` against 16 and `shows.length` against 64 before `.every`, `.map`, query parsing, or ID validation.
+
+`src/schema.ts` checks `supersedes.length` against 1,000 before mapping IDs or constructing a uniqueness `Set`, for both candidate input and canonical record parsing. `src/records.ts` consumes the same numeric authority for the aggregate 1,000-edge corpus limit. Exactly 1,000 targets remains accepted by the per-record parser; aggregate graph validation remains independently authoritative for the complete corpus.
+
+Empty and omitted arrays preserve their current semantics. Sparse arrays, accessor-bearing input envelopes, and proxy-specific behaviour remain the scope of MAR-2572 and are not changed here.
+
+## Cache execution
+
+`src/cache.ts` consumes the shared constants and retains its defensive assertions for result counts, query bytes, query terms, gather counts, and full-response bytes. Public parsing is the first authoritative boundary; cache checks protect internal callers and future refactors. Both layers use the same specification, stable budget name, field, and maximum.
+
+All request parsing and count checks occur before `resolveRepository`, cache-location inspection, SQLite access, or hydration. The default result limit remains 20.
+
+## CLI and documentation
+
+`src/cli.ts` parameterises `parseLimit` by the shared budget specification. List and non-compact search use the full limit; `search --compact` and gather use the compact limit. Search selects its specification after parsing the `--compact` flag but before invoking the API.
+
+Help text interpolates the shared values and states:
+
+- list and full search accept 1–50 results;
+- compact search and gather accept 1–100 results per search;
+- gather accepts at most 16 searches and 64 shows;
+- add accepts at most 1,000 supersession targets.
+
+README and the maintained contract describe the same public limits. Package checks run the packed CLI, validate the help fragments, and exercise one over-limit full and compact request so packaged behaviour cannot drift from source behaviour.
+
+## Error contract
+
+Budget failures remain `INVALID_ARGUMENT`. A shared internal helper in `src/errors.ts` constructs details containing only:
+
+```ts
+{ field, budget, maximum }
+```
+
+Existing stable budget names remain unchanged: `fullResultLimit`, `compactResultLimit`, `queryBytes`, `queryTerms`, `gatherSearches`, `gatherShows`, and `fullResponseBytes`. The new supersedes count uses `supersessionEdges`. Messages are concise and operation-specific. Details never include arrays, individual values, queries, paths, or other input contents.
+
+CLI failures retain exit status 2 and structured JSON. CLI-specific text names the applicable range rather than the removed generic 1–1,000 range.
+
+## Component boundaries
+
+- `src/operation-budgets.ts` owns fixed budget data and has no dependencies.
+- `src/errors.ts` owns bounded `INVALID_ARGUMENT` construction, without knowing parser or cache behaviour.
+- `src/api-input.ts` owns public input-envelope parsing and the earliest request checks.
+- `src/schema.ts` owns record-field validation, including supersedes count-before-normalisation.
+- `src/cache.ts` owns defensive execution checks and response accounting.
+- `src/cli.ts` owns command-mode selection and help rendering.
+- `src/records.ts` owns aggregate corpus-edge validation using the same supersession maximum.
+
+No public input or result type changes. No pagination, configurable limits, streaming response work, response-budget increases, or unrelated array hardening is introduced.
+
+## Verification
+
+The smallest complementary behavioural matrix covers:
+
+- pure full and compact parser boundaries at the maximum and one over, with exact bounded details;
+- 17 gather searches and 65 shows whose first ordinary element is invalid, proving the count error wins before item validation and before repository/cache access;
+- 1,001 supersedes whose first ordinary element is invalid, proving the count error wins before ID validation, mapping, uniqueness allocation, or repository access;
+- strengthened existing cache budget assertions for exact field, budget, maximum, and no cache path;
+- CLI list/full-search and compact-search/gather boundaries, exact help ranges, exit status, and structured details;
+- packed CLI help and representative full/compact over-limit failures;
+- unchanged query-byte, query-term, response-byte, empty-array, duplicate-order, public type, and package declaration regressions.
+
+Tests use ordinary dense arrays. They do not add proxies, getters, sparse arrays, or accessor semantics belonging to MAR-2572.

--- a/docs/superpowers/specs/2026-08-13-operation-budgets-design.md
+++ b/docs/superpowers/specs/2026-08-13-operation-budgets-design.md
@@ -94,3 +94,7 @@ The smallest complementary behavioural matrix covers:
 - unchanged query-byte, query-term, response-byte, empty-array, duplicate-order, public type, and package declaration regressions.
 
 Tests use ordinary dense arrays. They do not add proxies, getters, sparse arrays, or accessor semantics belonging to MAR-2572.
+
+## Reviewed implementation provenance
+
+The exact reviewed code and behavioural-test snapshot implementing this design is `6dc60e13e8e99b05fef566d4b80aeb663328664c`. Documentation changes do not alter the runtime API, package exports, or generated declarations.

--- a/docs/superpowers/specs/2026-08-13-operation-budgets-design.md
+++ b/docs/superpowers/specs/2026-08-13-operation-budgets-design.md
@@ -40,7 +40,7 @@ Empty and omitted arrays preserve their current semantics. Sparse arrays, access
 
 ## Cache execution
 
-`src/cache.ts` consumes the shared constants and retains its defensive assertions for result counts, query bytes, query terms, gather counts, and full-response bytes. Public parsing is the first authoritative boundary; cache checks protect internal callers and future refactors. Both layers use the same specification, stable budget name, field, and maximum.
+`src/cache.ts` consumes the shared constants and retains its defensive assertions for result counts, query bytes, query terms, gather counts, and full-response bytes. One gather reader shares a single full-response byte counter across every shown record, while compact gather search results remain excluded. Public parsing is the first authoritative boundary; cache checks protect internal callers and future refactors. Both layers use the same specification, stable budget name, field, and maximum.
 
 All request parsing and count checks occur before `resolveRepository`, cache-location inspection, SQLite access, or hydration. The default result limit remains 20.
 
@@ -89,6 +89,7 @@ The smallest complementary behavioural matrix covers:
 - 17 gather searches and 65 shows whose first ordinary element is invalid, including one request with invalid searches and 65 shows, proving both count checks run before either item-validation pass and before repository/cache access;
 - 1,001 supersedes whose first ordinary element is invalid, proving the count error wins before ID validation, mapping, uniqueness allocation, or repository access;
 - strengthened existing cache budget assertions for exact field, budget, maximum, no cache path, and untouched repository/cache inspection hooks;
+- repeated gather shows whose individual record is valid but whose cumulative full response exceeds 4 MiB, plus compact gather searches that remain usable independently of that budget;
 - CLI list/full-search and compact-search/gather boundaries, exact help ranges, exit status, structured details, and raw empty repeated values at 17 searches, 65 shows, and 1,001 supersedes;
 - packed CLI help and representative full/compact over-limit failures;
 - unchanged query-byte, query-term, response-byte, empty-array, duplicate-order, public type, and package declaration regressions.
@@ -97,4 +98,4 @@ Tests use ordinary dense arrays. They do not add proxies, getters, sparse arrays
 
 ## Reviewed implementation provenance
 
-The exact reviewed code and behavioural-test snapshot implementing this design is `011360c808a61a94a98683cbecf059da46a18471`. Documentation changes do not alter the runtime API, package exports, or generated declarations.
+The exact reviewed code and behavioural-test snapshot implementing this design is `1e913807c20a332dc49a004be672205fbeabfe15`. Documentation changes do not alter the runtime API, package exports, or generated declarations.

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -11,6 +11,7 @@ import {
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { isDeepStrictEqual } from 'node:util'
 import { gunzipSync } from 'node:zlib'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
@@ -322,7 +323,7 @@ try {
       result.exitCode !== 2 ||
       result.stdout !== '' ||
       body.error?.code !== 'INVALID_ARGUMENT' ||
-      JSON.stringify(body.error.details) !== JSON.stringify(expectedDetails)
+      !isDeepStrictEqual(body.error.details, expectedDetails)
     ) {
       throw new Error('The packed Node-only CLI operation budget contract failed.')
     }

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -31,6 +31,20 @@ const run = (command: string[], cwd = root) => {
   throw new Error(`${command[0]} failed with exit code ${result.exitCode}.`)
 }
 
+const runExpectedFailure = (command: string[], cwd = root) => {
+  const result = Bun.spawnSync({
+    cmd: command,
+    cwd,
+    stderr: 'pipe',
+    stdout: 'pipe',
+  })
+  return {
+    exitCode: result.exitCode,
+    stderr: result.stderr.toString(),
+    stdout: result.stdout.toString(),
+  }
+}
+
 const collectFiles = (directory: string): string[] =>
   readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
     const path = resolve(directory, entry.name)
@@ -275,11 +289,55 @@ try {
   )
   const installedCli = resolve(consumer, 'node_modules', 'encephalon', 'dist', 'cli.mjs')
   const cli = (arguments_: string[]) => run(['node', installedCli, ...arguments_], consumer)
+  const cliFailure = (arguments_: string[]) => runExpectedFailure(['node', installedCli, ...arguments_], consumer)
   const cliJson = (arguments_: string[]) => JSON.parse(cli(arguments_)) as unknown
 
-  if (!/^Usage: encephalon/m.test(cli(['--help'])) || cli(['--version']) !== `${packageJson.version}\n`) {
+  const help = cli(['--help'])
+  const helpFragments = [
+    'list [--kind <kind>] [--subject <subject>] [--include-superseded] [--limit <1..50>]',
+    'search [--kind <kind>] [--include-superseded] [--limit <1..50>] [--] <query>',
+    'search --compact [--kind <kind>] [--include-superseded] [--limit <1..100>] [--] <query>',
+    'gather [--search <query> ...] [--show <id> ...] [--hydrate] [--include-superseded]\n' +
+      '         [--kind <kind>] [--limit <1..100>]',
+    'Accepts at most 16 searches and 64 shows.',
+    'Accepts at most 1,000 supersession targets.',
+  ]
+  if (
+    !/^Usage: encephalon/m.test(help) ||
+    helpFragments.some(fragment => !help.includes(fragment)) ||
+    cli(['--version']) !== `${packageJson.version}\n`
+  ) {
     throw new Error('The packed Node-only CLI help/version contract failed.')
   }
+
+  const assertPackedBudgetFailure = (
+    arguments_: string[],
+    expectedDetails: { budget: string; field: string; maximum: number },
+  ) => {
+    const result = cliFailure(arguments_)
+    const body = JSON.parse(result.stderr) as {
+      error?: { code?: unknown; details?: unknown }
+    }
+    if (
+      result.exitCode !== 2 ||
+      result.stdout !== '' ||
+      body.error?.code !== 'INVALID_ARGUMENT' ||
+      JSON.stringify(body.error.details) !== JSON.stringify(expectedDetails)
+    ) {
+      throw new Error('The packed Node-only CLI operation budget contract failed.')
+    }
+  }
+
+  assertPackedBudgetFailure(['list', '--root', consumer, '--limit=51'], {
+    budget: 'fullResultLimit',
+    field: 'limit',
+    maximum: 50,
+  })
+  assertPackedBudgetFailure(['search', '--root', consumer, '--compact', '--limit=101', 'x'], {
+    budget: 'compactResultLimit',
+    field: 'limit',
+    maximum: 100,
+  })
 
   const prepared = cliJson(['--root', consumer, 'prepare']) as { hydrated?: unknown; recordsIndexed?: unknown }
   if (prepared.hydrated !== true || prepared.recordsIndexed !== 0) {

--- a/src/api-input.ts
+++ b/src/api-input.ts
@@ -19,6 +19,8 @@ export type ParsedAddRecordInput = AddRecordInput & {
 
 const MAX_TEXT_BYTES = 1024
 
+type OperationBudgetKey = keyof typeof OPERATION_BUDGETS
+
 const objectInput = (value: unknown, name: string): Record<string, unknown> => {
   if (value === undefined) {
     return {}
@@ -49,19 +51,15 @@ const optionalBoolean = (value: unknown, field: string) => {
   return fail('INVALID_ARGUMENT', `${field} must be a boolean.`, { field })
 }
 
-type ResultLimitBudget = typeof OPERATION_BUDGETS.compactResultLimit | typeof OPERATION_BUDGETS.fullResultLimit
+type ResultLimitBudgetKey = Extract<OperationBudgetKey, 'compactResultLimit' | 'fullResultLimit'>
 
-const optionalLimit = (value: unknown, budget: ResultLimitBudget) => {
+const optionalLimit = (value: unknown, budgetKey: ResultLimitBudgetKey) => {
   if (value !== undefined) {
+    const budget = OPERATION_BUDGETS[budgetKey]
     if (typeof value === 'number' && Number.isInteger(value) && value >= budget.minimum && value <= budget.maximum) {
       return value
     }
-    return failBudget(
-      budget.field,
-      budget === OPERATION_BUDGETS.fullResultLimit ? 'fullResultLimit' : 'compactResultLimit',
-      budget.maximum,
-      `limit must be an integer between ${budget.minimum} and ${budget.maximum}.`,
-    )
+    return failBudget(budgetKey, `limit must be an integer between ${budget.minimum} and ${budget.maximum}.`)
   }
 }
 
@@ -90,28 +88,27 @@ const optionalQuery = (value: unknown, field: string) => {
   return fail('INVALID_ARGUMENT', `${field} must be a string.`, { field })
 }
 
-const optionalBoundedStringArray = (
-  value: unknown,
-  budget: typeof OPERATION_BUDGETS.gatherSearches | typeof OPERATION_BUDGETS.gatherShows,
-  budgetName: 'gatherSearches' | 'gatherShows',
-  item: (value: unknown) => string,
-) => {
+type GatherArrayBudgetKey = Extract<OperationBudgetKey, 'gatherSearches' | 'gatherShows'>
+
+const optionalBoundedArray = (value: unknown, budgetKey: GatherArrayBudgetKey) => {
   if (value !== undefined) {
-    if (Array.isArray(value)) {
-      if (value.length > budget.maximum) {
-        return failBudget(
-          budget.field,
-          budgetName,
-          budget.maximum,
-          `gather may contain at most ${budget.maximum} ${budget.field}.`,
-        )
-      }
-      if (value.every(entry => typeof entry === 'string')) {
-        return value.map(item)
-      }
+    const budget = OPERATION_BUDGETS[budgetKey]
+    if (!Array.isArray(value)) {
+      return fail('INVALID_ARGUMENT', `${budget.field} must be an array of strings.`, { field: budget.field })
     }
-    return fail('INVALID_ARGUMENT', `${budget.field} must be an array of strings.`, { field: budget.field })
+    if (value.length > budget.maximum) {
+      return failBudget(budgetKey, `gather may contain at most ${budget.maximum} ${budget.field}.`)
+    }
+    return value
   }
+}
+
+const mapBoundedStringArray = (value: unknown[], budgetKey: GatherArrayBudgetKey, item: (value: unknown) => string) => {
+  const budget = OPERATION_BUDGETS[budgetKey]
+  if (value.every(entry => typeof entry === 'string')) {
+    return value.map(item)
+  }
+  return fail('INVALID_ARGUMENT', `${budget.field} must be an array of strings.`, { field: budget.field })
 }
 
 const rootProperties = (input: Record<string, unknown>): RootInput => {
@@ -128,7 +125,7 @@ export const parseListRecordsInput = (value: unknown = {}): ListRecordsInput => 
   const kind = input.kind === undefined ? undefined : validateKind(input.kind)
   const subject = optionalText(input.subject, 'subject')
   const includeSuperseded = optionalBoolean(input.includeSuperseded, 'includeSuperseded')
-  const limit = optionalLimit(input.limit, OPERATION_BUDGETS.fullResultLimit)
+  const limit = optionalLimit(input.limit, 'fullResultLimit')
   return {
     ...root,
     ...(kind === undefined ? {} : { kind }),
@@ -149,12 +146,12 @@ export const parseShowRecordInput = (value: unknown): ShowRecordInput => {
   }
 }
 
-const parseSearchRecordsInputWithBudget = (value: unknown, budget: ResultLimitBudget): SearchRecordsInput => {
+const parseSearchRecordsInputWithBudget = (value: unknown, budgetKey: ResultLimitBudgetKey): SearchRecordsInput => {
   const input = objectInput(value, 'searchRecords')
   const root = rootProperties(input)
   const kind = input.kind === undefined ? undefined : validateKind(input.kind)
   const includeSuperseded = optionalBoolean(input.includeSuperseded, 'includeSuperseded')
-  const limit = optionalLimit(input.limit, budget)
+  const limit = optionalLimit(input.limit, budgetKey)
   const query = optionalQuery(input.query, 'query')
   if (query === undefined) {
     return fail('INVALID_ARGUMENT', 'query must be a string.', { field: 'query' })
@@ -169,10 +166,10 @@ const parseSearchRecordsInputWithBudget = (value: unknown, budget: ResultLimitBu
 }
 
 export const parseFullSearchRecordsInput = (value: unknown): SearchRecordsInput =>
-  parseSearchRecordsInputWithBudget(value, OPERATION_BUDGETS.fullResultLimit)
+  parseSearchRecordsInputWithBudget(value, 'fullResultLimit')
 
 export const parseCompactSearchRecordsInput = (value: unknown): SearchRecordsInput =>
-  parseSearchRecordsInputWithBudget(value, OPERATION_BUDGETS.compactResultLimit)
+  parseSearchRecordsInputWithBudget(value, 'compactResultLimit')
 
 export const parseGatherInput = (value: unknown): GatherInput => {
   const input = objectInput(value, 'gatherRecords')
@@ -180,14 +177,15 @@ export const parseGatherInput = (value: unknown): GatherInput => {
   const kind = input.kind === undefined ? undefined : validateKind(input.kind)
   const includeSuperseded = optionalBoolean(input.includeSuperseded, 'includeSuperseded')
   const hydrate = optionalBoolean(input.hydrate, 'hydrate')
-  const limit = optionalLimit(input.limit, OPERATION_BUDGETS.compactResultLimit)
-  const searches = optionalBoundedStringArray(
-    input.searches,
-    OPERATION_BUDGETS.gatherSearches,
-    'gatherSearches',
-    entry => optionalQuery(entry, 'searches') ?? '',
-  )
-  const shows = optionalBoundedStringArray(input.shows, OPERATION_BUDGETS.gatherShows, 'gatherShows', validateId)
+  const limit = optionalLimit(input.limit, 'compactResultLimit')
+  const unvalidatedSearches = optionalBoundedArray(input.searches, 'gatherSearches')
+  const unvalidatedShows = optionalBoundedArray(input.shows, 'gatherShows')
+  const searches =
+    unvalidatedSearches === undefined
+      ? undefined
+      : mapBoundedStringArray(unvalidatedSearches, 'gatherSearches', entry => optionalQuery(entry, 'searches') ?? '')
+  const shows =
+    unvalidatedShows === undefined ? undefined : mapBoundedStringArray(unvalidatedShows, 'gatherShows', validateId)
   return {
     ...root,
     ...(searches === undefined ? {} : { searches }),

--- a/src/api-input.ts
+++ b/src/api-input.ts
@@ -174,9 +174,6 @@ export const parseFullSearchRecordsInput = (value: unknown): SearchRecordsInput 
 export const parseCompactSearchRecordsInput = (value: unknown): SearchRecordsInput =>
   parseSearchRecordsInputWithBudget(value, OPERATION_BUDGETS.compactResultLimit)
 
-/** @internal */
-export const parseSearchRecordsInput = parseFullSearchRecordsInput
-
 export const parseGatherInput = (value: unknown): GatherInput => {
   const input = objectInput(value, 'gatherRecords')
   const root = rootProperties(input)

--- a/src/api-input.ts
+++ b/src/api-input.ts
@@ -1,4 +1,5 @@
-import { fail } from './errors.ts'
+import { fail, failBudget } from './errors.ts'
+import { OPERATION_BUDGETS } from './operation-budgets.ts'
 import type { ValidatedAddRecordInput } from './schema.ts'
 import { validateAddRecordInput, validateId, validateKind } from './schema.ts'
 import type {
@@ -48,14 +49,20 @@ const optionalBoolean = (value: unknown, field: string) => {
   return fail('INVALID_ARGUMENT', `${field} must be a boolean.`, { field })
 }
 
-export const optionalLimit = (value: unknown) => {
-  if (value === undefined) {
-    return
+type ResultLimitBudget = typeof OPERATION_BUDGETS.compactResultLimit | typeof OPERATION_BUDGETS.fullResultLimit
+
+const optionalLimit = (value: unknown, budget: ResultLimitBudget) => {
+  if (value !== undefined) {
+    if (typeof value === 'number' && Number.isInteger(value) && value >= budget.minimum && value <= budget.maximum) {
+      return value
+    }
+    return failBudget(
+      budget.field,
+      budget === OPERATION_BUDGETS.fullResultLimit ? 'fullResultLimit' : 'compactResultLimit',
+      budget.maximum,
+      `limit must be an integer between ${budget.minimum} and ${budget.maximum}.`,
+    )
   }
-  if (typeof value === 'number' && Number.isInteger(value) && value > 0 && value <= 1000) {
-    return value
-  }
-  return fail('INVALID_ARGUMENT', 'limit must be an integer between 1 and 1000.', { field: 'limit' })
 }
 
 const optionalText = (value: unknown, field: string) => {
@@ -83,14 +90,28 @@ const optionalQuery = (value: unknown, field: string) => {
   return fail('INVALID_ARGUMENT', `${field} must be a string.`, { field })
 }
 
-const optionalStringArray = (value: unknown, field: string, item: (value: unknown) => string) => {
-  if (value === undefined) {
-    return
+const optionalBoundedStringArray = (
+  value: unknown,
+  budget: typeof OPERATION_BUDGETS.gatherSearches | typeof OPERATION_BUDGETS.gatherShows,
+  budgetName: 'gatherSearches' | 'gatherShows',
+  item: (value: unknown) => string,
+) => {
+  if (value !== undefined) {
+    if (Array.isArray(value)) {
+      if (value.length > budget.maximum) {
+        return failBudget(
+          budget.field,
+          budgetName,
+          budget.maximum,
+          `gather may contain at most ${budget.maximum} ${budget.field}.`,
+        )
+      }
+      if (value.every(entry => typeof entry === 'string')) {
+        return value.map(item)
+      }
+    }
+    return fail('INVALID_ARGUMENT', `${budget.field} must be an array of strings.`, { field: budget.field })
   }
-  if (Array.isArray(value) && value.every(entry => typeof entry === 'string')) {
-    return value.map(item)
-  }
-  return fail('INVALID_ARGUMENT', `${field} must be an array of strings.`, { field })
 }
 
 const rootProperties = (input: Record<string, unknown>): RootInput => {
@@ -107,7 +128,7 @@ export const parseListRecordsInput = (value: unknown = {}): ListRecordsInput => 
   const kind = input.kind === undefined ? undefined : validateKind(input.kind)
   const subject = optionalText(input.subject, 'subject')
   const includeSuperseded = optionalBoolean(input.includeSuperseded, 'includeSuperseded')
-  const limit = optionalLimit(input.limit)
+  const limit = optionalLimit(input.limit, OPERATION_BUDGETS.fullResultLimit)
   return {
     ...root,
     ...(kind === undefined ? {} : { kind }),
@@ -128,12 +149,12 @@ export const parseShowRecordInput = (value: unknown): ShowRecordInput => {
   }
 }
 
-export const parseSearchRecordsInput = (value: unknown): SearchRecordsInput => {
+const parseSearchRecordsInputWithBudget = (value: unknown, budget: ResultLimitBudget): SearchRecordsInput => {
   const input = objectInput(value, 'searchRecords')
   const root = rootProperties(input)
   const kind = input.kind === undefined ? undefined : validateKind(input.kind)
   const includeSuperseded = optionalBoolean(input.includeSuperseded, 'includeSuperseded')
-  const limit = optionalLimit(input.limit)
+  const limit = optionalLimit(input.limit, budget)
   const query = optionalQuery(input.query, 'query')
   if (query === undefined) {
     return fail('INVALID_ARGUMENT', 'query must be a string.', { field: 'query' })
@@ -147,15 +168,29 @@ export const parseSearchRecordsInput = (value: unknown): SearchRecordsInput => {
   }
 }
 
+export const parseFullSearchRecordsInput = (value: unknown): SearchRecordsInput =>
+  parseSearchRecordsInputWithBudget(value, OPERATION_BUDGETS.fullResultLimit)
+
+export const parseCompactSearchRecordsInput = (value: unknown): SearchRecordsInput =>
+  parseSearchRecordsInputWithBudget(value, OPERATION_BUDGETS.compactResultLimit)
+
+/** @internal */
+export const parseSearchRecordsInput = parseFullSearchRecordsInput
+
 export const parseGatherInput = (value: unknown): GatherInput => {
   const input = objectInput(value, 'gatherRecords')
   const root = rootProperties(input)
   const kind = input.kind === undefined ? undefined : validateKind(input.kind)
   const includeSuperseded = optionalBoolean(input.includeSuperseded, 'includeSuperseded')
   const hydrate = optionalBoolean(input.hydrate, 'hydrate')
-  const limit = optionalLimit(input.limit)
-  const searches = optionalStringArray(input.searches, 'searches', entry => optionalQuery(entry, 'searches') ?? '')
-  const shows = optionalStringArray(input.shows, 'shows', validateId)
+  const limit = optionalLimit(input.limit, OPERATION_BUDGETS.compactResultLimit)
+  const searches = optionalBoundedStringArray(
+    input.searches,
+    OPERATION_BUDGETS.gatherSearches,
+    'gatherSearches',
+    entry => optionalQuery(entry, 'searches') ?? '',
+  )
+  const shows = optionalBoundedStringArray(input.shows, OPERATION_BUDGETS.gatherShows, 'gatherShows', validateId)
   return {
     ...root,
     ...(searches === undefined ? {} : { searches }),

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -55,13 +55,11 @@ import type {
 
 const SCHEMA_VERSION = '1'
 const MAX_REPOSITORY_CHANGE_RETRIES = 3
-export const MAX_QUERY_BYTES = OPERATION_BUDGETS.queryBytes.maximum
-export const MAX_QUERY_TERMS = OPERATION_BUDGETS.queryTerms.maximum
-export const MAX_GATHER_SEARCHES = OPERATION_BUDGETS.gatherSearches.maximum
-export const MAX_GATHER_SHOWS = OPERATION_BUDGETS.gatherShows.maximum
-export const MAX_FULL_RESULT_LIMIT = OPERATION_BUDGETS.fullResultLimit.maximum
-export const MAX_COMPACT_RESULT_LIMIT = OPERATION_BUDGETS.compactResultLimit.maximum
-export const MAX_FULL_RESPONSE_BYTES = OPERATION_BUDGETS.fullResponseBytes.maximum
+const MAX_QUERY_BYTES = OPERATION_BUDGETS.queryBytes.maximum
+const MAX_QUERY_TERMS = OPERATION_BUDGETS.queryTerms.maximum
+const MAX_GATHER_SEARCHES = OPERATION_BUDGETS.gatherSearches.maximum
+const MAX_GATHER_SHOWS = OPERATION_BUDGETS.gatherShows.maximum
+const MAX_FULL_RESPONSE_BYTES = OPERATION_BUDGETS.fullResponseBytes.maximum
 const SQLITE_BUSY_TIMEOUT_MILLISECONDS = 1000
 const MAX_CACHE_METADATA_BYTES = 1024 * 1024
 const MAX_CACHE_RECORD_BYTES = MAX_RECORD_BYTES + 4096
@@ -934,25 +932,20 @@ export const hydrate = (input: RootInput = {}): HydrateResult => {
   }
 }
 
-type ResultLimitBudget = typeof OPERATION_BUDGETS.compactResultLimit | typeof OPERATION_BUDGETS.fullResultLimit
+type ResultLimitBudgetKey = 'compactResultLimit' | 'fullResultLimit'
 
-const positiveLimit = (value: unknown, budget: ResultLimitBudget, budgetName: string) => {
+const positiveLimit = (value: unknown, budgetKey: ResultLimitBudgetKey) => {
+  const budget = OPERATION_BUDGETS[budgetKey]
   const limit = value === undefined ? budget.default : value
   if (typeof limit === 'number' && Number.isInteger(limit) && limit >= budget.minimum && limit <= budget.maximum) {
     return limit
   }
-  return failBudget(
-    budget.field,
-    budgetName,
-    budget.maximum,
-    `limit must be an integer between ${budget.minimum} and ${budget.maximum}.`,
-  )
+  return failBudget(budgetKey, `limit must be an integer between ${budget.minimum} and ${budget.maximum}.`)
 }
 
-const fullResultLimit = (value: unknown) => positiveLimit(value, OPERATION_BUDGETS.fullResultLimit, 'fullResultLimit')
+const fullResultLimit = (value: unknown) => positiveLimit(value, 'fullResultLimit')
 
-const compactResultLimit = (value: unknown) =>
-  positiveLimit(value, OPERATION_BUDGETS.compactResultLimit, 'compactResultLimit')
+const compactResultLimit = (value: unknown) => positiveLimit(value, 'compactResultLimit')
 
 const readFreshDatabase = <Result>(root: string, location: CacheLocation, read: (database: DatabaseSync) => Result) => {
   const database = openReaderDatabase(location)
@@ -1013,9 +1006,7 @@ const parseRecordRowWithinBudget = (row: RecordRow, budget: FullResponseBudget) 
   budget.bytes += recordRowBytes(row)
   if (budget.bytes > MAX_FULL_RESPONSE_BYTES) {
     return failBudget(
-      OPERATION_BUDGETS.fullResponseBytes.field,
       'fullResponseBytes',
-      MAX_FULL_RESPONSE_BYTES,
       `full-record responses may contain at most ${MAX_FULL_RESPONSE_BYTES} UTF-8 bytes.`,
     )
   }
@@ -1071,21 +1062,11 @@ const literalMatchQuery = (query: unknown) => {
     })
   }
   if (byteLength(query) > MAX_QUERY_BYTES) {
-    return failBudget(
-      OPERATION_BUDGETS.queryBytes.field,
-      'queryBytes',
-      MAX_QUERY_BYTES,
-      `query must contain at most ${MAX_QUERY_BYTES} UTF-8 bytes.`,
-    )
+    return failBudget('queryBytes', `query must contain at most ${MAX_QUERY_BYTES} UTF-8 bytes.`)
   }
   const terms = query.split(/[^A-Za-z0-9_]+/u).filter(term => term.length > 0)
   if (terms.length > MAX_QUERY_TERMS) {
-    return failBudget(
-      OPERATION_BUDGETS.queryTerms.field,
-      'queryTerms',
-      MAX_QUERY_TERMS,
-      `query may contain at most ${MAX_QUERY_TERMS} literal terms.`,
-    )
+    return failBudget('queryTerms', `query may contain at most ${MAX_QUERY_TERMS} literal terms.`)
   }
   return terms.map(term => `"${term.replaceAll('"', '""')}"`).join(' AND ')
 }
@@ -1221,20 +1202,10 @@ const assertGatherBudgets = (input: GatherInput) => {
   const searches = input.searches ?? []
   const shows = input.shows ?? []
   if (searches.length > MAX_GATHER_SEARCHES) {
-    return failBudget(
-      OPERATION_BUDGETS.gatherSearches.field,
-      'gatherSearches',
-      MAX_GATHER_SEARCHES,
-      `gather may contain at most ${MAX_GATHER_SEARCHES} searches.`,
-    )
+    return failBudget('gatherSearches', `gather may contain at most ${MAX_GATHER_SEARCHES} searches.`)
   }
   if (shows.length > MAX_GATHER_SHOWS) {
-    return failBudget(
-      OPERATION_BUDGETS.gatherShows.field,
-      'gatherShows',
-      MAX_GATHER_SHOWS,
-      `gather may contain at most ${MAX_GATHER_SHOWS} shows.`,
-    )
+    return failBudget('gatherShows', `gather may contain at most ${MAX_GATHER_SHOWS} shows.`)
   }
   searches.forEach(literalMatchQuery)
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -4,10 +4,11 @@ import { createRequire } from 'node:module'
 import { resolve } from 'node:path'
 import type { DatabaseSync } from 'node:sqlite'
 import {
+  parseCompactSearchRecordsInput,
+  parseFullSearchRecordsInput,
   parseGatherInput,
   parseListRecordsInput,
   parseRootInput,
-  parseSearchRecordsInput,
   parseShowRecordInput,
 } from './api-input.ts'
 import { ArtifactChangedError, type ArtifactObservation, inspectArtifactFiles } from './artifact-inspection.ts'
@@ -30,9 +31,10 @@ import {
   MAX_CANONICAL_KIND_ENTRIES,
   revalidateCanonicalDirectory,
 } from './canonical-layout.ts'
-import { EncephalonError, fail, failWithCause, wrapIo } from './errors.ts'
+import { EncephalonError, fail, failBudget, failWithCause, wrapIo } from './errors.ts'
 import { PACKAGE_VERSION } from './generated/version.ts'
 import { withOperationLock } from './lock.ts'
+import { OPERATION_BUDGETS } from './operation-budgets.ts'
 import { ordinalStringCompare } from './order.ts'
 import { canonicalRecordPath, readRecords, readValidatedRecordSnapshotResolved } from './records.ts'
 import { resolveRepository } from './repository.ts'
@@ -53,13 +55,13 @@ import type {
 
 const SCHEMA_VERSION = '1'
 const MAX_REPOSITORY_CHANGE_RETRIES = 3
-export const MAX_QUERY_BYTES = 1024
-export const MAX_QUERY_TERMS = 32
-export const MAX_GATHER_SEARCHES = 16
-export const MAX_GATHER_SHOWS = 64
-export const MAX_FULL_RESULT_LIMIT = 50
-export const MAX_COMPACT_RESULT_LIMIT = 100
-export const MAX_FULL_RESPONSE_BYTES = 4 * 1024 * 1024
+export const MAX_QUERY_BYTES = OPERATION_BUDGETS.queryBytes.maximum
+export const MAX_QUERY_TERMS = OPERATION_BUDGETS.queryTerms.maximum
+export const MAX_GATHER_SEARCHES = OPERATION_BUDGETS.gatherSearches.maximum
+export const MAX_GATHER_SHOWS = OPERATION_BUDGETS.gatherShows.maximum
+export const MAX_FULL_RESULT_LIMIT = OPERATION_BUDGETS.fullResultLimit.maximum
+export const MAX_COMPACT_RESULT_LIMIT = OPERATION_BUDGETS.compactResultLimit.maximum
+export const MAX_FULL_RESPONSE_BYTES = OPERATION_BUDGETS.fullResponseBytes.maximum
 const SQLITE_BUSY_TIMEOUT_MILLISECONDS = 1000
 const MAX_CACHE_METADATA_BYTES = 1024 * 1024
 const MAX_CACHE_RECORD_BYTES = MAX_RECORD_BYTES + 4096
@@ -932,24 +934,25 @@ export const hydrate = (input: RootInput = {}): HydrateResult => {
   }
 }
 
-const budgetFailure = (field: string, budget: string, maximum: number, message: string) =>
-  fail('INVALID_ARGUMENT', message, {
-    budget,
-    field,
-    maximum,
-  })
+type ResultLimitBudget = typeof OPERATION_BUDGETS.compactResultLimit | typeof OPERATION_BUDGETS.fullResultLimit
 
-const positiveLimit = (value: unknown, maximum: number, budget: string, fallback = 20) => {
-  const limit = value === undefined ? fallback : value
-  if (typeof limit === 'number' && Number.isInteger(limit) && limit > 0 && limit <= maximum) {
+const positiveLimit = (value: unknown, budget: ResultLimitBudget, budgetName: string) => {
+  const limit = value === undefined ? budget.default : value
+  if (typeof limit === 'number' && Number.isInteger(limit) && limit >= budget.minimum && limit <= budget.maximum) {
     return limit
   }
-  return budgetFailure('limit', budget, maximum, `limit must be an integer between 1 and ${maximum}.`)
+  return failBudget(
+    budget.field,
+    budgetName,
+    budget.maximum,
+    `limit must be an integer between ${budget.minimum} and ${budget.maximum}.`,
+  )
 }
 
-const fullResultLimit = (value: unknown) => positiveLimit(value, MAX_FULL_RESULT_LIMIT, 'fullResultLimit')
+const fullResultLimit = (value: unknown) => positiveLimit(value, OPERATION_BUDGETS.fullResultLimit, 'fullResultLimit')
 
-const compactResultLimit = (value: unknown) => positiveLimit(value, MAX_COMPACT_RESULT_LIMIT, 'compactResultLimit')
+const compactResultLimit = (value: unknown) =>
+  positiveLimit(value, OPERATION_BUDGETS.compactResultLimit, 'compactResultLimit')
 
 const readFreshDatabase = <Result>(root: string, location: CacheLocation, read: (database: DatabaseSync) => Result) => {
   const database = openReaderDatabase(location)
@@ -1009,8 +1012,8 @@ const recordRowBytes = (row: RecordRow) => {
 const parseRecordRowWithinBudget = (row: RecordRow, budget: FullResponseBudget) => {
   budget.bytes += recordRowBytes(row)
   if (budget.bytes > MAX_FULL_RESPONSE_BYTES) {
-    return budgetFailure(
-      'response',
+    return failBudget(
+      OPERATION_BUDGETS.fullResponseBytes.field,
       'fullResponseBytes',
       MAX_FULL_RESPONSE_BYTES,
       `full-record responses may contain at most ${MAX_FULL_RESPONSE_BYTES} UTF-8 bytes.`,
@@ -1068,8 +1071,8 @@ const literalMatchQuery = (query: unknown) => {
     })
   }
   if (byteLength(query) > MAX_QUERY_BYTES) {
-    return budgetFailure(
-      'query',
+    return failBudget(
+      OPERATION_BUDGETS.queryBytes.field,
       'queryBytes',
       MAX_QUERY_BYTES,
       `query must contain at most ${MAX_QUERY_BYTES} UTF-8 bytes.`,
@@ -1077,8 +1080,8 @@ const literalMatchQuery = (query: unknown) => {
   }
   const terms = query.split(/[^A-Za-z0-9_]+/u).filter(term => term.length > 0)
   if (terms.length > MAX_QUERY_TERMS) {
-    return budgetFailure(
-      'query',
+    return failBudget(
+      OPERATION_BUDGETS.queryTerms.field,
       'queryTerms',
       MAX_QUERY_TERMS,
       `query may contain at most ${MAX_QUERY_TERMS} literal terms.`,
@@ -1186,7 +1189,7 @@ const createCompactSearchReader = (database: DatabaseSync, input: SearchStatemen
 }
 
 export const searchRecords = (input: SearchRecordsInput): BrainRecord[] => {
-  const parsed = parseSearchRecordsInput(input)
+  const parsed = parseFullSearchRecordsInput(input)
   const match = literalMatchQuery(parsed.query)
   const limit = fullResultLimit(parsed.limit)
   return withPreparedDatabase(parsed, database =>
@@ -1195,7 +1198,7 @@ export const searchRecords = (input: SearchRecordsInput): BrainRecord[] => {
 }
 
 export const searchCompactRecords = (input: SearchRecordsInput): CompactBrainRecord[] => {
-  const parsed = parseSearchRecordsInput(input)
+  const parsed = parseCompactSearchRecordsInput(input)
   literalMatchQuery(parsed.query)
   compactResultLimit(parsed.limit)
   return withPreparedDatabase(parsed, database => createCompactSearchReader(database, parsed)(parsed.query))
@@ -1218,16 +1221,16 @@ const assertGatherBudgets = (input: GatherInput) => {
   const searches = input.searches ?? []
   const shows = input.shows ?? []
   if (searches.length > MAX_GATHER_SEARCHES) {
-    return budgetFailure(
-      'searches',
+    return failBudget(
+      OPERATION_BUDGETS.gatherSearches.field,
       'gatherSearches',
       MAX_GATHER_SEARCHES,
       `gather may contain at most ${MAX_GATHER_SEARCHES} searches.`,
     )
   }
   if (shows.length > MAX_GATHER_SHOWS) {
-    return budgetFailure(
-      'shows',
+    return failBudget(
+      OPERATION_BUDGETS.gatherShows.field,
       'gatherShows',
       MAX_GATHER_SHOWS,
       `gather may contain at most ${MAX_GATHER_SHOWS} shows.`,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { parseArgs } from 'node:util'
-import { cliErrorResponse, fail } from './errors.ts'
+import { cliErrorResponse, fail, failBudget } from './errors.ts'
 import { PACKAGE_VERSION } from './generated/version.ts'
 import {
   addRecord,
@@ -16,6 +16,7 @@ import {
   showRecord,
   validateRecords,
 } from './index.ts'
+import { OPERATION_BUDGETS } from './operation-budgets.ts'
 import type { JsonValue } from './types.ts'
 
 const HELP = `Usage: encephalon [--root <path>] <command> [options]
@@ -24,14 +25,17 @@ Commands:
   init [--refresh-baseline] [--remove]
   add [--id <id>] --kind <kind> --subject <subject> --source <source> --data <json>
       [--confidence <0..1>] [--text <text>] [--supersedes <id> ...] [--artifact <path> ...]
+      Accepts at most ${OPERATION_BUDGETS.supersessionEdges.maximum.toLocaleString('en-GB')} supersession targets.
   prepare
   hydrate
   validate
-  list [--kind <kind>] [--subject <subject>] [--include-superseded] [--limit <1..1000>]
+  list [--kind <kind>] [--subject <subject>] [--include-superseded] [--limit <${OPERATION_BUDGETS.fullResultLimit.minimum}..${OPERATION_BUDGETS.fullResultLimit.maximum}>]
   show --id <id> [--active-only]
-  search [--compact] [--kind <kind>] [--include-superseded] [--limit <1..1000>] [--] <query>
+  search [--kind <kind>] [--include-superseded] [--limit <${OPERATION_BUDGETS.fullResultLimit.minimum}..${OPERATION_BUDGETS.fullResultLimit.maximum}>] [--] <query>
+  search --compact [--kind <kind>] [--include-superseded] [--limit <${OPERATION_BUDGETS.compactResultLimit.minimum}..${OPERATION_BUDGETS.compactResultLimit.maximum}>] [--] <query>
   gather [--search <query> ...] [--show <id> ...] [--hydrate] [--include-superseded]
-         [--kind <kind>] [--limit <1..1000>]
+         [--kind <kind>] [--limit <${OPERATION_BUDGETS.compactResultLimit.minimum}..${OPERATION_BUDGETS.compactResultLimit.maximum}>]
+         Accepts at most ${OPERATION_BUDGETS.gatherSearches.maximum} searches and ${OPERATION_BUDGETS.gatherShows.maximum} shows.
 
 Global options:
   --root <path>   Use this exact Git repository root.
@@ -170,15 +174,23 @@ const noPositionals = (options: ParsedOptions) => {
   }
 }
 
-const parseLimit = (value: string | undefined) => {
+type ResultLimitBudgetName = 'compactResultLimit' | 'fullResultLimit'
+
+const parseLimit = (value: string | undefined, budgetName: ResultLimitBudgetName) => {
   if (value === undefined) {
     return
   }
+  const budget = OPERATION_BUDGETS[budgetName]
   const parsed = Number(value)
-  if (Number.isInteger(parsed) && parsed > 0 && parsed <= 1000) {
+  if (Number.isInteger(parsed) && parsed >= budget.minimum && parsed <= budget.maximum) {
     return parsed
   }
-  return invalid('--limit must be an integer between 1 and 1000.')
+  return failBudget(
+    budget.field,
+    budgetName,
+    budget.maximum,
+    `--limit must be an integer between ${budget.minimum} and ${budget.maximum}.`,
+  )
 }
 
 const parsePayload = (value: string) => {
@@ -231,6 +243,7 @@ const dispatch = (arguments_: string[]): CommandResult => {
         values: ['id', 'kind', 'subject', 'source', 'data', 'text', 'confidence'],
       })
       noPositionals(options)
+      const supersedes = many(options, 'supersedes')
       const kind = one(options, 'kind')
       const subject = one(options, 'subject')
       const source = one(options, 'source')
@@ -242,6 +255,14 @@ const dispatch = (arguments_: string[]): CommandResult => {
       const requiredSubject = requiredOption(subject, 'add requires --kind, --subject, --source, and --data.')
       const requiredSource = requiredOption(source, 'add requires --kind, --subject, --source, and --data.')
       const requiredData = requiredOption(data, 'add requires --kind, --subject, --source, and --data.')
+      if (supersedes.length > OPERATION_BUDGETS.supersessionEdges.maximum) {
+        failBudget(
+          OPERATION_BUDGETS.supersessionEdges.field,
+          'supersessionEdges',
+          OPERATION_BUDGETS.supersessionEdges.maximum,
+          `--supersedes may be supplied at most ${OPERATION_BUDGETS.supersessionEdges.maximum} times.`,
+        )
+      }
       const confidenceValue = one(options, 'confidence')
       const confidence = confidenceValue === undefined ? undefined : Number(confidenceValue)
       const id = one(options, 'id')
@@ -254,7 +275,7 @@ const dispatch = (arguments_: string[]): CommandResult => {
           source: requiredSource,
           subject: requiredSubject,
           ...(confidence === undefined ? {} : { confidence }),
-          ...(many(options, 'supersedes').length === 0 ? {} : { supersedes: many(options, 'supersedes') }),
+          ...(supersedes.length === 0 ? {} : { supersedes }),
           ...(many(options, 'artifact').length === 0 ? {} : { artifacts: many(options, 'artifact') }),
           payload: parsePayload(requiredData),
           ...(searchText === undefined ? {} : { searchText }),
@@ -285,7 +306,7 @@ const dispatch = (arguments_: string[]): CommandResult => {
       noPositionals(options)
       const kind = one(options, 'kind')
       const subject = one(options, 'subject')
-      const limit = parseLimit(one(options, 'limit'))
+      const limit = parseLimit(one(options, 'limit'), 'fullResultLimit')
       return {
         value: listRecords({
           ...root,
@@ -323,7 +344,8 @@ const dispatch = (arguments_: string[]): CommandResult => {
         invalid('search requires a query.')
       }
       const kind = one(options, 'kind')
-      const limit = parseLimit(one(options, 'limit'))
+      const compact = options.flags.has('compact')
+      const limit = parseLimit(one(options, 'limit'), compact ? 'compactResultLimit' : 'fullResultLimit')
       const input = {
         ...root,
         query,
@@ -332,7 +354,7 @@ const dispatch = (arguments_: string[]): CommandResult => {
         ...(limit === undefined ? {} : { limit }),
       }
       return {
-        value: options.flags.has('compact') ? searchCompactRecords(input) : searchRecords(input),
+        value: compact ? searchCompactRecords(input) : searchRecords(input),
       }
     }
     case 'gather': {
@@ -342,13 +364,31 @@ const dispatch = (arguments_: string[]): CommandResult => {
         values: ['kind', 'limit'],
       })
       noPositionals(options)
+      const searches = many(options, 'search')
+      if (searches.length > OPERATION_BUDGETS.gatherSearches.maximum) {
+        failBudget(
+          OPERATION_BUDGETS.gatherSearches.field,
+          'gatherSearches',
+          OPERATION_BUDGETS.gatherSearches.maximum,
+          `gather may contain at most ${OPERATION_BUDGETS.gatherSearches.maximum} searches.`,
+        )
+      }
+      const shows = many(options, 'show')
+      if (shows.length > OPERATION_BUDGETS.gatherShows.maximum) {
+        failBudget(
+          OPERATION_BUDGETS.gatherShows.field,
+          'gatherShows',
+          OPERATION_BUDGETS.gatherShows.maximum,
+          `gather may contain at most ${OPERATION_BUDGETS.gatherShows.maximum} shows.`,
+        )
+      }
       const kind = one(options, 'kind')
-      const limit = parseLimit(one(options, 'limit'))
+      const limit = parseLimit(one(options, 'limit'), 'compactResultLimit')
       return {
         value: gatherRecords({
           ...root,
-          searches: many(options, 'search'),
-          shows: many(options, 'show'),
+          searches,
+          shows,
           ...(kind === undefined ? {} : { kind }),
           ...(limit === undefined ? {} : { limit }),
           hydrate: options.flags.has('hydrate'),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,8 +56,55 @@ type CommandResult = {
   format?: 'json' | 'text'
 }
 
+type RepeatedOptionBudget = {
+  budgetKey: 'gatherSearches' | 'gatherShows' | 'supersessionEdges'
+  message: (maximum: number) => string
+  option: 'search' | 'show' | 'supersedes'
+}
+
+const REPEATED_OPTION_BUDGETS = {
+  search: {
+    budgetKey: 'gatherSearches',
+    message: (maximum: number) => `gather may contain at most ${maximum} searches.`,
+    option: 'search',
+  },
+  show: {
+    budgetKey: 'gatherShows',
+    message: (maximum: number) => `gather may contain at most ${maximum} shows.`,
+    option: 'show',
+  },
+  supersedes: {
+    budgetKey: 'supersessionEdges',
+    message: (maximum: number) => `--supersedes may be supplied at most ${maximum} times.`,
+    option: 'supersedes',
+  },
+} as const satisfies Record<string, RepeatedOptionBudget>
+
 const invalid = (message: string, details: Record<string, JsonValue> = {}): never =>
   fail('INVALID_ARGUMENT', message, details)
+
+const rawOptionCount = (arguments_: readonly string[], option: string) =>
+  arguments_.reduce(
+    (state, argument) => {
+      if (!state.terminated) {
+        if (argument === '--') {
+          return { ...state, terminated: true }
+        }
+        if (argument === `--${option}` || argument.startsWith(`--${option}=`)) {
+          return { ...state, count: state.count + 1 }
+        }
+      }
+      return state
+    },
+    { count: 0, terminated: false },
+  ).count
+
+const preflightRepeatedOptionBudget = (arguments_: readonly string[], specification: RepeatedOptionBudget) => {
+  const budget = OPERATION_BUDGETS[specification.budgetKey]
+  if (rawOptionCount(arguments_, specification.option) > budget.maximum) {
+    return failBudget(specification.budgetKey, specification.message(budget.maximum))
+  }
+}
 
 const extractRoot = (arguments_: string[]) => {
   const roots: string[] = []
@@ -185,12 +232,7 @@ const parseLimit = (value: string | undefined, budgetName: ResultLimitBudgetName
   if (Number.isInteger(parsed) && parsed >= budget.minimum && parsed <= budget.maximum) {
     return parsed
   }
-  return failBudget(
-    budget.field,
-    budgetName,
-    budget.maximum,
-    `--limit must be an integer between ${budget.minimum} and ${budget.maximum}.`,
-  )
+  return failBudget(budgetName, `--limit must be an integer between ${budget.minimum} and ${budget.maximum}.`)
 }
 
 const parsePayload = (value: string) => {
@@ -238,6 +280,7 @@ const dispatch = (arguments_: string[]): CommandResult => {
       }
     }
     case 'add': {
+      preflightRepeatedOptionBudget(commandArguments, REPEATED_OPTION_BUDGETS.supersedes)
       const options = parseOptions(commandArguments, {
         repeated: ['supersedes', 'artifact'],
         values: ['id', 'kind', 'subject', 'source', 'data', 'text', 'confidence'],
@@ -255,14 +298,6 @@ const dispatch = (arguments_: string[]): CommandResult => {
       const requiredSubject = requiredOption(subject, 'add requires --kind, --subject, --source, and --data.')
       const requiredSource = requiredOption(source, 'add requires --kind, --subject, --source, and --data.')
       const requiredData = requiredOption(data, 'add requires --kind, --subject, --source, and --data.')
-      if (supersedes.length > OPERATION_BUDGETS.supersessionEdges.maximum) {
-        failBudget(
-          OPERATION_BUDGETS.supersessionEdges.field,
-          'supersessionEdges',
-          OPERATION_BUDGETS.supersessionEdges.maximum,
-          `--supersedes may be supplied at most ${OPERATION_BUDGETS.supersessionEdges.maximum} times.`,
-        )
-      }
       const confidenceValue = one(options, 'confidence')
       const confidence = confidenceValue === undefined ? undefined : Number(confidenceValue)
       const id = one(options, 'id')
@@ -358,6 +393,8 @@ const dispatch = (arguments_: string[]): CommandResult => {
       }
     }
     case 'gather': {
+      preflightRepeatedOptionBudget(commandArguments, REPEATED_OPTION_BUDGETS.search)
+      preflightRepeatedOptionBudget(commandArguments, REPEATED_OPTION_BUDGETS.show)
       const options = parseOptions(commandArguments, {
         flags: ['hydrate', 'include-superseded'],
         repeated: ['search', 'show'],
@@ -365,23 +402,7 @@ const dispatch = (arguments_: string[]): CommandResult => {
       })
       noPositionals(options)
       const searches = many(options, 'search')
-      if (searches.length > OPERATION_BUDGETS.gatherSearches.maximum) {
-        failBudget(
-          OPERATION_BUDGETS.gatherSearches.field,
-          'gatherSearches',
-          OPERATION_BUDGETS.gatherSearches.maximum,
-          `gather may contain at most ${OPERATION_BUDGETS.gatherSearches.maximum} searches.`,
-        )
-      }
       const shows = many(options, 'show')
-      if (shows.length > OPERATION_BUDGETS.gatherShows.maximum) {
-        failBudget(
-          OPERATION_BUDGETS.gatherShows.field,
-          'gatherShows',
-          OPERATION_BUDGETS.gatherShows.maximum,
-          `gather may contain at most ${OPERATION_BUDGETS.gatherShows.maximum} shows.`,
-        )
-      }
       const kind = one(options, 'kind')
       const limit = parseLimit(one(options, 'limit'), 'compactResultLimit')
       return {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -119,6 +119,9 @@ export const fail = (code: EncephalonErrorCode, message: string, details: Record
   throw new EncephalonError(code, message, details)
 }
 
+export const failBudget = (field: string, budget: string, maximum: number, message: string): never =>
+  fail('INVALID_ARGUMENT', message, { budget, field, maximum })
+
 export const failWithCause = (
   code: EncephalonErrorCode,
   message: string,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,4 @@
+import { OPERATION_BUDGETS } from './operation-budgets.ts'
 import { classifySQLiteError } from './sqlite-error.ts'
 import type { EncephalonErrorCode, JsonValue } from './types.ts'
 
@@ -27,6 +28,8 @@ const MAX_CLI_ARRAY_LENGTH = 25
 const MAX_CLI_OBJECT_KEYS = 25
 const MAX_CLI_NUMBER_MAGNITUDE = 1_000_000_000_000
 const UNSAFE_CLI_DETAIL_KEYS = new Set(['cause', 'stack'])
+
+type OperationBudgetKey = keyof typeof OPERATION_BUDGETS
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && !Array.isArray(value) && typeof value === 'object'
@@ -119,8 +122,15 @@ export const fail = (code: EncephalonErrorCode, message: string, details: Record
   throw new EncephalonError(code, message, details)
 }
 
-export const failBudget = (field: string, budget: string, maximum: number, message: string): never =>
-  fail('INVALID_ARGUMENT', message, { budget, field, maximum })
+/** @internal */
+export const failBudget = (budgetKey: OperationBudgetKey, message: string): never => {
+  const budget = OPERATION_BUDGETS[budgetKey]
+  return fail('INVALID_ARGUMENT', message, {
+    budget: budgetKey,
+    field: budget.field,
+    maximum: budget.maximum,
+  })
+}
 
 export const failWithCause = (
   code: EncephalonErrorCode,

--- a/src/operation-budgets.ts
+++ b/src/operation-budgets.ts
@@ -1,0 +1,10 @@
+export const OPERATION_BUDGETS = {
+  compactResultLimit: { default: 20, field: 'limit', maximum: 100, minimum: 1 },
+  fullResponseBytes: { field: 'response', maximum: 4 * 1024 * 1024 },
+  fullResultLimit: { default: 20, field: 'limit', maximum: 50, minimum: 1 },
+  gatherSearches: { field: 'searches', maximum: 16 },
+  gatherShows: { field: 'shows', maximum: 64 },
+  queryBytes: { field: 'query', maximum: 1024 },
+  queryTerms: { field: 'query', maximum: 32 },
+  supersessionEdges: { field: 'supersedes', maximum: 1000 },
+} as const

--- a/src/operation-budgets.ts
+++ b/src/operation-budgets.ts
@@ -1,10 +1,11 @@
-export const OPERATION_BUDGETS = {
-  compactResultLimit: { default: 20, field: 'limit', maximum: 100, minimum: 1 },
-  fullResponseBytes: { field: 'response', maximum: 4 * 1024 * 1024 },
-  fullResultLimit: { default: 20, field: 'limit', maximum: 50, minimum: 1 },
-  gatherSearches: { field: 'searches', maximum: 16 },
-  gatherShows: { field: 'shows', maximum: 64 },
-  queryBytes: { field: 'query', maximum: 1024 },
-  queryTerms: { field: 'query', maximum: 32 },
-  supersessionEdges: { field: 'supersedes', maximum: 1000 },
-} as const
+/** @internal */
+export const OPERATION_BUDGETS = Object.freeze({
+  compactResultLimit: Object.freeze({ default: 20, field: 'limit', maximum: 100, minimum: 1 }),
+  fullResponseBytes: Object.freeze({ field: 'response', maximum: 4 * 1024 * 1024 }),
+  fullResultLimit: Object.freeze({ default: 20, field: 'limit', maximum: 50, minimum: 1 }),
+  gatherSearches: Object.freeze({ field: 'searches', maximum: 16 }),
+  gatherShows: Object.freeze({ field: 'shows', maximum: 64 }),
+  queryBytes: Object.freeze({ field: 'query', maximum: 1024 }),
+  queryTerms: Object.freeze({ field: 'query', maximum: 32 }),
+  supersessionEdges: Object.freeze({ field: 'supersedes', maximum: 1000 }),
+} as const)

--- a/src/records.ts
+++ b/src/records.ts
@@ -41,6 +41,7 @@ import { type DirectoryWitness, DirectoryWitnessError, revalidateDirectoryWitnes
 import { EncephalonError, fail, wrapIo } from './errors.ts'
 import { sameEntryIdentity, sameStableEntryMetadata } from './filesystem-entry.ts'
 import { withOperationLock } from './lock.ts'
+import { OPERATION_BUDGETS } from './operation-budgets.ts'
 import { ordinalStringCompare } from './order.ts'
 import { resolveRepository } from './repository.ts'
 import {
@@ -271,7 +272,7 @@ export const MAX_CANONICAL_RECORDS = 1000
 /** @internal */
 export const MAX_CANONICAL_RECORD_BYTES = 8 * 1024 * 1024
 /** @internal */
-export const MAX_SUPERSESSION_EDGES = 1000
+export const MAX_SUPERSESSION_EDGES = OPERATION_BUDGETS.supersessionEdges.maximum
 /** @internal */
 export const MAX_ARTIFACT_REFERENCES = 1000
 /** @internal */

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -370,9 +370,7 @@ const normalizeOptionalText = (value: unknown, field: string, maximumBytes: numb
 const validateSupersedes = (value: unknown) => {
   if (Array.isArray(value) && value.length > OPERATION_BUDGETS.supersessionEdges.maximum) {
     return failBudget(
-      OPERATION_BUDGETS.supersessionEdges.field,
       'supersessionEdges',
-      OPERATION_BUDGETS.supersessionEdges.maximum,
       `supersedes may contain at most ${OPERATION_BUDGETS.supersessionEdges.maximum} record ids.`,
     )
   }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { ARTIFACTS_DIRECTORY_NAME } from './canonical-layout.ts'
-import { fail } from './errors.ts'
+import { fail, failBudget } from './errors.ts'
+import { OPERATION_BUDGETS } from './operation-budgets.ts'
 import type { AddRecordInput, BrainRecordFile, JsonValue } from './types.ts'
 
 export const MAX_RECORD_BYTES = 1024 * 1024
@@ -366,17 +367,29 @@ const normalizeOptionalText = (value: unknown, field: string, maximumBytes: numb
   return fail('INVALID_ARGUMENT', `${field} must be a non-empty string within its size limit.`, { field })
 }
 
-const optionalStringArray = (value: unknown, field: string, item: (value: unknown) => string) => {
+const validateSupersedes = (value: unknown) => {
+  if (Array.isArray(value) && value.length > OPERATION_BUDGETS.supersessionEdges.maximum) {
+    return failBudget(
+      OPERATION_BUDGETS.supersessionEdges.field,
+      'supersessionEdges',
+      OPERATION_BUDGETS.supersessionEdges.maximum,
+      `supersedes may contain at most ${OPERATION_BUDGETS.supersessionEdges.maximum} record ids.`,
+    )
+  }
+  return validateStringArray(value, 'supersedes', validateId)
+}
+
+const optionalSupersedes = (value: unknown) => {
   if (value === undefined) {
     return
   }
   if (!Array.isArray(value)) {
-    return fail('INVALID_ARGUMENT', `${field} must be an array of strings.`, { field })
+    return fail('INVALID_ARGUMENT', 'supersedes must be an array of strings.', { field: 'supersedes' })
   }
   if (value.length === 0) {
     return
   }
-  return validateStringArray(value, field, item)
+  return validateSupersedes(value)
 }
 
 const optionalArtifacts = (value: unknown, kind: string, id: string) => {
@@ -420,7 +433,7 @@ export const validateAddRecordInput = (input: AddRecordInput): ValidatedAddRecor
   const source = requiredText(input.source, 'source')
   const payload = validateJsonValue(input.payload)
   const confidence = input.confidence === undefined ? undefined : validateConfidence(input.confidence)
-  const supersedes = optionalStringArray(input.supersedes, 'supersedes', validateId)
+  const supersedes = optionalSupersedes(input.supersedes)
   const artifacts = optionalArtifacts(input.artifacts, kind, id)
   const searchText =
     input.searchText === undefined
@@ -480,7 +493,7 @@ export const parseRecordFile = (value: unknown): BrainRecordFile => {
     record.searchText = normalizeOptionalText(object.searchText, 'searchText', MAX_SEARCH_TEXT_BYTES)
   }
   if (object.supersedes !== undefined) {
-    record.supersedes = validateStringArray(object.supersedes, 'supersedes', validateId)
+    record.supersedes = validateSupersedes(object.supersedes)
   }
   return record
 }

--- a/test/api-input.test.ts
+++ b/test/api-input.test.ts
@@ -6,8 +6,8 @@ import {
   parseGatherInput,
   parseListRecordsInput,
 } from '../src/api-input.ts'
-import { EncephalonError } from '../src/errors.ts'
-import type { OPERATION_BUDGETS } from '../src/operation-budgets.ts'
+import { EncephalonError, failBudget } from '../src/errors.ts'
+import { OPERATION_BUDGETS } from '../src/operation-budgets.ts'
 
 type BudgetName = keyof typeof OPERATION_BUDGETS
 
@@ -21,6 +21,22 @@ const assertBudget = (operation: () => unknown, expected: { budget: BudgetName; 
 }
 
 describe('API input budgets', () => {
+  test('derives bounded error details from a typed budget key', () => {
+    assertBudget(() => failBudget('gatherShows', 'gather is over budget.'), {
+      budget: 'gatherShows',
+      field: 'shows',
+      maximum: 64,
+    })
+  })
+
+  test('freezes the budget authority and every nested specification at runtime', () => {
+    assert.equal(Object.isFrozen(OPERATION_BUDGETS), true)
+    assert.equal(
+      Object.values(OPERATION_BUDGETS).every(budget => Object.isFrozen(budget)),
+      true,
+    )
+  })
+
   test('applies operation-specific result limits', () => {
     const limitCases = [
       {
@@ -73,6 +89,14 @@ describe('API input budgets', () => {
     })
     assertBudget(
       () => parseGatherInput({ shows: ['not a valid id!', ...Array.from({ length: 64 }, () => 'valid-id')] }),
+      { budget: 'gatherShows', field: 'shows', maximum: 64 },
+    )
+    assertBudget(
+      () =>
+        parseGatherInput({
+          searches: [42],
+          shows: Array.from({ length: 65 }, () => 'valid-id'),
+        }),
       { budget: 'gatherShows', field: 'shows', maximum: 64 },
     )
   })

--- a/test/api-input.test.ts
+++ b/test/api-input.test.ts
@@ -55,6 +55,7 @@ describe('API input budgets', () => {
     }>
 
     for (const limitCase of limitCases) {
+      assert.equal(limitCase.parse(1).limit, 1)
       assert.equal(limitCase.parse(limitCase.accept).limit, limitCase.accept)
       assertBudget(() => limitCase.parse(limitCase.maximum + 1), {
         budget: limitCase.budget,

--- a/test/api-input.test.ts
+++ b/test/api-input.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import {
+  parseCompactSearchRecordsInput,
+  parseFullSearchRecordsInput,
+  parseGatherInput,
+  parseListRecordsInput,
+} from '../src/api-input.ts'
+import { EncephalonError } from '../src/errors.ts'
+import type { OPERATION_BUDGETS } from '../src/operation-budgets.ts'
+
+type BudgetName = keyof typeof OPERATION_BUDGETS
+
+const assertBudget = (operation: () => unknown, expected: { budget: BudgetName; field: string; maximum: number }) => {
+  assert.throws(operation, (error: unknown) => {
+    assert.ok(error instanceof EncephalonError)
+    assert.equal(error.code, 'INVALID_ARGUMENT')
+    assert.deepEqual(error.details, expected)
+    return true
+  })
+}
+
+describe('API input budgets', () => {
+  test('applies operation-specific result limits', () => {
+    const limitCases = [
+      {
+        accept: 50,
+        budget: 'fullResultLimit',
+        maximum: 50,
+        parse: (limit: number) => parseListRecordsInput({ limit }),
+      },
+      {
+        accept: 50,
+        budget: 'fullResultLimit',
+        maximum: 50,
+        parse: (limit: number) => parseFullSearchRecordsInput({ limit, query: 'x' }),
+      },
+      {
+        accept: 100,
+        budget: 'compactResultLimit',
+        maximum: 100,
+        parse: (limit: number) => parseCompactSearchRecordsInput({ limit, query: 'x' }),
+      },
+      {
+        accept: 100,
+        budget: 'compactResultLimit',
+        maximum: 100,
+        parse: (limit: number) => parseGatherInput({ limit }),
+      },
+    ] as const satisfies ReadonlyArray<{
+      accept: number
+      budget: BudgetName
+      maximum: number
+      parse: (limit: number) => { limit?: number }
+    }>
+
+    for (const limitCase of limitCases) {
+      assert.equal(limitCase.parse(limitCase.accept).limit, limitCase.accept)
+      assertBudget(() => limitCase.parse(limitCase.maximum + 1), {
+        budget: limitCase.budget,
+        field: 'limit',
+        maximum: limitCase.maximum,
+      })
+    }
+  })
+
+  test('rejects oversized gather arrays before validating their items', () => {
+    assertBudget(() => parseGatherInput({ searches: [42, ...Array.from({ length: 16 }, () => 'x')] }), {
+      budget: 'gatherSearches',
+      field: 'searches',
+      maximum: 16,
+    })
+    assertBudget(
+      () => parseGatherInput({ shows: ['not a valid id!', ...Array.from({ length: 64 }, () => 'valid-id')] }),
+      { budget: 'gatherShows', field: 'shows', maximum: 64 },
+    )
+  })
+})

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1881,6 +1881,27 @@ describe('SQLite cache and reads', () => {
       maximum: 4 * 1024 * 1024,
     })
 
+    const gatherRecords = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>>('gatherRecords')
+    assertBudgetError(
+      () =>
+        gatherRecords({
+          root,
+          shows: Array.from({ length: 5 }, () => 'large-response-0'),
+        }),
+      {
+        budget: 'fullResponseBytes',
+        field: 'response',
+        maximum: 4 * 1024 * 1024,
+      },
+    )
+    const gathered = gatherRecords({ limit: 5, root, searches: ['response budget marker'] }) as {
+      searches: Array<{ results: unknown[] }>
+    }
+    assert.deepEqual(
+      gathered.searches.map(search => search.results.length),
+      [5],
+    )
+
     const searchCompactRecords =
       functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>[]>('searchCompactRecords')
     assert.equal(searchCompactRecords({ limit: 5, query: 'response budget marker', root }).length, 5)

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -85,10 +85,10 @@ afterEach(() => {
 
 const functionFromApi = <T>(name: string) => (api as unknown as Record<string, T>)[name] as T
 
-const assertBudgetError = (operation: () => unknown, budget: string) => {
+const assertBudgetError = (operation: () => unknown, expected: { budget: string; field: string; maximum: number }) => {
   assert.throws(operation, (error: unknown) => {
     assert.equal((error as { code?: unknown }).code, 'INVALID_ARGUMENT')
-    assert.equal((error as { details?: { budget?: unknown } }).details?.budget, budget)
+    assert.deepEqual((error as { details?: unknown }).details, expected)
     return true
   })
 }
@@ -1782,50 +1782,60 @@ describe('SQLite cache and reads', () => {
       Array.from({ length: 64 }, () => 'missing'),
     )
 
-    const invalidCases: Array<{ budget: string; run: (root: string) => void }> = [
-      { budget: 'fullResultLimit', run: root => listRecords({ limit: 51, root }) },
-      { budget: 'fullResultLimit', run: root => searchRecords({ limit: 51, query: 'x', root }) },
+    const invalidCases: Array<{
+      expected: { budget: string; field: string; maximum: number }
+      run: (root: string) => void
+    }> = [
       {
-        budget: 'compactResultLimit',
+        expected: { budget: 'fullResultLimit', field: 'limit', maximum: 50 },
+        run: root => listRecords({ limit: 51, root }),
+      },
+      {
+        expected: { budget: 'fullResultLimit', field: 'limit', maximum: 50 },
+        run: root => searchRecords({ limit: 51, query: 'x', root }),
+      },
+      {
+        expected: { budget: 'compactResultLimit', field: 'limit', maximum: 100 },
         run: root => searchCompactRecords({ limit: 101, query: 'x', root }),
       },
       {
-        budget: 'queryBytes',
+        expected: { budget: 'queryBytes', field: 'query', maximum: 1024 },
         run: root => searchRecords({ query: `${'x'.repeat(1024)}y`, root }),
       },
       {
-        budget: 'queryBytes',
+        expected: { budget: 'queryBytes', field: 'query', maximum: 1024 },
         run: root => searchCompactRecords({ query: `${'x'.repeat(1024)}y`, root }),
       },
       {
-        budget: 'queryTerms',
+        expected: { budget: 'queryTerms', field: 'query', maximum: 32 },
         run: root => searchRecords({ query: Array.from({ length: 33 }, () => 'x').join(' '), root }),
       },
       {
-        budget: 'queryTerms',
+        expected: { budget: 'queryTerms', field: 'query', maximum: 32 },
         run: root => searchCompactRecords({ query: Array.from({ length: 33 }, () => 'x').join(' '), root }),
       },
       {
-        budget: 'gatherSearches',
-        run: root => gatherRecords({ root, searches: Array.from({ length: 17 }, () => 'x') }),
+        expected: { budget: 'gatherSearches', field: 'searches', maximum: 16 },
+        run: root => gatherRecords({ root, searches: [42, ...Array.from({ length: 16 }, () => 'x')] }),
       },
       {
-        budget: 'gatherShows',
-        run: root => gatherRecords({ root, shows: Array.from({ length: 65 }, () => 'missing') }),
+        expected: { budget: 'gatherShows', field: 'shows', maximum: 64 },
+        run: root =>
+          gatherRecords({ root, shows: ['not a valid record id', ...Array.from({ length: 64 }, () => 'missing')] }),
       },
       {
-        budget: 'compactResultLimit',
+        expected: { budget: 'compactResultLimit', field: 'limit', maximum: 100 },
         run: root => gatherRecords({ limit: 101, root, searches: ['x'] }),
       },
       {
-        budget: 'queryTerms',
+        expected: { budget: 'queryTerms', field: 'query', maximum: 32 },
         run: root => gatherRecords({ root, searches: [Array.from({ length: 33 }, () => 'x').join(' ')] }),
       },
     ]
 
     for (const invalidCase of invalidCases) {
       const root = createRoot()
-      assertBudgetError(() => invalidCase.run(root), invalidCase.budget)
+      assertBudgetError(() => invalidCase.run(root), invalidCase.expected)
       assert.equal(existsSync(cacheDirectoryPath(root)), false)
     }
   })
@@ -1847,7 +1857,11 @@ describe('SQLite cache and reads', () => {
 
     const searchRecords =
       functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>[]>('searchRecords')
-    assertBudgetError(() => searchRecords({ limit: 5, query: 'response budget marker', root }), 'fullResponseBytes')
+    assertBudgetError(() => searchRecords({ limit: 5, query: 'response budget marker', root }), {
+      budget: 'fullResponseBytes',
+      field: 'response',
+      maximum: 4 * 1024 * 1024,
+    })
 
     const searchCompactRecords =
       functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>[]>('searchCompactRecords')

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -37,6 +37,7 @@ import * as api from '../src/index.ts'
 import { withOperationLock } from '../src/lock.ts'
 import { ordinalStringCompare } from '../src/order.ts'
 import { recordWriteTestHooks } from '../src/records.ts'
+import { repositoryTestHooks } from '../src/repository.ts'
 import {
   canRenameParentWithOpenChild,
   createTestRepository,
@@ -80,6 +81,7 @@ afterEach(() => {
   cacheReadTestHooks.beforeManifestEntryLstat = undefined
   cacheReadTestHooks.duringDatabaseInitialisation = undefined
   recordWriteTestHooks.fault = undefined
+  repositoryTestHooks.afterGitMarkerDecision = undefined
   roots.splice(0).forEach(removeTestRepository)
 })
 
@@ -1824,6 +1826,10 @@ describe('SQLite cache and reads', () => {
           gatherRecords({ root, shows: ['not a valid record id', ...Array.from({ length: 64 }, () => 'missing')] }),
       },
       {
+        expected: { budget: 'gatherShows', field: 'shows', maximum: 64 },
+        run: root => gatherRecords({ root, searches: [42], shows: Array.from({ length: 65 }, () => 'missing') }),
+      },
+      {
         expected: { budget: 'compactResultLimit', field: 'limit', maximum: 100 },
         run: root => gatherRecords({ limit: 101, root, searches: ['x'] }),
       },
@@ -1835,7 +1841,19 @@ describe('SQLite cache and reads', () => {
 
     for (const invalidCase of invalidCases) {
       const root = createRoot()
+      let repositoryInspections = 0
+      let cacheLocationInspections = 0
+      repositoryTestHooks.afterGitMarkerDecision = () => {
+        repositoryInspections += 1
+        throw new Error('repository inspection must not run for rejected budget input')
+      }
+      cacheLocationTestHooks.beforeLocationInspection = () => {
+        cacheLocationInspections += 1
+        throw new Error('cache inspection must not run for rejected budget input')
+      }
       assertBudgetError(() => invalidCase.run(root), invalidCase.expected)
+      assert.equal(repositoryInspections, 0)
+      assert.equal(cacheLocationInspections, 0)
       assert.equal(existsSync(cacheDirectoryPath(root)), false)
     }
   })

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -317,6 +317,7 @@ describe('command-line interface', () => {
         field: 'limit',
         maximum: entry.maximum,
       })
+      assert.equal(errorJson(rejected).error.message, `--limit must be an integer between 1 and ${entry.maximum}.`)
     }
   })
 
@@ -364,6 +365,38 @@ describe('command-line interface', () => {
     })
     assert.equal(added.stderr.includes('private-invalid-json'), false)
     assert.equal(added.stderr.includes('private-supersedes'), false)
+
+    const rawCountCases = [
+      {
+        arguments: ['gather', ...Array.from({ length: 17 }, () => '--search=')],
+        details: { budget: 'gatherSearches', field: 'searches', maximum: 16 },
+        message: 'gather may contain at most 16 searches.',
+      },
+      {
+        arguments: ['gather', ...Array.from({ length: 65 }, () => '--show=')],
+        details: { budget: 'gatherShows', field: 'shows', maximum: 64 },
+        message: 'gather may contain at most 64 shows.',
+      },
+      {
+        arguments: [
+          'add',
+          '--kind=decision',
+          '--subject=cli.budget',
+          '--source=agent',
+          '--data={}',
+          ...Array.from({ length: 1001 }, () => '--supersedes='),
+        ],
+        details: { budget: 'supersessionEdges', field: 'supersedes', maximum: 1000 },
+        message: '--supersedes may be supplied at most 1000 times.',
+      },
+    ] as const
+
+    for (const rawCountCase of rawCountCases) {
+      const result = run(root, [...rawCountCase.arguments, '--root', root])
+      assert.equal(result.status, 2)
+      assert.deepEqual(errorJson(result).error.details, rawCountCase.details)
+      assert.equal(errorJson(result).error.message, rawCountCase.message)
+    }
   })
 
   test('parses terminators, hyphen-leading queries, and repeated options predictably', () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -339,7 +339,7 @@ describe('command-line interface', () => {
 
     const supersedesArguments = Array.from({ length: 1001 }, (_, index) => [
       '--supersedes',
-      `private-supersedes-${index}`,
+      index === 0 ? 'private-supersedes' : 'x',
     ]).flat()
     const added = run(root, [
       'add',

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -28,7 +28,10 @@ const run = (root: string, arguments_: string[]) =>
   })
 
 const outputJson = (result: ReturnType<typeof run>) => JSON.parse(result.stdout) as unknown
-const errorJson = (result: ReturnType<typeof run>) => JSON.parse(result.stderr) as { error: { message: string } }
+const errorJson = (result: ReturnType<typeof run>) =>
+  JSON.parse(result.stderr) as {
+    error: { code: string; details: Record<string, unknown>; message: string }
+  }
 const baselineSubjects = [
   ['context', 'encephalon:init/repository-overview'],
   ['architecture', 'encephalon:init/tooling-layout'],
@@ -249,6 +252,21 @@ describe('command-line interface', () => {
     const help = run(root, ['--help'])
     assert.equal(help.status, 0)
     assert.match(help.stdout, /^Usage: encephalon/m)
+    assert.ok(
+      help.stdout.includes('list [--kind <kind>] [--subject <subject>] [--include-superseded] [--limit <1..50>]'),
+    )
+    assert.ok(help.stdout.includes('search [--kind <kind>] [--include-superseded] [--limit <1..50>] [--] <query>'))
+    assert.ok(
+      help.stdout.includes('search --compact [--kind <kind>] [--include-superseded] [--limit <1..100>] [--] <query>'),
+    )
+    assert.ok(
+      help.stdout.includes(
+        'gather [--search <query> ...] [--show <id> ...] [--hydrate] [--include-superseded]\n' +
+          '         [--kind <kind>] [--limit <1..100>]',
+      ),
+    )
+    assert.ok(help.stdout.includes('Accepts at most 16 searches and 64 shows.'))
+    assert.ok(help.stdout.includes('Accepts at most 1,000 supersession targets.'))
     assert.match(help.stdout, /only remaining argv token/)
     assert.match(help.stdout, /must use --name=value/)
     const version = run(root, ['--version'])
@@ -257,6 +275,95 @@ describe('command-line interface', () => {
     const commandHelp = run(root, ['list', '--help'])
     assert.equal(commandHelp.status, 2)
     assert.equal(errorJson(commandHelp).error.message, 'Unknown option --help.')
+  })
+
+  test('enforces operation-specific limit budgets before API invocation', () => {
+    const root = createRoot()
+    const cases = [
+      {
+        accepted: ['list', '--limit=50'],
+        budget: 'fullResultLimit',
+        maximum: 50,
+        rejected: ['list', '--limit=51'],
+      },
+      {
+        accepted: ['search', '--limit=50', 'x'],
+        budget: 'fullResultLimit',
+        maximum: 50,
+        rejected: ['search', '--limit=51', 'x'],
+      },
+      {
+        accepted: ['search', '--compact', '--limit=100', 'x'],
+        budget: 'compactResultLimit',
+        maximum: 100,
+        rejected: ['search', '--compact', '--limit=101', 'x'],
+      },
+      {
+        accepted: ['gather', '--limit=100'],
+        budget: 'compactResultLimit',
+        maximum: 100,
+        rejected: ['gather', '--limit=101'],
+      },
+    ] as const
+
+    for (const entry of cases) {
+      const accepted = run(root, [...entry.accepted, '--root', root])
+      assert.equal(accepted.status, 0, entry.accepted.join(' '))
+
+      const rejected = run(root, [...entry.rejected, '--root', root])
+      assert.equal(rejected.status, 2, entry.rejected.join(' '))
+      assert.deepEqual(errorJson(rejected).error.details, {
+        budget: entry.budget,
+        field: 'limit',
+        maximum: entry.maximum,
+      })
+    }
+  })
+
+  test('enforces repeated-option count budgets before parsing their contents', () => {
+    const root = createRoot()
+    const oversizedQuery = Array.from({ length: 33 }, (_, index) => `private-query-${index}`).join(' ')
+    const gatherArguments = Array.from({ length: 17 }, (_, index) => [
+      '--search',
+      index === 0 ? oversizedQuery : `query-${index}`,
+    ]).flat()
+    const gathered = run(root, ['gather', '--root', root, ...gatherArguments])
+
+    assert.equal(gathered.status, 2)
+    assert.deepEqual(errorJson(gathered).error.details, {
+      budget: 'gatherSearches',
+      field: 'searches',
+      maximum: 16,
+    })
+    assert.equal(gathered.stderr.includes('private-query'), false)
+
+    const supersedesArguments = Array.from({ length: 1001 }, (_, index) => [
+      '--supersedes',
+      `private-supersedes-${index}`,
+    ]).flat()
+    const added = run(root, [
+      'add',
+      '--root',
+      root,
+      '--kind',
+      'decision',
+      '--subject',
+      'cli.budget',
+      '--source',
+      'agent',
+      '--data',
+      '{private-invalid-json',
+      ...supersedesArguments,
+    ])
+
+    assert.equal(added.status, 2)
+    assert.deepEqual(errorJson(added).error.details, {
+      budget: 'supersessionEdges',
+      field: 'supersedes',
+      maximum: 1000,
+    })
+    assert.equal(added.stderr.includes('private-invalid-json'), false)
+    assert.equal(added.stderr.includes('private-supersedes'), false)
   })
 
   test('parses terminators, hyphen-leading queries, and repeated options predictably', () => {
@@ -441,7 +548,7 @@ describe('command-line interface', () => {
       },
       {
         arguments_: ['list', '--root', root, '--limit=-1'],
-        message: '--limit must be an integer between 1 and 1000.',
+        message: '--limit must be an integer between 1 and 50.',
       },
       {
         arguments_: ['list', '--root', root, '--limit', '-1'],

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -47,11 +47,16 @@ describe('package contract', () => {
   test('marks the old implementation plan historical and maintains a concise contract', () => {
     const implementationPlan = readFileSync(resolve(root, 'docs', 'implementation-plan.md'), 'utf8')
     const contract = readFileSync(resolve(root, 'docs', 'contract.md'), 'utf8')
+    const operationBudgetsDesign = readFileSync(
+      resolve(root, 'docs', 'superpowers', 'specs', '2026-08-13-operation-budgets-design.md'),
+      'utf8',
+    )
 
     assert.match(implementationPlan, /Status: historical design input; not the maintained normative contract/)
     assert.match(implementationPlan, /\[`docs\/contract\.md`]\(\.\/contract\.md\)/)
     assert.doesNotMatch(implementationPlan, /createdAt is assigned only after the repository operation lock is held/)
     assert.match(contract, /## Public API and CLI/)
+    assert.match(contract, /## Operation Budgets/)
     assert.match(contract, /## Canonical Storage/)
     assert.match(contract, /## Partial Initialisation Progress/)
     assert.match(contract, /## Cache Compatibility/)
@@ -70,6 +75,10 @@ describe('package contract', () => {
       /MAR-2563 operation-locked record timestamp assignment, locked canonical authority, and cross-process ordering: `2874874096bb7d327e084d7e17d5243564244c43`\./,
     )
     assert.match(contract, /Historical plan's wall-clock-only `createdAt` policy/)
+    assert.match(
+      operationBudgetsDesign,
+      /The exact reviewed code and behavioural-test snapshot implementing this design is `6dc60e13e8e99b05fef566d4b80aeb663328664c`\./,
+    )
     assert.match(
       readFileSync(resolve(root, 'CHANGELOG.md'), 'utf8'),
       /creation timestamps under the repository operation lock/,

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -64,7 +64,7 @@ describe('package contract', () => {
     assert.match(contract, /## Historical Plan Divergence Checklist/)
     assert.match(
       contract,
-      /Last reviewed: 2026-08-13 for code and behavioural-test snapshot `011360c808a61a94a98683cbecf059da46a18471`\./,
+      /Last reviewed: 2026-08-13 for code and behavioural-test snapshot `1e913807c20a332dc49a004be672205fbeabfe15`\./,
     )
     assert.match(
       contract,
@@ -77,7 +77,7 @@ describe('package contract', () => {
     assert.match(contract, /Historical plan's wall-clock-only `createdAt` policy/)
     assert.match(
       operationBudgetsDesign,
-      /The exact reviewed code and behavioural-test snapshot implementing this design is `011360c808a61a94a98683cbecf059da46a18471`\./,
+      /The exact reviewed code and behavioural-test snapshot implementing this design is `1e913807c20a332dc49a004be672205fbeabfe15`\./,
     )
     assert.match(
       readFileSync(resolve(root, 'CHANGELOG.md'), 'utf8'),

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -84,6 +84,11 @@ describe('package contract', () => {
       /creation timestamps under the repository operation lock/,
     )
     assert.doesNotMatch(readFileSync(resolve(root, 'dist', 'api-input.d.ts'), 'utf8'), /ValidatedAddRecordInput/)
+    assert.doesNotMatch(readFileSync(resolve(root, 'dist', 'errors.d.ts'), 'utf8'), /failBudget|operation-budgets/)
+    assert.doesNotMatch(
+      readFileSync(resolve(root, 'dist', 'operation-budgets.d.ts'), 'utf8'),
+      /OPERATION_BUDGETS|OperationBudgetKey/,
+    )
   })
 
   test('keeps installed command guidance aligned with root-install verification', () => {

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -64,7 +64,7 @@ describe('package contract', () => {
     assert.match(contract, /## Historical Plan Divergence Checklist/)
     assert.match(
       contract,
-      /Last reviewed: 2026-08-13 for code and behavioural-test snapshot `6dc60e13e8e99b05fef566d4b80aeb663328664c`\./,
+      /Last reviewed: 2026-08-13 for code and behavioural-test snapshot `011360c808a61a94a98683cbecf059da46a18471`\./,
     )
     assert.match(
       contract,
@@ -77,7 +77,7 @@ describe('package contract', () => {
     assert.match(contract, /Historical plan's wall-clock-only `createdAt` policy/)
     assert.match(
       operationBudgetsDesign,
-      /The exact reviewed code and behavioural-test snapshot implementing this design is `6dc60e13e8e99b05fef566d4b80aeb663328664c`\./,
+      /The exact reviewed code and behavioural-test snapshot implementing this design is `011360c808a61a94a98683cbecf059da46a18471`\./,
     )
     assert.match(
       readFileSync(resolve(root, 'CHANGELOG.md'), 'utf8'),

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -64,7 +64,7 @@ describe('package contract', () => {
     assert.match(contract, /## Historical Plan Divergence Checklist/)
     assert.match(
       contract,
-      /Last reviewed: 2026-08-13 for code and behavioural-test snapshot `2874874096bb7d327e084d7e17d5243564244c43`\./,
+      /Last reviewed: 2026-08-13 for code and behavioural-test snapshot `6dc60e13e8e99b05fef566d4b80aeb663328664c`\./,
     )
     assert.match(
       contract,

--- a/test/records.test.ts
+++ b/test/records.test.ts
@@ -38,7 +38,7 @@ import {
   validateRecordsResolved,
 } from '../src/records.ts'
 import { discoverRepository, repositoryTestHooks } from '../src/repository.ts'
-import { validateKind } from '../src/schema.ts'
+import { parseRecordFile, validateAddRecordInput, validateKind } from '../src/schema.ts'
 import * as stagingInternals from '../src/staging.ts'
 import type { BrainRecord, ValidateResult } from '../src/types.ts'
 import {
@@ -2327,8 +2327,13 @@ describe('canonical records', () => {
 
     const edgeRoot = createRoot()
     writeCanonicalRecord(edgeRoot, {
-      id: 'too-many-edges',
-      supersedes: Array.from({ length: 1001 }, (_, index) => `missing-${index}`),
+      id: 'edge-budget-at-maximum',
+      supersedes: Array.from({ length: 1000 }, (_, index) => `missing-${index}`),
+    })
+    writeCanonicalRecord(edgeRoot, {
+      createdAt: timestampAt(1),
+      id: 'edge-budget-overflow',
+      supersedes: ['one-more-missing-edge'],
     })
     const edgeResult = api.validateRecords({ root: edgeRoot })
     assert.equal(edgeResult.valid, false)
@@ -2658,6 +2663,52 @@ describe('canonical records', () => {
     assert.equal(created, true)
     assert.deepEqual(readdirSync(join(root, 'encephalon', 'new-kind')), [])
     assert.equal(existsSync(join(root, 'encephalon', '_staging')), false)
+  })
+
+  test('enforces supersedes count before item validation and repository access', () => {
+    const validSupersedes = Array.from({ length: 1000 }, (_, index) => `superseded-${index}`)
+    const candidate = {
+      id: 'supersedes-boundary-candidate',
+      kind: 'decision',
+      payload: {},
+      source: 'test',
+      subject: 'validation.supersedes-boundary',
+      supersedes: validSupersedes,
+    }
+    assert.equal(validateAddRecordInput(candidate).supersedes?.length, 1000)
+    assert.equal(parseRecordFile({ ...candidate, createdAt: timestampAt(0) }).supersedes?.length, 1000)
+
+    const root = createRoot()
+    const oversizedSupersedes = ['not a valid supersedes id', ...validSupersedes]
+    let repositoryHookCalls = 0
+    repositoryTestHooks.afterGitMarkerDecision = () => {
+      repositoryHookCalls += 1
+    }
+    const assertSupersedesBudget = (operation: () => unknown) => {
+      assert.throws(operation, (error: unknown) => {
+        const actual = error as { code?: unknown; details?: unknown; message?: unknown }
+        assert.equal(actual.code, 'INVALID_ARGUMENT')
+        assert.deepEqual(actual.details, {
+          budget: 'supersessionEdges',
+          field: 'supersedes',
+          maximum: 1000,
+        })
+        const exposed = JSON.stringify({ details: actual.details, message: actual.message })
+        assert.equal(
+          oversizedSupersedes.some(entry => exposed.includes(entry)),
+          false,
+        )
+        return true
+      })
+    }
+
+    assertSupersedesBudget(() =>
+      parseRecordFile({ ...candidate, createdAt: timestampAt(0), supersedes: oversizedSupersedes }),
+    )
+    assertSupersedesBudget(() => api.addRecord({ ...candidate, root, supersedes: oversizedSupersedes }))
+    assert.equal(repositoryHookCalls, 0)
+    assert.equal(existsSync(join(root, 'encephalon')), false)
+    assert.equal(existsSync(join(root, 'node_modules', '.cache', 'encephalon')), false)
   })
 
   test('rejects addRecord when the candidate would exceed corpus count or byte budgets', () => {

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -28,6 +28,7 @@ const createIsolatedPackage = () => {
     'directory-witness.ts',
     'errors.ts',
     'filesystem-entry.ts',
+    'operation-budgets.ts',
     'repository.ts',
     'sqlite-error.ts',
     'verified-file.ts',


### PR DESCRIPTION
## Summary

- centralise full, compact, gather, supersession, query, and response budgets in one dependency-free internal authority
- reject oversized limits and arrays before value parsing, repository discovery, cache inspection, or SQLite work
- keep matching cache checks as defence in depth while aligning the CLI, packed package, and maintained documentation

## Changes

- add an immutable `operation-budgets.ts` authority for 50 full results, 100 compact/gather results, 16 gather searches, 64 gather shows, 1,000 supersession targets, and the existing query/response limits
- derive bounded `{ field, budget, maximum }` errors from typed budget keys so callers cannot construct contradictory details
- preflight both gather arrays and raw repeated CLI options before parsing individual values, and preflight supersession counts before mapping IDs
- preserve the existing 4 MiB aggregate full-record response budget, including one shared counter across all records shown by a gather request
- remove unused cache budget exports and update copied-source/package fixtures for the new internal dependency
- document the exact public limits, failure ordering, privacy guarantees, and reviewed implementation provenance

## Compatibility

- public TypeScript input and result shapes are unchanged
- defaults remain unchanged
- compact gather search results do not consume the full-record response budget
- invalid over-limit requests now fail earlier and deterministically with `INVALID_ARGUMENT`

## Validation

- 451 tests passed with 2 established filesystem-capability skips and 0 failures
- lint passed across 102 files
- all four TypeScript projects passed
- baseline and CI-budget benchmarks passed
- build, packed-package, publish-contract, and frozen-install gates passed
- Ubuntu (current and latest), macOS, and Windows CI passed on the preceding implementation head; the final test/provenance-only head is being revalidated by CI

## Review

- completed three specialist/bot review waves plus a final separation-of-concerns and tidy audit
- addressed all accepted findings from waves one and two
- the final aggregate-gather concern was verified as already correctly implemented; an exact counter-reset mutation made the new regression fail, and restoring production made it pass
- no unresolved high- or medium-confidence concerns remain
