### PR TITLE
[MAR-2552] Stabilise Windows benchmark worker test

### DIFF
--- a/test/benchmark.test.ts
+++ b/test/benchmark.test.ts
@@ -36,6 +36,7 @@ import { createTestRepository, removeTestRepository } from './helpers.ts'
 
 const fixtureWorker = join(import.meta.dirname, 'fixtures', 'benchmark-worker.ts')
 const realWorker = join(import.meta.dirname, '..', 'scripts', 'benchmark-worker.ts')
+const realWorkerExitTimeoutMilliseconds = process.platform === 'win32' ? 10_000 : 5000
 const benchmarkScript = join(import.meta.dirname, '..', 'scripts', 'benchmark.ts')
 const privateRenameGuard = join(import.meta.dirname, 'fixtures', 'require-private-benchmark-rename.ts')
 
@@ -426,14 +427,14 @@ describe('isolated benchmark authority', () => {
         operation: 'coldHydrate',
         records: 0,
         root,
-        timeoutMilliseconds: 5000,
+        timeoutMilliseconds: realWorkerExitTimeoutMilliseconds,
         workerPath: realWorker,
       })
       const unchanged = await runBenchmarkWorker({
         operation: 'unchangedPrepare',
         records: 0,
         root,
-        timeoutMilliseconds: 5000,
+        timeoutMilliseconds: realWorkerExitTimeoutMilliseconds,
         workerPath: realWorker,
       })
       for (const result of [cold, unchanged]) {
@@ -445,14 +446,14 @@ describe('isolated benchmark authority', () => {
         operation: 'fullSearch',
         records: 0,
         root,
-        timeoutMilliseconds: 5000,
+        timeoutMilliseconds: realWorkerExitTimeoutMilliseconds,
         workerPath: realWorker,
       })
       const second = await runBenchmarkWorker({
         operation: 'fullSearch',
         records: 0,
         root,
-        timeoutMilliseconds: 5000,
+        timeoutMilliseconds: realWorkerExitTimeoutMilliseconds,
         workerPath: realWorker,
       })
       assert.notEqual(first.processId, second.processId)


### PR DESCRIPTION
## Human summary

Prevents an intermittent Windows CI failure by allowing the benchmark test more time to start and close child processes, while keeping a strict test-only limit and leaving production behaviour unchanged.

## Summary

- raises only the real benchmark worker test's Windows lifecycle bound from 5 seconds to 10 seconds
- retains the existing 5-second bound on Linux and macOS and the production benchmark default of 30 seconds
- preserves the existing memory-isolation, additive-phase, process-identity, timeout, abort, and clean-close assertions
- fixes the failure from main CI run `32616092972`, where an unusually slow Windows host exceeded the test-only 5-second limit
- remains fully backwards compatible: no source, public API, CLI, package, persistence, or runtime behaviour changes

### Review

- six final exact-head reviewers returned `SHIP`
- security, correctness, race/data consistency, test coverage, maintainability, and UX/API compatibility reported no P0-P3 findings

### Verification

- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run typecheck`
- `bun run test` — 552 tests, 550 passed, 2 intentional skips
- `bun run benchmark:check`
- `bun run build`
- `bun run check:package`
- `bun run check:publish` — expected refusal for already-published version `0.2.0`
- `node dist/cli.mjs validate` — 38 records checked, 0 errors
- focused real-worker phase test
- `git diff --check origin/main...HEAD`
