### PR TITLE
[MAR-2568] Replace source-regex performance guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Encephalon are documented here.
 - Verified each bounded cached FTS row against the exact UTF-8 search projection derived from its cached record before serving reads or mutating an existing cache.
 - Preserved Unicode letter and number terms in literal FTS queries with shared NFC normalization for queries and derived cache search documents.
 - Made compact search avoid materialising full record JSON and removed persistent-style copying from hot scans.
+- Replaced source-regex hot-scan guards with behavioural work bounds while keeping latency and memory enforcement in the benchmark budget.
 - Centralised the package version and separated cache schema compatibility from diagnostic package metadata.
 - Improved validation of record graphs, kind directories, artifact paths, Windows filename portability, and locale-independent ordering.
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ bun run benchmark -- --profile full --output docs/performance-baseline.json
 bun run benchmark:check
 ```
 
+Correctness tests enforce deterministic bounded-work counts without reading production source. `benchmark:check` independently owns timing, memory, and cache-size ceilings.
+
 The full profile runs every operation in fresh child processes with two discarded warmups and five measured samples at 0, 100, and 1,000 records. `benchmark:check` keeps CI to a single 0/100 sample with generous schema-version 2 p95 and cache-size ceilings. See [docs/performance.md](./docs/performance.md) for phase semantics, memory sources, profiles, budgets, baseline distributions, and scale guidance.
 
 `check:package` inspects the npm tarball, installs it with lifecycle scripts disabled, imports the public API, and runs the bundled CLI using Node. `check:publish` exercises npm's publish-time manifest normalisation without uploading anything. CI runs four verification lanes: Node 24.15.0 on Ubuntu, macOS, and Windows, plus Node 26 on Ubuntu. Only trusted pushes to `main` run the separate release-equivalent package gate, which validates the publish dry run before uploading the generated `npm pack` tarball for inspection.

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -144,7 +144,7 @@ This document is the concise contract maintainers should update when public beha
 
 The exact code and behavioural-test snapshot implementing these guarantees is `eae98315e53ce568c62f6854a8542b285b7f9e4f`.
 
-MAR-2568 behavioural hot-scan work bounds: `589c8d9a4db6e612e22b5a86cc456da6b18d65f4`.
+MAR-2568 behavioural hot-scan work bounds: `dbe77b5742d9891ee1d6de1bd0676ae166a076d7`.
 
 ## Package and Release Gates
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -142,7 +142,7 @@ This document is the concise contract maintainers should update when public beha
 - Zero-record stale preparation is unavailable and represented as `null`. Stale samples use a valid different-length canonical record variant so rapid runs cannot mistake unchanged timestamp/size metadata for a changed corpus.
 - Report output is written at mode `0600` inside a private `0700` staging directory beside the destination. The retained descriptor, rather than the replaceable destination pathname, applies an existing regular report's permission mode or the normal process-umask mode for a new report before close and atomic rename. Rename is the publication commit; later best-effort removal of the now-empty private staging directory cannot turn a successful publication into a reported failure. On platforms that deliver handled `SIGINT` and `SIGTERM`, signals cancel the active child, await closure, clean temporary repositories, and return a non-zero status without publishing a report. Windows force-terminates Node children for `SIGTERM`, so that CLI signal-cleanup guarantee does not apply there; platform-neutral `AbortController` cancellation cleanup remains covered everywhere.
 
-The exact code and behavioural-test snapshot implementing these guarantees is `eae98315e53ce568c62f6854a8542b285b7f9e4f`.
+The exact code and behavioural-test snapshot implementing the MAR-2566 benchmark guarantees above is `eae98315e53ce568c62f6854a8542b285b7f9e4f`.
 
 MAR-2568 behavioural hot-scan work bounds: `7304c07b0fd1554470a25307ff028c03b3653274`.
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-18 for code and behavioural-test snapshot `dbe77b5742d9891ee1d6de1bd0676ae166a076d7`.
+Last reviewed: 2026-08-23 for code and behavioural-test snapshot `eae98315e53ce568c62f6854a8542b285b7f9e4f`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 
@@ -144,7 +144,7 @@ This document is the concise contract maintainers should update when public beha
 
 The exact code and behavioural-test snapshot implementing these guarantees is `eae98315e53ce568c62f6854a8542b285b7f9e4f`.
 
-MAR-2568 behavioural hot-scan work bounds: `dbe77b5742d9891ee1d6de1bd0676ae166a076d7`.
+MAR-2568 behavioural hot-scan work bounds: `7304c07b0fd1554470a25307ff028c03b3653274`.
 
 ## Package and Release Gates
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -144,7 +144,7 @@ This document is the concise contract maintainers should update when public beha
 
 The exact code and behavioural-test snapshot implementing these guarantees is `eae98315e53ce568c62f6854a8542b285b7f9e4f`.
 
-MAR-2568 behavioural hot-scan work bounds: `d8d9ea8f6c7833e0c737c16880abe510f2793529`.
+MAR-2568 behavioural hot-scan work bounds: `589c8d9a4db6e612e22b5a86cc456da6b18d65f4`.
 
 ## Package and Release Gates
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -133,6 +133,7 @@ This document is the concise contract maintainers should update when public beha
 
 ## Performance Evidence
 
+- Correctness performance guards use per-invocation internal observers to assert deterministic canonical scans, supersession-edge visits, active-group and issue insertion, bounded directory consumption, and baseline accumulator writes. They do not read production source text or set latency, memory, or cache-size thresholds; `benchmark:check` owns those measured ceilings.
 - Benchmark report and budget files use schema version 2. Old versions, unknown fields, malformed finite limits, budget cases without at least one cache or operation limit, zero-record amplification limits, duplicate corpus cases, and missing requested corpus cases fail before benchmark repository creation.
 - `ci` measures 0 and 100 records with no warmup and one measured sample; default `baseline` uses one warmup and three measured samples for 0 and 100; `full` uses two warmups and five measured samples for 0, 100, and 1,000. Explicit record counts label the report `custom`.
 - Every warmup and measured operation runs in a fresh Node child against a parent-restored repository state. Because copying changes canonical filesystem metadata, the parent re-prepares every restored non-cold sample outside the measured child and applies the stale mutation only after that preparation. The parent accepts exactly one nonce-bound IPC result followed by a clean close, kills and awaits timed-out or cancelled children, and attempts every owned sample and template repository cleanup on success, cancellation, or setup/worker failure while retaining the primary or first cleanup failure.
@@ -142,6 +143,8 @@ This document is the concise contract maintainers should update when public beha
 - Report output is written at mode `0600` inside a private `0700` staging directory beside the destination. The retained descriptor, rather than the replaceable destination pathname, applies an existing regular report's permission mode or the normal process-umask mode for a new report before close and atomic rename. Rename is the publication commit; later best-effort removal of the now-empty private staging directory cannot turn a successful publication into a reported failure. On platforms that deliver handled `SIGINT` and `SIGTERM`, signals cancel the active child, await closure, clean temporary repositories, and return a non-zero status without publishing a report. Windows force-terminates Node children for `SIGTERM`, so that CLI signal-cleanup guarantee does not apply there; platform-neutral `AbortController` cancellation cleanup remains covered everywhere.
 
 The exact code and behavioural-test snapshot implementing these guarantees is `eae98315e53ce568c62f6854a8542b285b7f9e4f`.
+
+MAR-2568 behavioural hot-scan work bounds: `d8d9ea8f6c7833e0c737c16880abe510f2793529`.
 
 ## Package and Release Gates
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,7 +1,7 @@
 # Encephalon Maintained Contract
 
 Status: maintained for the current v0.x implementation.
-Last reviewed: 2026-08-23 for code and behavioural-test snapshot `eae98315e53ce568c62f6854a8542b285b7f9e4f`.
+Last reviewed: 2026-08-18 for code and behavioural-test snapshot `dbe77b5742d9891ee1d6de1bd0676ae166a076d7`.
 
 This document is the concise contract maintainers should update when public behaviour or safety invariants intentionally change. The historical implementation plan remains design input and provenance context, not the normative source of truth.
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -144,7 +144,7 @@ This document is the concise contract maintainers should update when public beha
 
 The exact code and behavioural-test snapshot implementing the MAR-2566 benchmark guarantees above is `eae98315e53ce568c62f6854a8542b285b7f9e4f`.
 
-MAR-2568 behavioural hot-scan work bounds: `7304c07b0fd1554470a25307ff028c03b3653274`.
+MAR-2568 behavioural hot-scan work bounds: `d775559bad4189621f07d837c14082009fbe380c`.
 
 ## Package and Release Gates
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -144,7 +144,7 @@ This document is the concise contract maintainers should update when public beha
 
 The exact code and behavioural-test snapshot implementing the MAR-2566 benchmark guarantees above is `eae98315e53ce568c62f6854a8542b285b7f9e4f`.
 
-MAR-2568 behavioural hot-scan work bounds: `d775559bad4189621f07d837c14082009fbe380c`.
+MAR-2568 behavioural hot-scan work bounds: `de66f6ab7e10696fc878e380dd5417d194d60fe8`.
 
 ## Package and Release Gates
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -32,6 +32,8 @@ Every warmup and measured operation runs in a fresh Node child after the parent 
 
 Results are committed in [performance-baseline.json](./performance-baseline.json). CI ceilings live in [performance-budgets.json](./performance-budgets.json), select explicit p95 total-time or maximum cache statistics, and reject incompatible or incomplete budget schemas before creating a benchmark repository.
 
+Correctness tests enforce deterministic output and bounded work counts for canonical scans, supersession graphs, and baseline accumulation. They use per-invocation internal observers and never inspect production source spelling. Wall-clock latency, memory, and cache-size regressions remain the exclusive responsibility of `benchmark:check` and the stable full-profile evidence.
+
 ## Stable baseline
 
 The committed schema-version 2 baseline was measured on Node.js v26.5.0 on darwin arm64. Each timing is median / p95 across five measured fresh processes after two discarded warmups.

--- a/src/baseline.ts
+++ b/src/baseline.ts
@@ -206,6 +206,13 @@ const observedMap = <Key, Value>(onWrite?: () => void) => {
   return new Map<Key, Value>()
 }
 
+const observeWork = (hooks: BaselineScanHooks | undefined, operation: BaselineWork) => {
+  const onWork = hooks?.onWork
+  if (onWork !== undefined) {
+    return () => onWork(operation)
+  }
+}
+
 type BaselineReason =
   | 'directory-entry-limit'
   | 'directory-limit'
@@ -410,7 +417,7 @@ const readBoundedDirectoryEntries = (
 const scanLanguages = (root: string, hooks: BaselineScanHooks) => {
   const state: ScanState = {
     filesSeen: 0,
-    languageCounts: observedMap(() => hooks.onWork?.('language-count-write')),
+    languageCounts: observedMap(observeWork(hooks, 'language-count-write')),
     truncationReasons: new Set(),
   }
   const maximumDirectories = hooks.maximumScannedDirectories ?? MAX_SCANNED_DIRECTORIES
@@ -516,8 +523,8 @@ const workflowFiles = (root: string, hooks: BaselineScanHooks, expectedGithub: b
 }
 
 const emptyTopLevelFacts = (hooks?: BaselineScanHooks) => ({
-  directories: observedArray<string>(() => hooks?.onWork?.('top-level-fact-write')),
-  recognisedFiles: observedArray<string>(() => hooks?.onWork?.('top-level-fact-write')),
+  directories: observedArray<string>(observeWork(hooks, 'top-level-fact-write')),
+  recognisedFiles: observedArray<string>(observeWork(hooks, 'top-level-fact-write')),
 })
 
 const topLevelFacts = (root: string, hooks: BaselineScanHooks) => {

--- a/src/baseline.ts
+++ b/src/baseline.ts
@@ -15,6 +15,7 @@ import {
 import { ordinalStringCompare } from './order.ts'
 import type { AddRecordInput, JsonValue } from './types.ts'
 import { decodeVerifiedUtf8, readVerifiedRegularFile } from './verified-file.ts'
+import { observedArray, observedMap, observeWork, rethrowWorkObserverError } from './work-observer.ts'
 
 const MAX_SCANNED_FILES = 100_000
 const MAX_SCANNED_DIRECTORIES = 10_000
@@ -175,42 +176,6 @@ type BaselineScanHooks = {
   maximumScannedFiles?: number | undefined
   onLanguageDirectoryScheduled?: (() => void) | undefined
   onWork?: ((operation: BaselineWork) => void) | undefined
-}
-
-const isArrayIndex = (property: string | symbol) => typeof property === 'string' && /^(?:0|[1-9]\d*)$/.test(property)
-
-const observedArray = <Value>(onWrite?: () => void) => {
-  const values: Value[] = []
-  if (onWrite !== undefined) {
-    return new Proxy(values, {
-      set: (target, property, value, receiver) => {
-        if (isArrayIndex(property)) {
-          onWrite()
-        }
-        return Reflect.set(target, property, value, receiver)
-      },
-    })
-  }
-  return values
-}
-
-const observedMap = <Key, Value>(onWrite?: () => void) => {
-  if (onWrite !== undefined) {
-    return new (class extends Map<Key, Value> {
-      override set(key: Key, value: Value) {
-        onWrite()
-        return super.set(key, value)
-      }
-    })()
-  }
-  return new Map<Key, Value>()
-}
-
-const observeWork = (hooks: BaselineScanHooks | undefined, operation: BaselineWork) => {
-  const onWork = hooks?.onWork
-  if (onWork !== undefined) {
-    return () => onWork(operation)
-  }
 }
 
 type BaselineReason =
@@ -393,8 +358,11 @@ const readBoundedDirectoryEntries = (
   if (parent !== undefined) {
     revalidateCanonicalDirectory(parent)
   }
-  const snapshot = captureCanonicalDirectory(directory, MAX_LANGUAGE_DIRECTORY_ENTRIES, undefined, () =>
-    hooks.onWork?.('language-entry'),
+  const snapshot = captureCanonicalDirectory(
+    directory,
+    MAX_LANGUAGE_DIRECTORY_ENTRIES,
+    undefined,
+    observeWork(hooks.onWork, 'language-entry'),
   )
   hooks.afterLanguageDirectoryCapture?.(directory)
   if (parent !== undefined) {
@@ -417,7 +385,7 @@ const readBoundedDirectoryEntries = (
 const scanLanguages = (root: string, hooks: BaselineScanHooks) => {
   const state: ScanState = {
     filesSeen: 0,
-    languageCounts: observedMap(observeWork(hooks, 'language-count-write')),
+    languageCounts: observedMap(observeWork(hooks.onWork, 'language-count-write')),
     truncationReasons: new Set(),
   }
   const maximumDirectories = hooks.maximumScannedDirectories ?? MAX_SCANNED_DIRECTORIES
@@ -459,7 +427,8 @@ const scanLanguages = (root: string, hooks: BaselineScanHooks) => {
           }
         }
       }
-    } catch {
+    } catch (error) {
+      rethrowWorkObserverError(error)
       state.truncationReasons.add('unreadable-directory')
     }
   }
@@ -496,7 +465,7 @@ const workflowFiles = (root: string, hooks: BaselineScanHooks, expectedGithub: b
           workflowsWitness.canonicalPath,
           MAX_WORKFLOW_ENTRIES,
           undefined,
-          () => hooks.onWork?.('workflow-entry'),
+          observeWork(hooks.onWork, 'workflow-entry'),
         )
         hooks.afterWorkflowEnumeration?.()
         revalidateDirectoryWitness(workflowsWitness)
@@ -516,15 +485,16 @@ const workflowFiles = (root: string, hooks: BaselineScanHooks, expectedGithub: b
         }
       }
     }
-  } catch {
+  } catch (error) {
+    rethrowWorkObserverError(error)
     result = { reasons: ['workflow-enumeration-error'], value: [] }
   }
   return result
 }
 
 const emptyTopLevelFacts = (hooks?: BaselineScanHooks) => ({
-  directories: observedArray<string>(observeWork(hooks, 'top-level-fact-write')),
-  recognisedFiles: observedArray<string>(observeWork(hooks, 'top-level-fact-write')),
+  directories: observedArray<string>(undefined, observeWork(hooks?.onWork, 'top-level-fact-write')),
+  recognisedFiles: observedArray<string>(undefined, observeWork(hooks?.onWork, 'top-level-fact-write')),
 })
 
 const topLevelFacts = (root: string, hooks: BaselineScanHooks) => {
@@ -533,8 +503,11 @@ const topLevelFacts = (root: string, hooks: BaselineScanHooks) => {
     value: emptyTopLevelFacts(),
   }
   try {
-    const snapshot = captureCanonicalDirectory(root, MAX_TOP_LEVEL_ENTRIES, undefined, () =>
-      hooks.onWork?.('top-level-entry'),
+    const snapshot = captureCanonicalDirectory(
+      root,
+      MAX_TOP_LEVEL_ENTRIES,
+      undefined,
+      observeWork(hooks.onWork, 'top-level-entry'),
     )
     if (snapshot.overflow) {
       result = { reasons: ['top-level-entry-limit'], value: emptyTopLevelFacts() }
@@ -553,7 +526,8 @@ const topLevelFacts = (root: string, hooks: BaselineScanHooks) => {
       revalidateCanonicalDirectory(snapshot)
       result = { reasons: [], value: facts }
     }
-  } catch {
+  } catch (error) {
+    rethrowWorkObserverError(error)
     result = { reasons: ['unreadable-directory'], value: emptyTopLevelFacts() }
   }
   return result
@@ -689,13 +663,13 @@ export const scanBaselineWithHooks = (root: string, hooks: BaselineScanHooks): A
       kind: 'context',
       payload: {
         languageCounts: languages,
-        recognisedTopLevelFiles: layout.recognisedFiles,
+        recognisedTopLevelFiles: [...layout.recognisedFiles],
         scannedRegularFiles: scan.filesSeen,
         scanTruncated: truncationReasons.size > 0,
         scanTruncationReasons: [...truncationReasons].sort(ordinalStringCompare),
         sources: safeSources,
         summary: 'Derived repository overview captured during Encephalon initialisation.',
-        topLevelDirectories: layout.directories,
+        topLevelDirectories: [...layout.directories],
       },
       source: 'encephalon:init',
       subject: 'encephalon:init/repository-overview',
@@ -707,7 +681,7 @@ export const scanBaselineWithHooks = (root: string, hooks: BaselineScanHooks): A
         ...(packageFacts.name === undefined ? {} : { packageName: packageFacts.name }),
         ...(packageManager === undefined ? {} : { packageManager }),
         packageManagerEvidence: packageEvidence,
-        recognisedFiles: layout.recognisedFiles,
+        recognisedFiles: [...layout.recognisedFiles],
         sources: layoutSources,
         workspaceConfigured: packageFacts.workspacePatterns.length > 0,
         workspacePatterns: packageFacts.workspacePatterns,

--- a/src/baseline.ts
+++ b/src/baseline.ts
@@ -154,6 +154,13 @@ type PackageManagerEvidence =
       status: 'unknown'
     }
 
+type BaselineWork =
+  | 'language-count-write'
+  | 'language-entry'
+  | 'top-level-entry'
+  | 'top-level-fact-write'
+  | 'workflow-entry'
+
 type BaselineScanHooks = {
   afterBaselineSources?: (() => void) | undefined
   afterLanguageDirectoryCapture?: ((path: string) => void) | undefined
@@ -167,6 +174,7 @@ type BaselineScanHooks = {
   maximumScannedDirectories?: number | undefined
   maximumScannedFiles?: number | undefined
   onLanguageDirectoryScheduled?: (() => void) | undefined
+  onWork?: ((operation: BaselineWork) => void) | undefined
 }
 
 type BaselineReason =
@@ -349,7 +357,9 @@ const readBoundedDirectoryEntries = (
   if (parent !== undefined) {
     revalidateCanonicalDirectory(parent)
   }
-  const snapshot = captureCanonicalDirectory(directory, MAX_LANGUAGE_DIRECTORY_ENTRIES)
+  const snapshot = captureCanonicalDirectory(directory, MAX_LANGUAGE_DIRECTORY_ENTRIES, undefined, () =>
+    hooks.onWork?.('language-entry'),
+  )
   hooks.afterLanguageDirectoryCapture?.(directory)
   if (parent !== undefined) {
     revalidateCanonicalDirectory(parent)
@@ -408,6 +418,7 @@ const scanLanguages = (root: string, hooks: BaselineScanHooks) => {
             state.filesSeen += 1
             const language = LANGUAGE_BY_EXTENSION.get(extname(entry.name).toLowerCase())
             if (language !== undefined) {
+              hooks.onWork?.('language-count-write')
               state.languageCounts.set(language, (state.languageCounts.get(language) ?? 0) + 1)
             }
           }
@@ -446,7 +457,12 @@ const workflowFiles = (root: string, hooks: BaselineScanHooks, expectedGithub: b
       if (workflowsWitness === undefined) {
         revalidateDirectoryWitness(githubWitness)
       } else {
-        const collected = collectBoundedDirectoryEntries(workflowsWitness.canonicalPath, MAX_WORKFLOW_ENTRIES)
+        const collected = collectBoundedDirectoryEntries(
+          workflowsWitness.canonicalPath,
+          MAX_WORKFLOW_ENTRIES,
+          undefined,
+          () => hooks.onWork?.('workflow-entry'),
+        )
         hooks.afterWorkflowEnumeration?.()
         revalidateDirectoryWitness(workflowsWitness)
         revalidateDirectoryWitness(githubWitness)
@@ -482,7 +498,9 @@ const topLevelFacts = (root: string, hooks: BaselineScanHooks) => {
     value: emptyTopLevelFacts(),
   }
   try {
-    const snapshot = captureCanonicalDirectory(root, MAX_TOP_LEVEL_ENTRIES)
+    const snapshot = captureCanonicalDirectory(root, MAX_TOP_LEVEL_ENTRIES, undefined, () =>
+      hooks.onWork?.('top-level-entry'),
+    )
     if (snapshot.overflow) {
       result = { reasons: ['top-level-entry-limit'], value: emptyTopLevelFacts() }
     } else {
@@ -491,8 +509,10 @@ const topLevelFacts = (root: string, hooks: BaselineScanHooks) => {
         .reduce((candidate, entry) => {
           if (entry.isDirectory() && !EXCLUDED_DIRECTORIES.has(entry.name.toLowerCase())) {
             candidate.directories.push(entry.name)
+            hooks.onWork?.('top-level-fact-write')
           } else if (entry.isFile() && RECOGNISED_FILES.has(entry.name.toLowerCase())) {
             candidate.recognisedFiles.push(entry.name)
+            hooks.onWork?.('top-level-fact-write')
           }
           return candidate
         }, emptyTopLevelFacts())

--- a/src/baseline.ts
+++ b/src/baseline.ts
@@ -177,6 +177,35 @@ type BaselineScanHooks = {
   onWork?: ((operation: BaselineWork) => void) | undefined
 }
 
+const isArrayIndex = (property: string | symbol) => typeof property === 'string' && /^(?:0|[1-9]\d*)$/.test(property)
+
+const observedArray = <Value>(onWrite?: () => void) => {
+  const values: Value[] = []
+  if (onWrite !== undefined) {
+    return new Proxy(values, {
+      set: (target, property, value, receiver) => {
+        if (isArrayIndex(property)) {
+          onWrite()
+        }
+        return Reflect.set(target, property, value, receiver)
+      },
+    })
+  }
+  return values
+}
+
+const observedMap = <Key, Value>(onWrite?: () => void) => {
+  if (onWrite !== undefined) {
+    return new (class extends Map<Key, Value> {
+      override set(key: Key, value: Value) {
+        onWrite()
+        return super.set(key, value)
+      }
+    })()
+  }
+  return new Map<Key, Value>()
+}
+
 type BaselineReason =
   | 'directory-entry-limit'
   | 'directory-limit'
@@ -381,7 +410,7 @@ const readBoundedDirectoryEntries = (
 const scanLanguages = (root: string, hooks: BaselineScanHooks) => {
   const state: ScanState = {
     filesSeen: 0,
-    languageCounts: new Map(),
+    languageCounts: observedMap(() => hooks.onWork?.('language-count-write')),
     truncationReasons: new Set(),
   }
   const maximumDirectories = hooks.maximumScannedDirectories ?? MAX_SCANNED_DIRECTORIES
@@ -418,7 +447,6 @@ const scanLanguages = (root: string, hooks: BaselineScanHooks) => {
             state.filesSeen += 1
             const language = LANGUAGE_BY_EXTENSION.get(extname(entry.name).toLowerCase())
             if (language !== undefined) {
-              hooks.onWork?.('language-count-write')
               state.languageCounts.set(language, (state.languageCounts.get(language) ?? 0) + 1)
             }
           }
@@ -487,9 +515,9 @@ const workflowFiles = (root: string, hooks: BaselineScanHooks, expectedGithub: b
   return result
 }
 
-const emptyTopLevelFacts = () => ({
-  directories: [] as string[],
-  recognisedFiles: [] as string[],
+const emptyTopLevelFacts = (hooks?: BaselineScanHooks) => ({
+  directories: observedArray<string>(() => hooks?.onWork?.('top-level-fact-write')),
+  recognisedFiles: observedArray<string>(() => hooks?.onWork?.('top-level-fact-write')),
 })
 
 const topLevelFacts = (root: string, hooks: BaselineScanHooks) => {
@@ -509,13 +537,11 @@ const topLevelFacts = (root: string, hooks: BaselineScanHooks) => {
         .reduce((candidate, entry) => {
           if (entry.isDirectory() && !EXCLUDED_DIRECTORIES.has(entry.name.toLowerCase())) {
             candidate.directories.push(entry.name)
-            hooks.onWork?.('top-level-fact-write')
           } else if (entry.isFile() && RECOGNISED_FILES.has(entry.name.toLowerCase())) {
             candidate.recognisedFiles.push(entry.name)
-            hooks.onWork?.('top-level-fact-write')
           }
           return candidate
-        }, emptyTopLevelFacts())
+        }, emptyTopLevelFacts(hooks))
       hooks.beforeTopLevelRevalidation?.()
       revalidateCanonicalDirectory(snapshot)
       result = { reasons: [], value: facts }

--- a/src/canonical-layout.ts
+++ b/src/canonical-layout.ts
@@ -43,6 +43,7 @@ export const collectBoundedDirectoryEntries = <Entry extends { name: string } = 
   directory: string,
   maximum: number,
   openDirectory: OpenDirectory<Entry> = opendirSync as unknown as OpenDirectory<Entry>,
+  onEntry?: () => void,
 ) => {
   const reader = openDirectory(directory)
   let primaryError: unknown
@@ -58,6 +59,7 @@ export const collectBoundedDirectoryEntries = <Entry extends { name: string } = 
         }
         break
       }
+      onEntry?.()
       entries.push(entry)
     }
     result ??= { entries: [], overflow: true as const }
@@ -98,10 +100,11 @@ export const captureCanonicalDirectory = (
   path: string,
   maximum: number,
   afterEnumeration?: (path: string) => void,
+  onEntry?: () => void,
 ): CanonicalDirectorySnapshot => {
   try {
     const witness = captureDirectoryWitness(path, { allowLink: false })
-    const collected = collectBoundedDirectoryEntries(witness.canonicalPath, maximum)
+    const collected = collectBoundedDirectoryEntries(witness.canonicalPath, maximum, undefined, onEntry)
     afterEnumeration?.(path)
     revalidateDirectoryWitness(witness)
     return { ...collected, witness }

--- a/src/canonical-layout.ts
+++ b/src/canonical-layout.ts
@@ -39,6 +39,7 @@ type DirectoryReader<Entry> = {
 
 type OpenDirectory<Entry> = (path: string) => DirectoryReader<Entry>
 
+/** @internal */
 export const collectBoundedDirectoryEntries = <Entry extends { name: string } = Dirent>(
   directory: string,
   maximum: number,
@@ -96,6 +97,7 @@ export type CanonicalDirectorySnapshot = {
   witness: DirectoryWitness
 }
 
+/** @internal */
 export const captureCanonicalDirectory = (
   path: string,
   maximum: number,

--- a/src/records.ts
+++ b/src/records.ts
@@ -235,6 +235,13 @@ const observedSet = <Value>(onWrite?: () => void) => {
   return new Set<Value>()
 }
 
+const observeWork = (hooks: RecordReadHooks, operation: RecordWork) => {
+  const { onWork } = hooks
+  if (onWork !== undefined) {
+    return () => onWork(operation)
+  }
+}
+
 type AllowedMultiHead = {
   kind: string
   source: string
@@ -789,8 +796,8 @@ const duplicateAndCaseIssues = (records: BrainRecord[], hooks: RecordReadHooks) 
   const ids = new Map<string, BrainRecord>()
   const paths = new Map<string, BrainRecord>()
   const errors = observedArray<ValidationIssue>(
-    () => hooks.onWork?.('duplicate-issue-read'),
-    () => hooks.onWork?.('duplicate-issue-write'),
+    observeWork(hooks, 'duplicate-issue-read'),
+    observeWork(hooks, 'duplicate-issue-write'),
   )
   for (const record of records) {
     hooks.onWork?.('duplicate-record')
@@ -900,8 +907,8 @@ const supersessionIssues = (records: BrainRecord[], hooks: RecordReadHooks) => {
       const group = activeGroups.get(key)
       if (group === undefined) {
         const firstGroup = observedArray<BrainRecord>(
-          () => hooks.onWork?.('active-group-read'),
-          () => hooks.onWork?.('active-group-write'),
+          observeWork(hooks, 'active-group-read'),
+          observeWork(hooks, 'active-group-write'),
         )
         firstGroup.push(record)
         activeGroups.set(key, firstGroup)
@@ -911,8 +918,8 @@ const supersessionIssues = (records: BrainRecord[], hooks: RecordReadHooks) => {
     }
   }
   const activeIssues = observedArray<ValidationIssue>(
-    () => hooks.onWork?.('active-issue-read'),
-    () => hooks.onWork?.('active-issue-write'),
+    observeWork(hooks, 'active-issue-read'),
+    observeWork(hooks, 'active-issue-write'),
   )
   for (const group of activeGroups.values()) {
     if (group.length > 1) {
@@ -1075,7 +1082,7 @@ const allowedMultiHeadRecordIds = (records: BrainRecord[], allowed: AllowedMulti
       const key = `${record.kind} ${record.subject}`
       const group = activeGroups.get(key)
       if (group === undefined) {
-        const firstGroup = observedArray<BrainRecord>(undefined, () => hooks.onWork?.('allowed-group-write'))
+        const firstGroup = observedArray<BrainRecord>(undefined, observeWork(hooks, 'allowed-group-write'))
         firstGroup.push(record)
         activeGroups.set(key, firstGroup)
       } else {
@@ -1083,7 +1090,7 @@ const allowedMultiHeadRecordIds = (records: BrainRecord[], allowed: AllowedMulti
       }
     }
   }
-  const ids = observedSet<string>(() => hooks.onWork?.('allowed-id-write'))
+  const ids = observedSet<string>(observeWork(hooks, 'allowed-id-write'))
   for (const group of activeGroups.values()) {
     const [first] = group
     if (

--- a/src/records.ts
+++ b/src/records.ts
@@ -157,12 +157,16 @@ export const recordWriteTestHooks: AddRecordTestHooks = {}
 type RecordReadFault = 'after-record-fstat' | 'after-record-lstat' | 'after-record-open'
 
 type RecordWork =
+  | 'active-group-read'
   | 'active-group-write'
+  | 'active-issue-read'
   | 'active-issue-write'
   | 'allowed-group-write'
   | 'allowed-id-write'
   | 'canonical-entry'
   | 'cycle-edge'
+  | 'duplicate-issue-read'
+  | 'duplicate-issue-write'
   | 'duplicate-record'
   | 'edge-validation'
   | 'superseded-edge'
@@ -194,6 +198,41 @@ type PlannedRecord = {
 
 type ValidateRecordsOptions = {
   hooks?: RecordReadHooks
+}
+
+const isArrayIndex = (property: string | symbol) => typeof property === 'string' && /^(?:0|[1-9]\d*)$/.test(property)
+
+const observedArray = <Value>(onRead?: () => void, onWrite?: () => void) => {
+  const values: Value[] = []
+  if (onRead !== undefined || onWrite !== undefined) {
+    return new Proxy(values, {
+      get: (target, property, receiver) => {
+        if (isArrayIndex(property)) {
+          onRead?.()
+        }
+        return Reflect.get(target, property, receiver) as unknown
+      },
+      set: (target, property, value, receiver) => {
+        if (isArrayIndex(property)) {
+          onWrite?.()
+        }
+        return Reflect.set(target, property, value, receiver)
+      },
+    })
+  }
+  return values
+}
+
+const observedSet = <Value>(onWrite?: () => void) => {
+  if (onWrite !== undefined) {
+    return new (class extends Set<Value> {
+      override add(value: Value) {
+        onWrite()
+        return super.add(value)
+      }
+    })()
+  }
+  return new Set<Value>()
 }
 
 type AllowedMultiHead = {
@@ -749,7 +788,10 @@ const scanCanonicalRecords = (root: string, options: ValidateRecordsOptions = {}
 const duplicateAndCaseIssues = (records: BrainRecord[], hooks: RecordReadHooks) => {
   const ids = new Map<string, BrainRecord>()
   const paths = new Map<string, BrainRecord>()
-  const errors: ValidationIssue[] = []
+  const errors = observedArray<ValidationIssue>(
+    () => hooks.onWork?.('duplicate-issue-read'),
+    () => hooks.onWork?.('duplicate-issue-write'),
+  )
   for (const record of records) {
     hooks.onWork?.('duplicate-record')
     const idCollision = ids.get(record.id)
@@ -854,21 +896,27 @@ const supersessionIssues = (records: BrainRecord[], hooks: RecordReadHooks) => {
   const activeGroups = new Map<string, BrainRecord[]>()
   for (const record of records) {
     if (!superseded.has(record.id)) {
-      hooks.onWork?.('active-group-write')
       const key = `${record.kind}\0${record.subject}`
       const group = activeGroups.get(key)
       if (group === undefined) {
-        activeGroups.set(key, [record])
+        const firstGroup = observedArray<BrainRecord>(
+          () => hooks.onWork?.('active-group-read'),
+          () => hooks.onWork?.('active-group-write'),
+        )
+        firstGroup.push(record)
+        activeGroups.set(key, firstGroup)
       } else {
         group.push(record)
       }
     }
   }
-  const activeIssues: ValidationIssue[] = []
+  const activeIssues = observedArray<ValidationIssue>(
+    () => hooks.onWork?.('active-issue-read'),
+    () => hooks.onWork?.('active-issue-write'),
+  )
   for (const group of activeGroups.values()) {
     if (group.length > 1) {
       for (const record of group) {
-        hooks.onWork?.('active-issue-write')
         activeIssues.push(
           issue(
             'MULTIPLE_ACTIVE_HEADS',
@@ -1024,17 +1072,18 @@ const allowedMultiHeadRecordIds = (records: BrainRecord[], allowed: AllowedMulti
   const activeGroups = new Map<string, BrainRecord[]>()
   for (const record of records) {
     if (!superseded.has(record.id)) {
-      hooks.onWork?.('allowed-group-write')
       const key = `${record.kind} ${record.subject}`
       const group = activeGroups.get(key)
       if (group === undefined) {
-        activeGroups.set(key, [record])
+        const firstGroup = observedArray<BrainRecord>(undefined, () => hooks.onWork?.('allowed-group-write'))
+        firstGroup.push(record)
+        activeGroups.set(key, firstGroup)
       } else {
         group.push(record)
       }
     }
   }
-  const ids = new Set<string>()
+  const ids = observedSet<string>(() => hooks.onWork?.('allowed-id-write'))
   for (const group of activeGroups.values()) {
     const [first] = group
     if (
@@ -1043,7 +1092,6 @@ const allowedMultiHeadRecordIds = (records: BrainRecord[], allowed: AllowedMulti
       group.every(record => allowedKeys.has(`${record.kind} ${record.subject} ${record.source}`))
     ) {
       for (const record of group) {
-        hooks.onWork?.('allowed-id-write')
         ids.add(record.id)
       }
     }

--- a/src/records.ts
+++ b/src/records.ts
@@ -156,6 +156,17 @@ export const recordWriteTestHooks: AddRecordTestHooks = {}
 
 type RecordReadFault = 'after-record-fstat' | 'after-record-lstat' | 'after-record-open'
 
+type RecordWork =
+  | 'active-group-write'
+  | 'active-issue-write'
+  | 'allowed-group-write'
+  | 'allowed-id-write'
+  | 'canonical-entry'
+  | 'cycle-edge'
+  | 'duplicate-record'
+  | 'edge-validation'
+  | 'superseded-edge'
+
 /** @internal */
 export type RecordReadHooks = {
   afterBrainRootEnumeration?: (() => void) | undefined
@@ -164,6 +175,7 @@ export type RecordReadHooks = {
   beforeFinalWitnessValidation?: (() => void) | undefined
   fault?: (point: RecordReadFault, path: string) => void
   graphValidation?: () => void
+  onWork?: ((operation: RecordWork) => void) | undefined
 }
 
 type AddRecordOptions = {
@@ -624,6 +636,7 @@ const scanCanonicalRecords = (root: string, options: ValidateRecordsOptions = {}
             if (stopScanning) {
               break
             }
+            options.hooks?.onWork?.('canonical-entry')
             const recordPath = join(kindPath, recordEntry.name)
             const relativePath = posixRelative(root, recordPath)
             if (recordEntry.isFile() && !recordEntry.isSymbolicLink() && recordEntry.name.endsWith('.json')) {
@@ -733,11 +746,12 @@ const scanCanonicalRecords = (root: string, options: ValidateRecordsOptions = {}
   return { bytes: 0, errors: [], layout: { kinds: new Map(), root: null }, observations: [], records: [] }
 }
 
-const duplicateAndCaseIssues = (records: BrainRecord[]) => {
+const duplicateAndCaseIssues = (records: BrainRecord[], hooks: RecordReadHooks) => {
   const ids = new Map<string, BrainRecord>()
   const paths = new Map<string, BrainRecord>()
   const errors: ValidationIssue[] = []
   for (const record of records) {
+    hooks.onWork?.('duplicate-record')
     const idCollision = ids.get(record.id)
     const pathCollision = paths.get(record.path.normalize('NFC').toLowerCase())
     ids.set(record.id, record)
@@ -754,7 +768,7 @@ const duplicateAndCaseIssues = (records: BrainRecord[]) => {
   return errors
 }
 
-const supersessionIssues = (records: BrainRecord[]) => {
+const supersessionIssues = (records: BrainRecord[], hooks: RecordReadHooks) => {
   const byId = new Map(records.map(record => [record.id, record]))
   const edgeCount = records.reduce((count, record) => count + (record.supersedes?.length ?? 0), 0)
   if (edgeCount > MAX_SUPERSESSION_EDGES) {
@@ -768,6 +782,7 @@ const supersessionIssues = (records: BrainRecord[]) => {
   const edgeIssues: ValidationIssue[] = []
   for (const record of records) {
     for (const targetId of record.supersedes ?? []) {
+      hooks.onWork?.('edge-validation')
       const target = byId.get(targetId)
       if (target === undefined) {
         edgeIssues.push(
@@ -806,6 +821,7 @@ const supersessionIssues = (records: BrainRecord[]) => {
         } else {
           const targetId = targets[frame.index] ?? ''
           frame.index += 1
+          hooks.onWork?.('cycle-edge')
           const target = byId.get(targetId)
           if (target !== undefined) {
             const targetState = state.get(target.id)
@@ -831,12 +847,14 @@ const supersessionIssues = (records: BrainRecord[]) => {
   const superseded = new Set<string>()
   for (const record of records) {
     for (const targetId of record.supersedes ?? []) {
+      hooks.onWork?.('superseded-edge')
       superseded.add(targetId)
     }
   }
   const activeGroups = new Map<string, BrainRecord[]>()
   for (const record of records) {
     if (!superseded.has(record.id)) {
+      hooks.onWork?.('active-group-write')
       const key = `${record.kind}\0${record.subject}`
       const group = activeGroups.get(key)
       if (group === undefined) {
@@ -850,6 +868,7 @@ const supersessionIssues = (records: BrainRecord[]) => {
   for (const group of activeGroups.values()) {
     if (group.length > 1) {
       for (const record of group) {
+        hooks.onWork?.('active-issue-write')
         activeIssues.push(
           issue(
             'MULTIPLE_ACTIVE_HEADS',
@@ -975,8 +994,8 @@ const validateScannedSnapshot = (root: string, scan: RecordScan, hooks: RecordRe
   const collectedErrors = [
     ...scan.errors,
     ...corpusBudgetIssues(scan),
-    ...duplicateAndCaseIssues(scan.records),
-    ...supersessionIssues(scan.records),
+    ...duplicateAndCaseIssues(scan.records, hooks),
+    ...supersessionIssues(scan.records, hooks),
     ...artifactValidation.errors,
   ]
   const { errors, truncated } = truncateValidationIssues(collectedErrors)
@@ -994,7 +1013,7 @@ const validateScannedSnapshot = (root: string, scan: RecordScan, hooks: RecordRe
 const validateScanned = (root: string, scan: RecordScan, hooks: RecordReadHooks = {}): ValidateResult =>
   validateScannedSnapshot(root, scan, hooks).result
 
-const allowedMultiHeadRecordIds = (records: BrainRecord[], allowed: AllowedMultiHead[]) => {
+const allowedMultiHeadRecordIds = (records: BrainRecord[], allowed: AllowedMultiHead[], hooks: RecordReadHooks) => {
   const allowedKeys = new Set(allowed.map(candidate => `${candidate.kind} ${candidate.subject} ${candidate.source}`))
   const superseded = new Set<string>()
   for (const record of records) {
@@ -1005,6 +1024,7 @@ const allowedMultiHeadRecordIds = (records: BrainRecord[], allowed: AllowedMulti
   const activeGroups = new Map<string, BrainRecord[]>()
   for (const record of records) {
     if (!superseded.has(record.id)) {
+      hooks.onWork?.('allowed-group-write')
       const key = `${record.kind} ${record.subject}`
       const group = activeGroups.get(key)
       if (group === undefined) {
@@ -1023,6 +1043,7 @@ const allowedMultiHeadRecordIds = (records: BrainRecord[], allowed: AllowedMulti
       group.every(record => allowedKeys.has(`${record.kind} ${record.subject} ${record.source}`))
     ) {
       for (const record of group) {
+        hooks.onWork?.('allowed-id-write')
         ids.add(record.id)
       }
     }
@@ -1033,7 +1054,7 @@ const allowedMultiHeadRecordIds = (records: BrainRecord[], allowed: AllowedMulti
 /** @internal */
 export const validateRecordsResolved = (root: string, options: ValidateRecordsOptions = {}): ValidateResult => {
   try {
-    return validateScanned(root, scanCanonicalRecords(root, options))
+    return validateScanned(root, scanCanonicalRecords(root, options), options.hooks)
   } catch (error) {
     if (error instanceof EncephalonError) {
       throw error
@@ -1063,7 +1084,7 @@ const readRecordScanResolved = (root: string, hooks: RecordReadHooks = {}, allow
       })),
     })
   }
-  const allowedIds = allowedMultiHeadRecordIds(scan.records, allowed)
+  const allowedIds = allowedMultiHeadRecordIds(scan.records, allowed, hooks)
   const blockingErrors = result.errors.filter(
     error =>
       !(error.code === 'MULTIPLE_ACTIVE_HEADS' && error.recordId !== undefined && allowedIds.has(error.recordId)),

--- a/src/records.ts
+++ b/src/records.ts
@@ -69,6 +69,7 @@ import type {
   ValidateResult,
   ValidationIssue,
 } from './types.ts'
+import { observedArray, observedSet, observeWork, reportWork, rethrowWorkObserverError } from './work-observer.ts'
 
 type RecordScan = {
   records: BrainRecord[]
@@ -198,48 +199,6 @@ type PlannedRecord = {
 
 type ValidateRecordsOptions = {
   hooks?: RecordReadHooks
-}
-
-const isArrayIndex = (property: string | symbol) => typeof property === 'string' && /^(?:0|[1-9]\d*)$/.test(property)
-
-const observedArray = <Value>(onRead?: () => void, onWrite?: () => void) => {
-  const values: Value[] = []
-  if (onRead !== undefined || onWrite !== undefined) {
-    return new Proxy(values, {
-      get: (target, property, receiver) => {
-        if (isArrayIndex(property)) {
-          onRead?.()
-        }
-        return Reflect.get(target, property, receiver) as unknown
-      },
-      set: (target, property, value, receiver) => {
-        if (isArrayIndex(property)) {
-          onWrite?.()
-        }
-        return Reflect.set(target, property, value, receiver)
-      },
-    })
-  }
-  return values
-}
-
-const observedSet = <Value>(onWrite?: () => void) => {
-  if (onWrite !== undefined) {
-    return new (class extends Set<Value> {
-      override add(value: Value) {
-        onWrite()
-        return super.add(value)
-      }
-    })()
-  }
-  return new Set<Value>()
-}
-
-const observeWork = (hooks: RecordReadHooks, operation: RecordWork) => {
-  const { onWork } = hooks
-  if (onWork !== undefined) {
-    return () => onWork(operation)
-  }
 }
 
 type AllowedMultiHead = {
@@ -619,6 +578,7 @@ const scanCanonicalRecords = (root: string, options: ValidateRecordsOptions = {}
 
     const kindDirectoryNames = new Map<string, string>()
     const scanned: RecordScan = { bytes: 0, errors: [], observations: [], records: [] }
+    const onWork = options.hooks?.onWork
     let recordBytes = 0
     let stopScanning = false
     const addScanError = (validationIssue: ValidationIssue) => {
@@ -682,7 +642,9 @@ const scanCanonicalRecords = (root: string, options: ValidateRecordsOptions = {}
             if (stopScanning) {
               break
             }
-            options.hooks?.onWork?.('canonical-entry')
+            if (onWork !== undefined) {
+              reportWork(onWork, 'canonical-entry')
+            }
             const recordPath = join(kindPath, recordEntry.name)
             const relativePath = posixRelative(root, recordPath)
             if (recordEntry.isFile() && !recordEntry.isSymbolicLink() && recordEntry.name.endsWith('.json')) {
@@ -795,12 +757,15 @@ const scanCanonicalRecords = (root: string, options: ValidateRecordsOptions = {}
 const duplicateAndCaseIssues = (records: BrainRecord[], hooks: RecordReadHooks) => {
   const ids = new Map<string, BrainRecord>()
   const paths = new Map<string, BrainRecord>()
+  const { onWork } = hooks
   const errors = observedArray<ValidationIssue>(
-    observeWork(hooks, 'duplicate-issue-read'),
-    observeWork(hooks, 'duplicate-issue-write'),
+    observeWork(hooks.onWork, 'duplicate-issue-read'),
+    observeWork(hooks.onWork, 'duplicate-issue-write'),
   )
   for (const record of records) {
-    hooks.onWork?.('duplicate-record')
+    if (onWork !== undefined) {
+      reportWork(onWork, 'duplicate-record')
+    }
     const idCollision = ids.get(record.id)
     const pathCollision = paths.get(record.path.normalize('NFC').toLowerCase())
     ids.set(record.id, record)
@@ -819,6 +784,7 @@ const duplicateAndCaseIssues = (records: BrainRecord[], hooks: RecordReadHooks) 
 
 const supersessionIssues = (records: BrainRecord[], hooks: RecordReadHooks) => {
   const byId = new Map(records.map(record => [record.id, record]))
+  const { onWork } = hooks
   const edgeCount = records.reduce((count, record) => count + (record.supersedes?.length ?? 0), 0)
   if (edgeCount > MAX_SUPERSESSION_EDGES) {
     return [
@@ -831,7 +797,9 @@ const supersessionIssues = (records: BrainRecord[], hooks: RecordReadHooks) => {
   const edgeIssues: ValidationIssue[] = []
   for (const record of records) {
     for (const targetId of record.supersedes ?? []) {
-      hooks.onWork?.('edge-validation')
+      if (onWork !== undefined) {
+        reportWork(onWork, 'edge-validation')
+      }
       const target = byId.get(targetId)
       if (target === undefined) {
         edgeIssues.push(
@@ -870,7 +838,9 @@ const supersessionIssues = (records: BrainRecord[], hooks: RecordReadHooks) => {
         } else {
           const targetId = targets[frame.index] ?? ''
           frame.index += 1
-          hooks.onWork?.('cycle-edge')
+          if (onWork !== undefined) {
+            reportWork(onWork, 'cycle-edge')
+          }
           const target = byId.get(targetId)
           if (target !== undefined) {
             const targetState = state.get(target.id)
@@ -896,7 +866,9 @@ const supersessionIssues = (records: BrainRecord[], hooks: RecordReadHooks) => {
   const superseded = new Set<string>()
   for (const record of records) {
     for (const targetId of record.supersedes ?? []) {
-      hooks.onWork?.('superseded-edge')
+      if (onWork !== undefined) {
+        reportWork(onWork, 'superseded-edge')
+      }
       superseded.add(targetId)
     }
   }
@@ -907,8 +879,8 @@ const supersessionIssues = (records: BrainRecord[], hooks: RecordReadHooks) => {
       const group = activeGroups.get(key)
       if (group === undefined) {
         const firstGroup = observedArray<BrainRecord>(
-          observeWork(hooks, 'active-group-read'),
-          observeWork(hooks, 'active-group-write'),
+          observeWork(hooks.onWork, 'active-group-read'),
+          observeWork(hooks.onWork, 'active-group-write'),
         )
         firstGroup.push(record)
         activeGroups.set(key, firstGroup)
@@ -918,8 +890,8 @@ const supersessionIssues = (records: BrainRecord[], hooks: RecordReadHooks) => {
     }
   }
   const activeIssues = observedArray<ValidationIssue>(
-    observeWork(hooks, 'active-issue-read'),
-    observeWork(hooks, 'active-issue-write'),
+    observeWork(hooks.onWork, 'active-issue-read'),
+    observeWork(hooks.onWork, 'active-issue-write'),
   )
   for (const group of activeGroups.values()) {
     if (group.length > 1) {
@@ -1082,7 +1054,7 @@ const allowedMultiHeadRecordIds = (records: BrainRecord[], allowed: AllowedMulti
       const key = `${record.kind} ${record.subject}`
       const group = activeGroups.get(key)
       if (group === undefined) {
-        const firstGroup = observedArray<BrainRecord>(undefined, observeWork(hooks, 'allowed-group-write'))
+        const firstGroup = observedArray<BrainRecord>(undefined, observeWork(hooks.onWork, 'allowed-group-write'))
         firstGroup.push(record)
         activeGroups.set(key, firstGroup)
       } else {
@@ -1090,7 +1062,7 @@ const allowedMultiHeadRecordIds = (records: BrainRecord[], allowed: AllowedMulti
       }
     }
   }
-  const ids = observedSet<string>(observeWork(hooks, 'allowed-id-write'))
+  const ids = observedSet<string>(observeWork(hooks.onWork, 'allowed-id-write'))
   for (const group of activeGroups.values()) {
     const [first] = group
     if (
@@ -1111,6 +1083,7 @@ export const validateRecordsResolved = (root: string, options: ValidateRecordsOp
   try {
     return validateScanned(root, scanCanonicalRecords(root, options), options.hooks)
   } catch (error) {
+    rethrowWorkObserverError(error)
     if (error instanceof EncephalonError) {
       throw error
     }

--- a/src/records.ts
+++ b/src/records.ts
@@ -201,6 +201,15 @@ type ValidateRecordsOptions = {
   hooks?: RecordReadHooks
 }
 
+const preserveWorkObserverFailure = <Result>(operation: () => Result) => {
+  try {
+    return operation()
+  } catch (error) {
+    rethrowWorkObserverError(error)
+    throw error
+  }
+}
+
 type AllowedMultiHead = {
   kind: string
   source: string
@@ -1096,7 +1105,7 @@ export const validateRecords = (input: RootInput = {}): ValidateResult => {
   return validateRecordsResolved(root)
 }
 
-const readRecordScanResolved = (root: string, hooks: RecordReadHooks = {}, allowed?: AllowedMultiHead[]) => {
+const readRecordScanResolvedUnchecked = (root: string, hooks: RecordReadHooks = {}, allowed?: AllowedMultiHead[]) => {
   hooks.canonicalScan?.()
   const scan = scanCanonicalRecords(root, { hooks })
   const validation = validateScannedSnapshot(root, scan, hooks)
@@ -1127,6 +1136,9 @@ const readRecordScanResolved = (root: string, hooks: RecordReadHooks = {}, allow
     })),
   })
 }
+
+const readRecordScanResolved = (root: string, hooks: RecordReadHooks = {}, allowed?: AllowedMultiHead[]) =>
+  preserveWorkObserverFailure(() => readRecordScanResolvedUnchecked(root, hooks, allowed))
 
 const canonicalPublicationAuthority = (
   root: string,
@@ -1382,15 +1394,17 @@ export const assertRecordGraph = (
   hooks: RecordReadHooks = {},
   bytes?: number,
 ) => {
-  const result = validateScanned(
-    root,
-    {
-      bytes: bytes ?? records.reduce((total, record) => total + canonicalRecordBytes(record), 0),
-      errors: [],
-      observations: [],
-      records,
-    },
-    hooks,
+  const result = preserveWorkObserverFailure(() =>
+    validateScanned(
+      root,
+      {
+        bytes: bytes ?? records.reduce((total, record) => total + canonicalRecordBytes(record), 0),
+        errors: [],
+        observations: [],
+        records,
+      },
+      hooks,
+    ),
   )
   if (result.valid) {
     return

--- a/src/work-observer.ts
+++ b/src/work-observer.ts
@@ -1,0 +1,82 @@
+type WorkObserver<Operation extends string> = (operation: Operation) => void
+
+class WorkObserverError extends Error {}
+
+const invokeWorkObserver = <Operation extends string>(observer: WorkObserver<Operation>, operation: Operation) => {
+  try {
+    observer(operation)
+  } catch (error) {
+    throw new WorkObserverError('Internal work observer failed.', { cause: error })
+  }
+}
+
+/** @internal */
+export const reportWork = <Operation extends string>(observer: WorkObserver<Operation>, operation: Operation) =>
+  invokeWorkObserver(observer, operation)
+
+/** @internal */
+export const observeWork = <Operation extends string>(
+  observer: WorkObserver<Operation> | undefined,
+  operation: Operation,
+) => {
+  if (observer !== undefined) {
+    return () => invokeWorkObserver(observer, operation)
+  }
+}
+
+/** @internal */
+export const rethrowWorkObserverError = (error: unknown) => {
+  if (error instanceof WorkObserverError) {
+    throw error.cause
+  }
+}
+
+const isArrayIndex = (property: string | symbol) => typeof property === 'string' && /^(?:0|[1-9]\d*)$/.test(property)
+
+/** @internal */
+export const observedArray = <Value>(onRead?: () => void, onWrite?: () => void) => {
+  const values: Value[] = []
+  if (onRead !== undefined || onWrite !== undefined) {
+    return new Proxy(values, {
+      get: (target, property, receiver) => {
+        if (isArrayIndex(property)) {
+          onRead?.()
+        }
+        return Reflect.get(target, property, receiver) as unknown
+      },
+      set: (target, property, value, receiver) => {
+        if (isArrayIndex(property)) {
+          onWrite?.()
+        }
+        return Reflect.set(target, property, value, receiver)
+      },
+    })
+  }
+  return values
+}
+
+/** @internal */
+export const observedMap = <Key, Value>(onWrite?: () => void) => {
+  if (onWrite !== undefined) {
+    return new (class extends Map<Key, Value> {
+      override set(key: Key, value: Value) {
+        onWrite()
+        return super.set(key, value)
+      }
+    })()
+  }
+  return new Map<Key, Value>()
+}
+
+/** @internal */
+export const observedSet = <Value>(onWrite?: () => void) => {
+  if (onWrite !== undefined) {
+    return new (class extends Set<Value> {
+      override add(value: Value) {
+        onWrite()
+        return super.add(value)
+      }
+    })()
+  }
+  return new Set<Value>()
+}

--- a/test/canonical-layout.test.ts
+++ b/test/canonical-layout.test.ts
@@ -36,11 +36,18 @@ describe('bounded canonical directory collection', () => {
   test('reads no more than limit plus one and hides order and names on overflow', () => {
     const first = readerFor([{ name: 'z' }, { name: 'secret-excess' }, { name: 'a' }, { name: 'unread' }])
     const second = readerFor([{ name: 'a' }, { name: 'z' }, { name: 'different-excess' }, { name: 'unread' }])
+    let observedEntries = 0
 
-    assert.deepEqual(collectBoundedDirectoryEntries('ignored', 2, first.open), { entries: [], overflow: true })
+    assert.deepEqual(
+      collectBoundedDirectoryEntries('ignored', 2, first.open, () => {
+        observedEntries += 1
+      }),
+      { entries: [], overflow: true },
+    )
     assert.deepEqual(collectBoundedDirectoryEntries('ignored', 2, second.open), { entries: [], overflow: true })
     assert.deepEqual(first.state(), { closed: 1, entriesRead: 3 })
     assert.deepEqual(second.state(), { closed: 1, entriesRead: 3 })
+    assert.equal(observedEntries, 3)
   })
 
   test('does not inspect entry names after detecting overflow', () => {

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -103,7 +103,7 @@ describe('package contract', () => {
     )
     assert.match(
       contract,
-      /Last reviewed: 2026-08-23 for code and behavioural-test snapshot `eae98315e53ce568c62f6854a8542b285b7f9e4f`\./,
+      /Last reviewed: 2026-08-18 for code and behavioural-test snapshot `dbe77b5742d9891ee1d6de1bd0676ae166a076d7`\./,
     )
     assert.match(contract, /## Performance Evidence/)
     assert.match(contract, /MAR-2568 behavioural hot-scan work bounds: `dbe77b5742d9891ee1d6de1bd0676ae166a076d7`\./)

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -31,7 +31,7 @@ describe('package contract', () => {
       .join('\n')
     assert.doesNotMatch(
       declarations,
-      /BaselineWork|RecordWork|onEntry|onWork|scanBaselineWithHooks|validateRecordsResolved/,
+      /BaselineWork|RecordWork|WorkObserver|onEntry|onWork|scanBaselineWithHooks|validateRecordsResolved/,
     )
   })
 
@@ -106,6 +106,7 @@ describe('package contract', () => {
       /Last reviewed: 2026-08-23 for code and behavioural-test snapshot `eae98315e53ce568c62f6854a8542b285b7f9e4f`\./,
     )
     assert.match(contract, /## Performance Evidence/)
+    assert.match(contract, /implementing the MAR-2566 benchmark guarantees above/)
     assert.match(contract, /MAR-2568 behavioural hot-scan work bounds: `7304c07b0fd1554470a25307ff028c03b3653274`\./)
     assert.match(performance, /Correctness tests enforce deterministic output and bounded work counts/)
     assert.match(

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -106,7 +106,7 @@ describe('package contract', () => {
       /Last reviewed: 2026-08-23 for code and behavioural-test snapshot `eae98315e53ce568c62f6854a8542b285b7f9e4f`\./,
     )
     assert.match(contract, /## Performance Evidence/)
-    assert.match(contract, /MAR-2568 behavioural hot-scan work bounds: `589c8d9a4db6e612e22b5a86cc456da6b18d65f4`\./)
+    assert.match(contract, /MAR-2568 behavioural hot-scan work bounds: `dbe77b5742d9891ee1d6de1bd0676ae166a076d7`\./)
     assert.match(performance, /Correctness tests enforce deterministic output and bounded work counts/)
     assert.match(
       contract,

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -106,7 +106,7 @@ describe('package contract', () => {
       /Last reviewed: 2026-08-23 for code and behavioural-test snapshot `eae98315e53ce568c62f6854a8542b285b7f9e4f`\./,
     )
     assert.match(contract, /## Performance Evidence/)
-    assert.match(contract, /MAR-2568 behavioural hot-scan work bounds: `d8d9ea8f6c7833e0c737c16880abe510f2793529`\./)
+    assert.match(contract, /MAR-2568 behavioural hot-scan work bounds: `589c8d9a4db6e612e22b5a86cc456da6b18d65f4`\./)
     assert.match(performance, /Correctness tests enforce deterministic output and bounded work counts/)
     assert.match(
       contract,

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -103,10 +103,10 @@ describe('package contract', () => {
     )
     assert.match(
       contract,
-      /Last reviewed: 2026-08-18 for code and behavioural-test snapshot `dbe77b5742d9891ee1d6de1bd0676ae166a076d7`\./,
+      /Last reviewed: 2026-08-23 for code and behavioural-test snapshot `eae98315e53ce568c62f6854a8542b285b7f9e4f`\./,
     )
     assert.match(contract, /## Performance Evidence/)
-    assert.match(contract, /MAR-2568 behavioural hot-scan work bounds: `dbe77b5742d9891ee1d6de1bd0676ae166a076d7`\./)
+    assert.match(contract, /MAR-2568 behavioural hot-scan work bounds: `7304c07b0fd1554470a25307ff028c03b3653274`\./)
     assert.match(performance, /Correctness tests enforce deterministic output and bounded work counts/)
     assert.match(
       contract,

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -51,6 +51,7 @@ describe('package contract', () => {
   test('marks the old implementation plan historical and maintains a concise contract', () => {
     const implementationPlan = readFileSync(resolve(root, 'docs', 'implementation-plan.md'), 'utf8')
     const contract = readFileSync(resolve(root, 'docs', 'contract.md'), 'utf8')
+    const performance = readFileSync(resolve(root, 'docs', 'performance.md'), 'utf8')
     const operationBudgetsDesign = readFileSync(
       resolve(root, 'docs', 'superpowers', 'specs', '2026-08-13-operation-budgets-design.md'),
       'utf8',
@@ -102,6 +103,8 @@ describe('package contract', () => {
       /Last reviewed: 2026-08-23 for code and behavioural-test snapshot `eae98315e53ce568c62f6854a8542b285b7f9e4f`\./,
     )
     assert.match(contract, /## Performance Evidence/)
+    assert.match(contract, /MAR-2568 behavioural hot-scan work bounds: `d8d9ea8f6c7833e0c737c16880abe510f2793529`\./)
+    assert.match(performance, /Correctness tests enforce deterministic output and bounded work counts/)
     assert.match(
       contract,
       /MAR-2566 isolated operation performance samples, additive phase boundaries, schema-version 2 distributions and strict budgets: `eae98315e53ce568c62f6854a8542b285b7f9e4f`\./,

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -26,9 +26,12 @@ describe('package contract', () => {
 
   test('has a side-effect-free TypeScript API entrypoint', () => {
     assert.equal(existsSync(resolve(root, 'src/index.ts')), true)
+    const declarations = ['index.d.ts', 'baseline.d.ts', 'canonical-layout.d.ts', 'records.d.ts']
+      .map(file => readFileSync(resolve(root, 'dist', file), 'utf8'))
+      .join('\n')
     assert.doesNotMatch(
-      readFileSync(resolve(root, 'dist', 'index.d.ts'), 'utf8'),
-      /BaselineWork|RecordWork|onWork|scanBaselineWithHooks|validateRecordsResolved/,
+      declarations,
+      /BaselineWork|RecordWork|onEntry|onWork|scanBaselineWithHooks|validateRecordsResolved/,
     )
   })
 

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -26,6 +26,10 @@ describe('package contract', () => {
 
   test('has a side-effect-free TypeScript API entrypoint', () => {
     assert.equal(existsSync(resolve(root, 'src/index.ts')), true)
+    assert.doesNotMatch(
+      readFileSync(resolve(root, 'dist', 'index.d.ts'), 'utf8'),
+      /BaselineWork|RecordWork|onWork|scanBaselineWithHooks|validateRecordsResolved/,
+    )
   })
 
   test('keeps generated runtime version metadata in sync with the manifest', () => {

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -107,7 +107,7 @@ describe('package contract', () => {
     )
     assert.match(contract, /## Performance Evidence/)
     assert.match(contract, /implementing the MAR-2566 benchmark guarantees above/)
-    assert.match(contract, /MAR-2568 behavioural hot-scan work bounds: `7304c07b0fd1554470a25307ff028c03b3653274`\./)
+    assert.match(contract, /MAR-2568 behavioural hot-scan work bounds: `d775559bad4189621f07d837c14082009fbe380c`\./)
     assert.match(performance, /Correctness tests enforce deterministic output and bounded work counts/)
     assert.match(
       contract,

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -107,7 +107,7 @@ describe('package contract', () => {
     )
     assert.match(contract, /## Performance Evidence/)
     assert.match(contract, /implementing the MAR-2566 benchmark guarantees above/)
-    assert.match(contract, /MAR-2568 behavioural hot-scan work bounds: `d775559bad4189621f07d837c14082009fbe380c`\./)
+    assert.match(contract, /MAR-2568 behavioural hot-scan work bounds: `de66f6ab7e10696fc878e380dd5417d194d60fe8`\./)
     assert.match(performance, /Correctness tests enforce deterministic output and bounded work counts/)
     assert.match(
       contract,

--- a/test/performance.test.ts
+++ b/test/performance.test.ts
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict'
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, describe, test } from 'node:test'
-import { scanBaseline } from '../src/baseline.ts'
-import * as api from '../src/index.ts'
+import { scanBaselineWithHooks } from '../src/baseline.ts'
+import { readRecordsResolved, validateRecordsResolved } from '../src/records.ts'
 import { createTestRepository, ensureParent, removeTestRepository } from '../test/helpers.ts'
 
 const roots: string[] = []
@@ -47,7 +47,7 @@ const writeRecord = (
 }
 
 describe('hot scan performance regressions', () => {
-  test('preserves validation issue order for a dense same-subject history', () => {
+  test('bounds validation work while preserving dense-history issue order', () => {
     const root = createRoot()
     writeRecord(root, {
       createdAt: '2026-08-08T00:00:00.000Z',
@@ -69,7 +69,14 @@ describe('hot scan performance regressions', () => {
       supersedes: ['history-001'],
     })
 
-    assert.deepEqual(api.validateRecords({ root }), {
+    const validationWork = new Map<string, number>()
+    const result = validateRecordsResolved(root, {
+      hooks: {
+        onWork: operation => validationWork.set(operation, (validationWork.get(operation) ?? 0) + 1),
+      },
+    })
+
+    assert.deepEqual(result, {
       errors: [
         {
           code: 'MULTIPLE_ACTIVE_HEADS',
@@ -88,9 +95,33 @@ describe('hot scan performance regressions', () => {
       truncated: false,
       valid: false,
     })
+
+    assert.deepEqual(Object.fromEntries(validationWork), {
+      'active-group-write': 2,
+      'active-issue-write': 2,
+      'canonical-entry': 4,
+      'cycle-edge': 3,
+      'duplicate-record': 4,
+      'edge-validation': 3,
+      'superseded-edge': 3,
+    })
+
+    const allowedWork = new Map<string, number>()
+    assert.equal(
+      readRecordsResolved(
+        root,
+        {
+          onWork: operation => allowedWork.set(operation, (allowedWork.get(operation) ?? 0) + 1),
+        },
+        [{ kind: 'context', source: 'test', subject: 'dense.history' }],
+      ).length,
+      4,
+    )
+    assert.equal(allowedWork.get('allowed-group-write'), 2, 'allowed group work exceeded active records')
+    assert.equal(allowedWork.get('allowed-id-write'), 2, 'allowed id work exceeded accepted active records')
   })
 
-  test('preserves baseline output order while scanning many files', () => {
+  test('bounds baseline accumulator work while preserving output order', () => {
     const root = createRoot()
     writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'sample-project' }))
     ensureParent(join(root, 'src', 'alpha.ts'))
@@ -99,8 +130,11 @@ describe('hot scan performance regressions', () => {
     ensureParent(join(root, 'scripts', 'build.sh'))
     writeFileSync(join(root, 'scripts', 'build.sh'), 'echo build')
 
+    const work = new Map<string, number>()
     assert.deepEqual(
-      scanBaseline(root).map(record => {
+      scanBaselineWithHooks(root, {
+        onWork: operation => work.set(operation, (work.get(operation) ?? 0) + 1),
+      }).map(record => {
         const payload = record.payload as Record<string, unknown>
         return {
           languageCounts: payload.languageCounts,
@@ -134,16 +168,11 @@ describe('hot scan performance regressions', () => {
         },
       ],
     )
-  })
-
-  test('does not reintroduce persistent accumulator copying in hot loops', () => {
-    const recordsSource = readFileSync(join(import.meta.dirname, '..', 'src', 'records.ts'), 'utf8')
-    const baselineSource = readFileSync(join(import.meta.dirname, '..', 'src', 'baseline.ts'), 'utf8')
-
-    assert.doesNotMatch(recordsSource, /return \[\.\.\.errors,/)
-    assert.doesNotMatch(recordsSource, /new Set\(\[\.\.\.ids,\s*\.\.\./)
-    assert.doesNotMatch(recordsSource, /groups\.set\(key,\s*\[\.\.\./)
-    assert.doesNotMatch(baselineSource, /new Map\(current\.languageCounts\)/)
-    assert.doesNotMatch(baselineSource, /\.\.\.facts\.(?:directories|recognisedFiles)/)
+    assert.deepEqual(Object.fromEntries(work), {
+      'language-count-write': 3,
+      'language-entry': 8,
+      'top-level-entry': 5,
+      'top-level-fact-write': 3,
+    })
   })
 })

--- a/test/performance.test.ts
+++ b/test/performance.test.ts
@@ -49,11 +49,53 @@ const writeRecord = (
 }
 
 describe('hot scan performance regressions', () => {
-  test('leaves unobserved baseline results free of instrumentation wrappers', () => {
+  test('leaves returned baseline results free of instrumentation wrappers', () => {
     const root = createRoot()
     writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'sample-project' }))
 
     assert.doesNotThrow(() => structuredClone(scanBaseline(root)))
+    assert.doesNotThrow(() =>
+      structuredClone(
+        scanBaselineWithHooks(root, {
+          onWork: () => undefined,
+        }),
+      ),
+    )
+  })
+
+  test('propagates internal work observer failures unchanged', () => {
+    const baselineRoot = createRoot()
+    writeFileSync(join(baselineRoot, 'package.json'), JSON.stringify({ name: 'sample-project' }))
+    const baselineFailure = new Error('baseline observer failed')
+
+    assert.throws(
+      () =>
+        scanBaselineWithHooks(baselineRoot, {
+          onWork: () => {
+            throw baselineFailure
+          },
+        }),
+      error => error === baselineFailure,
+    )
+
+    const recordsRoot = createRoot()
+    writeRecord(recordsRoot, {
+      createdAt: '2026-08-08T00:00:00.000Z',
+      id: 'observed-record',
+    })
+    const recordFailure = new Error('record observer failed')
+
+    assert.throws(
+      () =>
+        validateRecordsResolved(recordsRoot, {
+          hooks: {
+            onWork: () => {
+              throw recordFailure
+            },
+          },
+        }),
+      error => error === recordFailure,
+    )
   })
 
   test('bounds validation work while preserving dense-history issue order', () => {

--- a/test/performance.test.ts
+++ b/test/performance.test.ts
@@ -23,10 +23,12 @@ const writeRecord = (
   record: {
     createdAt: string
     id: string
+    kind?: string
     supersedes?: string[]
   },
 ) => {
-  const directory = join(root, 'encephalon', 'context')
+  const kind = record.kind ?? 'context'
+  const directory = join(root, 'encephalon', kind)
   mkdirSync(directory, { recursive: true })
   writeFileSync(
     join(directory, `${record.id}.json`),
@@ -34,7 +36,7 @@ const writeRecord = (
       {
         createdAt: record.createdAt,
         id: record.id,
-        kind: 'context',
+        kind,
         payload: { summary: record.id },
         source: 'test',
         subject: 'dense.history',
@@ -97,7 +99,9 @@ describe('hot scan performance regressions', () => {
     })
 
     assert.deepEqual(Object.fromEntries(validationWork), {
+      'active-group-read': 2,
       'active-group-write': 2,
+      'active-issue-read': 2,
       'active-issue-write': 2,
       'canonical-entry': 4,
       'cycle-edge': 3,
@@ -121,6 +125,31 @@ describe('hot scan performance regressions', () => {
     assert.equal(allowedWork.get('allowed-id-write'), 2, 'allowed id work exceeded accepted active records')
   })
 
+  test('counts duplicate issue accumulator work from collection operations', () => {
+    const root = createRoot()
+    writeRecord(root, {
+      createdAt: '2026-08-08T00:00:00.000Z',
+      id: 'duplicate-record',
+      kind: 'context',
+    })
+    writeRecord(root, {
+      createdAt: '2026-08-08T00:00:01.000Z',
+      id: 'duplicate-record',
+      kind: 'decision',
+    })
+
+    const work = new Map<string, number>()
+    const result = validateRecordsResolved(root, {
+      hooks: {
+        onWork: operation => work.set(operation, (work.get(operation) ?? 0) + 1),
+      },
+    })
+
+    assert.equal(result.errors[0]?.code, 'DUPLICATE_RECORD_ID')
+    assert.equal(work.get('duplicate-issue-read'), 1)
+    assert.equal(work.get('duplicate-issue-write'), 1)
+  })
+
   test('bounds baseline accumulator work while preserving output order', () => {
     const root = createRoot()
     writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'sample-project' }))
@@ -129,6 +158,8 @@ describe('hot scan performance regressions', () => {
     writeFileSync(join(root, 'src', 'beta.js'), 'export const beta = 2')
     ensureParent(join(root, 'scripts', 'build.sh'))
     writeFileSync(join(root, 'scripts', 'build.sh'), 'echo build')
+    ensureParent(join(root, '.github', 'workflows', 'ci.yml'))
+    writeFileSync(join(root, '.github', 'workflows', 'ci.yml'), 'name: CI')
 
     const work = new Map<string, number>()
     assert.deepEqual(
@@ -152,7 +183,7 @@ describe('hot scan performance regressions', () => {
           ],
           recognisedFiles: ['package.json'],
           subject: 'encephalon:init/repository-overview',
-          topLevelDirectories: ['scripts', 'src'],
+          topLevelDirectories: ['.github', 'scripts', 'src'],
         },
         {
           languageCounts: undefined,
@@ -170,9 +201,10 @@ describe('hot scan performance regressions', () => {
     )
     assert.deepEqual(Object.fromEntries(work), {
       'language-count-write': 3,
-      'language-entry': 8,
-      'top-level-entry': 5,
-      'top-level-fact-write': 3,
+      'language-entry': 11,
+      'top-level-entry': 6,
+      'top-level-fact-write': 4,
+      'workflow-entry': 1,
     })
   })
 })

--- a/test/performance.test.ts
+++ b/test/performance.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, describe, test } from 'node:test'
 import { scanBaseline, scanBaselineWithHooks } from '../src/baseline.ts'
-import { readRecordsResolved, validateRecordsResolved } from '../src/records.ts'
+import { assertRecordGraph, readRecordsResolved, validateRecordsResolved } from '../src/records.ts'
 import { createTestRepository, ensureParent, removeTestRepository } from '../test/helpers.ts'
 
 const roots: string[] = []
@@ -92,6 +92,26 @@ describe('hot scan performance regressions', () => {
             onWork: () => {
               throw recordFailure
             },
+          },
+        }),
+      error => error === recordFailure,
+    )
+    assert.throws(
+      () =>
+        readRecordsResolved(recordsRoot, {
+          onWork: () => {
+            throw recordFailure
+          },
+        }),
+      error => error === recordFailure,
+    )
+
+    const records = readRecordsResolved(recordsRoot)
+    assert.throws(
+      () =>
+        assertRecordGraph(recordsRoot, records, 'Observed records are invalid.', {
+          onWork: () => {
+            throw recordFailure
           },
         }),
       error => error === recordFailure,

--- a/test/performance.test.ts
+++ b/test/performance.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, describe, test } from 'node:test'
-import { scanBaselineWithHooks } from '../src/baseline.ts'
+import { scanBaseline, scanBaselineWithHooks } from '../src/baseline.ts'
 import { readRecordsResolved, validateRecordsResolved } from '../src/records.ts'
 import { createTestRepository, ensureParent, removeTestRepository } from '../test/helpers.ts'
 
@@ -49,6 +49,13 @@ const writeRecord = (
 }
 
 describe('hot scan performance regressions', () => {
+  test('leaves unobserved baseline results free of instrumentation wrappers', () => {
+    const root = createRoot()
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'sample-project' }))
+
+    assert.doesNotThrow(() => structuredClone(scanBaseline(root)))
+  })
+
   test('bounds validation work while preserving dense-history issue order', () => {
     const root = createRoot()
     writeRecord(root, {

--- a/test/records.test.ts
+++ b/test/records.test.ts
@@ -2266,7 +2266,7 @@ describe('canonical records', () => {
     assert.equal(api.validateRecords({ root }).valid, true)
   })
 
-  test('validates a corpus at the record limit with an iterative supersession chain', () => {
+  test('bounds graph work for a corpus-limit supersession chain', () => {
     const root = createRoot()
     for (const index of Array.from({ length: 1000 }, (_, value) => value)) {
       writeCanonicalRecord(root, {
@@ -2276,11 +2276,24 @@ describe('canonical records', () => {
       })
     }
 
-    const result = api.validateRecords({ root }) as { truncated?: boolean } & ReturnType<typeof api.validateRecords>
+    const work = new Map<string, number>()
+    const result = validateRecordsResolved(root, {
+      hooks: {
+        onWork: operation => work.set(operation, (work.get(operation) ?? 0) + 1),
+      },
+    }) as { truncated?: boolean } & ReturnType<typeof api.validateRecords>
     assert.equal(result.valid, true)
     assert.equal(result.recordsChecked, 1000)
     assert.equal(result.errors.length, 0)
     assert.equal(result.truncated, false)
+    assert.deepEqual(Object.fromEntries(work), {
+      'active-group-write': 1,
+      'canonical-entry': 1000,
+      'cycle-edge': 999,
+      'duplicate-record': 1000,
+      'edge-validation': 999,
+      'superseded-edge': 999,
+    })
   })
 
   test('preflights exact and overflowing planned kind directory entries', () => {
@@ -2335,9 +2348,19 @@ describe('canonical records', () => {
       id: 'edge-budget-overflow',
       supersedes: ['one-more-missing-edge'],
     })
-    const edgeResult = api.validateRecords({ root: edgeRoot })
+    let traversedOverflowEdges = 0
+    const edgeResult = validateRecordsResolved(edgeRoot, {
+      hooks: {
+        onWork: operation => {
+          if (operation === 'cycle-edge' || operation === 'edge-validation' || operation === 'superseded-edge') {
+            traversedOverflowEdges += 1
+          }
+        },
+      },
+    })
     assert.equal(edgeResult.valid, false)
     assert.equal(edgeResult.errors[0]?.code, 'CORPUS_SUPERSEDES_LIMIT')
+    assert.equal(traversedOverflowEdges, 0, 'supersession traversal continued after the edge budget failed')
 
     const artifactRoot = createRoot()
     for (const recordIndex of Array.from({ length: 201 }, (_, value) => value)) {

--- a/test/records.test.ts
+++ b/test/records.test.ts
@@ -2272,7 +2272,9 @@ describe('canonical records', () => {
       writeCanonicalRecord(root, {
         createdAt: timestampAt(index),
         id: `chain-${index}`,
-        ...(index === 0 ? {} : { supersedes: [`chain-${index - 1}`] }),
+        ...(index === 0
+          ? {}
+          : { supersedes: index === 999 ? [`chain-${index - 1}`, 'chain-0'] : [`chain-${index - 1}`] }),
       })
     }
 
@@ -2289,10 +2291,10 @@ describe('canonical records', () => {
     assert.deepEqual(Object.fromEntries(work), {
       'active-group-write': 1,
       'canonical-entry': 1000,
-      'cycle-edge': 999,
+      'cycle-edge': 1000,
       'duplicate-record': 1000,
-      'edge-validation': 999,
-      'superseded-edge': 999,
+      'edge-validation': 1000,
+      'superseded-edge': 1000,
     })
   })
 


### PR DESCRIPTION
## Summary

- replace source-text regex assertions with pass-scoped behavioural work observers
- count actual collection reads and writes for record and baseline accumulators
- cover exact supersession, workflow, and bounded directory work while preserving deterministic output
- keep observer mechanics internal, inactive when no observer is supplied, and absent from public declarations
- return ordinary result containers and preserve internal observer failures across every hook-enabled reader
- document the boundary between correctness work counts and benchmark budgets without regressing existing provenance

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test` — 546 passed, 2 established capability skips
- `bun run benchmark:check`
- `bun run build`
- `bun run check:package`
- `bun run check:publish` — expected refusal for already-published 0.2.0, gate exit 0
- `bun install --frozen-lockfile`
- six-role independent final review at `71f20d9`: SHIP with no P0–P3 findings

## Review evidence

The former group, error-array, Set, language-Map, and top-level-array copying patterns were reintroduced without changing instrumentation. The focused behavioural suite failed, then returned green after restoring bounded accumulation. Review follow-ups additionally proved that observer-free scans avoid per-entry callbacks, hook-enabled results remain ordinary cloneable values, and observer failures retain their original identity across validation, readers, graph assertions, and initialisation paths.

## Merge order

- based directly on `main` after merged PR #59
- Linear: MAR-2568

## Checklist

- [x] Tests cover the behaviour change
- [x] Documentation matches the current implementation
- [x] Public declarations and package surface are unchanged
- [x] No lockfile, package, or TypeScript configuration drift
