### PR TITLE
[MAR-2549] Preserve exclusive gate recovery state

### DIFF
--- a/src/lock.ts
+++ b/src/lock.ts
@@ -303,7 +303,7 @@ export const withOperationLock = <Result>(
 
   const beginGateTransaction = (primary: GatePrimary) => {
     try {
-      gate = openVerifiedCacheDatabase({
+      const opened = openVerifiedCacheDatabase({
         afterVerifiedOpen: database => {
           database.exec('BEGIN IMMEDIATE')
         },
@@ -313,14 +313,16 @@ export const withOperationLock = <Result>(
         openOptions: { timeout: remainingMilliseconds() },
         preserveDatabaseLocksAfterInitialisation: true,
         primary,
-      }).database
+      })
+      gate = opened.database
+      gateTransaction = true
+      return opened.identity
     } catch (error) {
       if (error instanceof CacheDatabaseCreationConflict) {
         return operationGateChanged()
       }
       throw error
     }
-    gateTransaction = true
   }
 
   const releaseGate = () => {
@@ -342,18 +344,18 @@ export const withOperationLock = <Result>(
 
   const beginGateWhileRecoveryOwned = (ownedMarker: OwnedRecoveryMarker, primary: GatePrimary) => {
     let owned = false
-    beginGateTransaction(primary)
+    const database = beginGateTransaction(primary)
     if (recoveryMarkerIsOwned(ownedMarker)) {
       owned = true
     } else {
       releaseGate()
     }
-    return owned
+    return { acquired: owned, database }
   }
 
   const attemptGateWhileOwned = (ownedMarker: OwnedRecoveryMarker, primary: GatePrimary) => {
     try {
-      return { acquired: beginGateWhileRecoveryOwned(ownedMarker, primary), category: undefined }
+      return { ...beginGateWhileRecoveryOwned(ownedMarker, primary), category: undefined }
     } catch (error) {
       const category = sqliteFailureCategory(error)
       if (category === 'busy' || category === 'locked') {
@@ -364,6 +366,8 @@ export const withOperationLock = <Result>(
       return { acquired: false, category, error }
     }
   }
+
+  let nextGatePrimary: GatePrimary = { kind: 'create-if-missing' }
 
   const acquireRecoveryMarker = (): OwnedRecoveryMarker => {
     let ownedMarker: OwnedRecoveryMarker | undefined
@@ -420,8 +424,9 @@ export const withOperationLock = <Result>(
   const acquireGateWhileOwned = (ownedMarker: OwnedRecoveryMarker) => {
     let acquired = false
     if (recoveryMarkerIsOwned(ownedMarker)) {
-      const initial = attemptGateWhileOwned(ownedMarker, { kind: 'create-if-missing' })
-      if (initial.error === undefined) {
+      const initial = attemptGateWhileOwned(ownedMarker, nextGatePrimary)
+      if ('database' in initial) {
+        nextGatePrimary = { database: initial.database, kind: 'expected-owned' }
         ;({ acquired } = initial)
       } else {
         const recoverable = initial.category === 'corrupt' || initial.category === 'notadb'
@@ -431,16 +436,19 @@ export const withOperationLock = <Result>(
               database: initial.error.database,
               kind: 'expected-owned',
             })
-            if (confirmed.error === undefined) {
+            if ('database' in confirmed) {
+              nextGatePrimary = { database: confirmed.database, kind: 'expected-owned' }
               ;({ acquired } = confirmed)
             } else {
               const confirmedRecoverable = confirmed.category === 'corrupt' || confirmed.category === 'notadb'
               if (confirmedRecoverable) {
                 if (recoveryMarkerIsOwned(ownedMarker)) {
                   quarantineCorruptGate(confirmed.error)
+                  nextGatePrimary = { kind: 'create-exclusive' }
                   if (recoveryMarkerIsOwned(ownedMarker)) {
-                    const retried = attemptGateWhileOwned(ownedMarker, { kind: 'create-exclusive' })
-                    if (retried.error === undefined) {
+                    const retried = attemptGateWhileOwned(ownedMarker, nextGatePrimary)
+                    if ('database' in retried) {
+                      nextGatePrimary = { database: retried.database, kind: 'expected-owned' }
                       ;({ acquired } = retried)
                     } else {
                       throw retried.error

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -4947,6 +4947,58 @@ describe('SQLite cache and reads', () => {
     assert.equal(replacementObservations, 1)
   })
 
+  test('rejects a successor inserted after gate quarantine and recovery ownership loss', () => {
+    const root = createRoot()
+    const cachePath = cacheDirectoryPath(root)
+    const gatePath = join(cachePath, 'operation-lock.sqlite')
+    const recoveryPath = join(cachePath, 'operation-lock.recovery')
+    mkdirSync(cachePath, { recursive: true })
+    writeFileSync(gatePath, 'not a sqlite database')
+    let operationEntered = false
+    let replacementObservations = 0
+    let successorIdentity: { dev: bigint; ino: bigint } | undefined
+    cacheLocationTestHooks.afterQuarantineRename = path => {
+      if (successorIdentity === undefined && basename(path).includes('.operation-lock.sqlite.')) {
+        const successor = new DatabaseSync(gatePath)
+        successor.close()
+        successorIdentity = statSync(gatePath, { bigint: true })
+        writeFileSync(
+          join(recoveryPath, 'owner.json'),
+          `${JSON.stringify({ acquiredAt: new Date().toISOString(), pid: process.pid, token: 'gate-successor' })}\n`,
+        )
+      }
+    }
+
+    assert.throws(
+      () =>
+        withOperationLock(
+          root,
+          () => {
+            operationEntered = true
+            return 'entered'
+          },
+          {
+            duringRecoveryObservation: () => {
+              replacementObservations += 1
+              rmSync(recoveryPath, { recursive: true })
+            },
+          },
+        ),
+      (error: unknown) => {
+        assert.equal((error as { code?: unknown }).code, 'REPOSITORY_CHANGED')
+        assert.deepEqual((error as { details?: unknown }).details, {
+          entry: 'node_modules/.cache/encephalon/operation-lock.sqlite',
+          invariant: 'stable-identity',
+        })
+        return true
+      },
+    )
+    assert.equal(operationEntered, false)
+    assert.equal(replacementObservations, 1)
+    assert.ok(successorIdentity !== undefined)
+    assert.equal(sameCacheEntryIdentity(successorIdentity, statSync(gatePath, { bigint: true })), true)
+  })
+
   test('reacquires recovery ownership lost after the recovered gate begins', () => {
     const root = createRoot()
     const cachePath = cacheDirectoryPath(root)


### PR DESCRIPTION
## Summary

- preserve the exclusive-creation requirement after a corrupt operation gate is quarantined
- bind every successful gate retry to the exact verified gate generation
- reject an externally inserted successor with the existing REPOSITORY_CHANGED classification

## Changes

- retain the verified gate identity after BEGIN IMMEDIATE
- carry create-exclusive and expected-owned state across recovery-marker ownership loss
- add a deterministic regression test for successor insertion between quarantine and recovery reacquisition

## Compatibility

- public API signatures, CLI behaviour, package exports, and successful operation-lock behaviour are unchanged
- the failing subsystem keeps the existing REPOSITORY_CHANGED code and stable-identity details
- recovery remains bounded and existing safe ownership-reacquisition paths remain supported

## Validation

- 487 tests passed with 2 established filesystem-capability skips and 0 failures on macOS Node 24
- the complete Linux matrix passed on Node 24 and Node 26 with 485 passes, 4 established skips, and 0 failures
- lint, all TypeScript projects, benchmarks, build, package checks, diff checks, and repository validation passed
- six-role specialist review completed with no findings

## Review

- this is a narrowly scoped follow-up to MAR-2549 discovered during the ordered PR #55 review
- the ticket queue remains paused until this PR, its bot review, its CI, and subsequent main CI are fully green