### PR TITLE
[MAR-2787] Stream strict cache and FTS equivalence

### DIFF
--- a/encephalon/architecture/89820a16-b53f-4109-acc8-c656c4fb2b06.json
+++ b/encephalon/architecture/89820a16-b53f-4109-acc8-c656c4fb2b06.json
@@ -1,0 +1,30 @@
+{
+  "createdAt": "2026-09-10T12:13:59.909Z",
+  "id": "89820a16-b53f-4109-acc8-c656c4fb2b06",
+  "kind": "architecture",
+  "payload": {
+    "summary": "Share one immutable operation-local VerifiedCorpus and stream strict cache equivalence for each accepted canonical generation.",
+    "authority": [
+      "Reuse ID, case-path, supersession, active-head and artifact indexes across validation, planning and cache operations.",
+      "Bind relative canonical paths to accepted raw SHA-256 witnesses with the domain-separated version-2 fingerprint; do not recursively hash normalised payloads.",
+      "Freeze owned payloads during parser exit actions, preserve mutable independent public results, and capture fixed publication evidence for committed assertions."
+    ],
+    "cache": [
+      "Fresh reads require complete canonical equality in the same verified read transaction as the query, even when cached metadata copies the canonical fingerprint.",
+      "Stream ID-ordered record comparisons and key-only FTS rowid lookups. Retain bounded membership and active bits, never a second parsed corpus or expected-document buffer map.",
+      "Compare scalar and FTS bytes inside SQLite. Exact writer JSON avoids a second parse; alternate valid UTF-8 representations retain existing structural and signed-zero normalisation semantics.",
+      "Compute strict-validation body and preview projections without populating corpus-wide memoised strings; ordinary projection consumers retain their existing memoisation.",
+      "Bound posting and auxiliary shadow row counts, per-value bytes and aggregate storage before native read-only FTS integrity checking; native integrity supplements exact canonical projection identity.",
+      "Writer predecessors may be validated canonical subsets: check their own active flags and fingerprint their accepted member witnesses in existing canonical path order before replacement.",
+      "Reuse a replacement corpus during disposable recovery only after its generation assertion succeeds."
+    ],
+    "scope": [
+      "Keep existing filesystem proof passes, graph/error budgets, numeric-first SQL admission, schema 3 and independent mutable public results.",
+      "Recover incompatible disposable caches through the existing locked quarantine/rebuild path; no new metadata fields, global cache or public exports."
+    ]
+  },
+  "searchText": "verified corpus strict streaming raw digest fingerprint cache predecessor subset native FTS integrity bounds MAR-2787",
+  "source": "agent",
+  "subject": "canonical.verified-corpus",
+  "supersedes": ["1228daeb-c260-4542-b798-9d828ce95cd9"]
+}

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,3 +1,4 @@
+import { isUtf8 } from 'node:buffer'
 import { type BigIntStats, lstatSync, realpathSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { resolve } from 'node:path'
@@ -40,9 +41,8 @@ import { manifestEntryMetadataFrom, sameStableEntryMetadata } from './filesystem
 import { PACKAGE_VERSION } from './generated/version.ts'
 import { withOperationLock } from './lock.ts'
 import { OPERATION_BUDGETS } from './operation-budgets.ts'
-import { ordinalStringCompare } from './order.ts'
 import { recordCorpusFingerprint } from './record-corpus-fingerprint.ts'
-import { MAX_SEARCH_PREVIEW_BYTES } from './record-projection.ts'
+import { MAX_SEARCH_PREVIEW_BYTES, searchDocumentForRecord, searchPreviewForRecord } from './record-projection.ts'
 import {
   canonicalCacheManifest,
   canonicalRecordPath,
@@ -88,6 +88,9 @@ const MAX_CACHE_SEARCH_DOCUMENT_AGGREGATE_BYTES =
 const MAX_CACHE_FTS_ID_BYTES = CANONICAL_BUDGETS.records * 255
 const MAX_CACHE_SEARCH_PREVIEW_BYTES = MAX_SEARCH_PREVIEW_BYTES
 const MAX_CACHE_SEARCH_PREVIEW_AGGREGATE_BYTES = CANONICAL_BUDGETS.records * MAX_CACHE_SEARCH_PREVIEW_BYTES
+const MAX_CACHE_SEARCH_INDEX_BYTES = MAX_CACHE_SEARCH_DOCUMENT_AGGREGATE_BYTES * 2
+// The writer uses FTS5's default ~4 KiB pages. Allow 1 KiB packing plus per-record tails.
+const MAX_CACHE_SEARCH_INDEX_ROWS = Math.ceil(MAX_CACHE_SEARCH_INDEX_BYTES / 1024) + CANONICAL_BUDGETS.records
 const METADATA_KEYS = [
   'artifactPaths',
   'manifest',
@@ -1215,6 +1218,60 @@ const assertCacheScope = (root: string, metadata: Metadata | undefined) => {
   }
 }
 
+function* cachedRecordWitnesses(snapshot: VerifiedCorpus, members: ReadonlyMap<string, 0 | 1>) {
+  for (const record of snapshot.recordsByPath) {
+    if (members.has(record.id)) {
+      yield snapshot.recordFacts(record)
+    }
+  }
+}
+
+const assertSearchIndexBounded = (database: DatabaseSync) => {
+  const tables = [
+    {
+      maximumRows: MAX_CACHE_SEARCH_INDEX_ROWS,
+      sql: `SELECT typeof(id) = 'integer' AND typeof(block) = 'blob' AS valid,
+        octet_length(block) AS bytes FROM record_search_data LIMIT ?`,
+    },
+    {
+      maximumRows: MAX_CACHE_SEARCH_INDEX_ROWS,
+      sql: `SELECT typeof(segid) = 'integer' AND typeof(pgno) = 'integer'
+          AND typeof(term) = 'blob' AS valid,
+        octet_length(term) AS bytes FROM record_search_idx LIMIT ?`,
+    },
+    {
+      maximumRows: CANONICAL_BUDGETS.records,
+      sql: `SELECT typeof(id) = 'integer' AND typeof(sz) = 'blob' AS valid,
+        octet_length(sz) AS bytes FROM record_search_docsize LIMIT ?`,
+    },
+    {
+      maximumRows: CANONICAL_BUDGETS.records,
+      sql: `SELECT typeof(k) = 'text' AND typeof(v) IN ('integer', 'text') AS valid,
+        octet_length(k) + octet_length(v) AS bytes FROM record_search_config LIMIT ?`,
+    },
+  ]
+  let totalBytes = 0
+  for (const { sql, maximumRows } of tables) {
+    let rows = 0
+    const sizes = database.prepare(sql).iterate(maximumRows + 1) as Iterable<{ bytes?: unknown; valid?: unknown }>
+    for (const row of sizes) {
+      rows += 1
+      if (
+        rows > maximumRows ||
+        row.valid !== 1 ||
+        typeof row.bytes !== 'number' ||
+        !Number.isSafeInteger(row.bytes) ||
+        row.bytes < 0 ||
+        row.bytes > MAX_CACHE_RECORD_BYTES ||
+        row.bytes > MAX_CACHE_SEARCH_INDEX_BYTES - totalBytes
+      ) {
+        throw new CacheSchemaMismatch('The cache search index exceeds its storage bounds.')
+      }
+      totalBytes += row.bytes
+    }
+  }
+}
+
 const assertCacheContentConsistent = (database: DatabaseSync, metadata: Metadata, snapshot: VerifiedCorpus) => {
   const maximumRows = CANONICAL_BUDGETS.records + 1
   const recordsProbe = readIntegrityProbe(
@@ -1280,81 +1337,86 @@ const assertCacheContentConsistent = (database: DatabaseSync, metadata: Metadata
   }
   cacheReadTestHooks.beforeIntegrityTextRead?.('records')
   const recordRows = database
-    .prepare('SELECT id, kind, subject, source, created_at, path, active, summary, record_json FROM records LIMIT ?')
-    .iterate(maximumRows) as Iterable<
-    RecordRow & {
-      active?: unknown
-      created_at?: unknown
-      id?: unknown
-      kind?: unknown
-      path?: unknown
-      source?: unknown
-      subject?: unknown
-      summary?: unknown
-    }
-  >
-  const records = Array.from(recordRows, row => ({
-    record: parseCachedRecord(row.record_json),
-    row,
-  }))
-  const superseded =
-    records.length === snapshot.records.length
-      ? snapshot.supersededIds
-      : new Set(records.flatMap(({ record }) => record.supersedes ?? []))
-  for (const { record, row } of records) {
-    const canonical = snapshot.byId.get(record.id)
-    if (canonical === undefined || !isDeepStrictEqual(record, canonical)) {
+    .prepare('SELECT id, active FROM records ORDER BY id COLLATE BINARY LIMIT ?')
+    .iterate(maximumRows) as Iterable<{
+    active?: unknown
+    id?: unknown
+  }>
+  // One bounded identity/active-bit map also tracks unmatched FTS rows; it never retains documents.
+  const members = new Map<string, 0 | 1>()
+  const subsetSuperseded = recordsProbe.rows === snapshot.records.length ? undefined : new Set<string>()
+  const representation = database.prepare(`SELECT
+    CASE WHEN CAST(record_json AS BLOB) = CAST(?1 AS BLOB) THEN NULL
+      ELSE CAST(record_json AS BLOB) END AS mismatch_bytes,
+    CAST(id AS BLOB) = CAST(?2 AS BLOB) AND CAST(kind AS BLOB) = CAST(?3 AS BLOB)
+      AND CAST(subject AS BLOB) = CAST(?4 AS BLOB) AND CAST(source AS BLOB) = CAST(?5 AS BLOB)
+      AND CAST(created_at AS BLOB) = CAST(?6 AS BLOB) AND CAST(path AS BLOB) = CAST(?7 AS BLOB)
+      AND (CAST(summary AS BLOB) IS CAST(?8 AS BLOB)) AS projection_matches
+    FROM records WHERE id = ?2`)
+  for (const row of recordRows) {
+    const canonical = typeof row.id === 'string' ? snapshot.byId.get(row.id) : undefined
+    if (canonical === undefined || members.has(canonical.id)) {
       throw new CacheSchemaMismatch('The cache record table does not match the canonical record corpus.')
     }
-    const active = superseded.has(record.id) ? 0 : 1
+    // The writer's exact representation needs no transfer or parse. Preserve structural and
+    // normalisation compatibility for other encodings with the existing bounded parser.
+    const { summary } = snapshot.recordFacts(canonical).projection
+    const encoded = representation.get(
+      JSON.stringify(canonical),
+      canonical.id,
+      canonical.kind,
+      canonical.subject,
+      canonical.source,
+      canonical.createdAt,
+      canonical.path,
+      summary,
+    ) as { mismatch_bytes?: unknown; projection_matches?: unknown } | undefined
     if (
-      row.id !== record.id ||
-      row.kind !== record.kind ||
-      row.subject !== record.subject ||
-      row.source !== record.source ||
-      row.created_at !== record.createdAt ||
-      row.path !== record.path ||
-      row.active !== active ||
-      row.summary !== snapshot.recordFacts(canonical).projection.summary
+      encoded === undefined ||
+      (encoded.mismatch_bytes !== null &&
+        !(
+          encoded.mismatch_bytes instanceof Uint8Array &&
+          isUtf8(encoded.mismatch_bytes) &&
+          isDeepStrictEqual(parseCachedRecord(Buffer.from(encoded.mismatch_bytes).toString('utf8')), canonical)
+        ))
+    ) {
+      throw new CacheSchemaMismatch('The cache record table does not match the canonical record corpus.')
+    }
+    // SQL bindings replace lone surrogates; byte equality must not relax the old scalar string equality.
+    if (
+      encoded.projection_matches !== 1 ||
+      !canonical.source.isWellFormed() ||
+      !canonical.subject.isWellFormed() ||
+      (summary !== null && !summary.isWellFormed()) ||
+      (row.active !== 0 && row.active !== 1)
     ) {
       throw new CacheSchemaMismatch('The cache record table does not match its canonical JSON.')
     }
+    members.set(canonical.id, row.active)
+    if (subsetSuperseded !== undefined) {
+      for (const id of canonical.supersedes ?? []) {
+        subsetSuperseded.add(id)
+      }
+    }
   }
-  // An existing writer cache can describe the accepted corpus before this operation's additions.
-  // Its rows must still match canonical records; hash that subset's accepted raw digests, never cached JSON.
-  const recordFingerprint =
-    records.length === snapshot.records.length
-      ? snapshot.recordFingerprint
-      : recordCorpusFingerprint(
-          records
-            .map(({ record }) => {
-              const canonical = snapshot.byId.get(record.id)
-              if (canonical !== undefined) {
-                return snapshot.recordFacts(canonical)
-              }
-              throw new CacheSchemaMismatch('The cache record table does not match the canonical record corpus.')
-            })
-            .sort((first, second) => ordinalStringCompare(first.path, second.path)),
-        )
-  if (metadata.recordFingerprint !== recordFingerprint) {
+  if (members.size !== recordsProbe.rows) {
     throw new CacheSchemaMismatch('The cache record table does not match the canonical record corpus.')
   }
-  const expectedSearchRows = new Map(
-    records.map(({ record }) => {
-      const canonical = snapshot.byId.get(record.id)
-      if (canonical !== undefined) {
-        const { projection } = snapshot.recordFacts(canonical)
-        return [
-          Buffer.from(record.id, 'utf8').toString('hex'),
-          {
-            preview: Buffer.from(projection.preview, 'utf8'),
-            text: Buffer.from(projection.text, 'utf8'),
-          },
-        ]
-      }
-      throw new CacheSchemaMismatch('The cache record table does not match the canonical record corpus.')
-    }),
-  )
+  const superseded = subsetSuperseded ?? snapshot.supersededIds
+  for (const [id, active] of members) {
+    if (active !== (superseded.has(id) ? 0 : 1)) {
+      throw new CacheSchemaMismatch('The cache record table does not match its canonical JSON.')
+    }
+  }
+  // A writer can replace a proper predecessor subset, but its active bits and raw witnesses
+  // must describe that subset. Full reads separately require complete snapshot metadata.
+  const fingerprint =
+    subsetSuperseded === undefined
+      ? snapshot.recordFingerprint
+      : recordCorpusFingerprint(cachedRecordWitnesses(snapshot, members))
+  if (metadata.recordFingerprint !== fingerprint) {
+    throw new CacheSchemaMismatch('The cache record table does not match the canonical record corpus.')
+  }
   const searchProbe = readIntegrityProbe(
     'record-search',
     database
@@ -1400,33 +1462,50 @@ const assertCacheContentConsistent = (database: DatabaseSync, metadata: Metadata
   ) {
     throw new CacheSchemaMismatch('The cache record and search tables are inconsistent.')
   }
-  cacheReadTestHooks.beforeIntegrityTextRead?.('record-search')
-  const searchRows = database
-    .prepare(`SELECT CAST(id AS BLOB) AS id_bytes, CAST(text AS BLOB) AS text_bytes,
-      CAST(preview AS BLOB) AS preview_bytes FROM record_search LIMIT ?`)
-    .iterate(maximumRows) as Iterable<{ id_bytes?: unknown; text_bytes?: unknown; preview_bytes?: unknown }>
-  for (const row of searchRows) {
-    if (
-      !(
-        row.id_bytes instanceof Uint8Array &&
-        row.text_bytes instanceof Uint8Array &&
-        row.preview_bytes instanceof Uint8Array
-      )
-    ) {
-      throw new CacheSchemaMismatch('The cache record and search tables are inconsistent.')
-    }
-    const idBytes = Buffer.from(row.id_bytes)
-    const expected = expectedSearchRows.get(idBytes.toString('hex'))
-    if (
-      expected === undefined ||
-      !expected.text.equals(Buffer.from(row.text_bytes)) ||
-      !expected.preview.equals(Buffer.from(row.preview_bytes))
-    ) {
-      throw new CacheSchemaMismatch('The cache record and search tables are inconsistent.')
-    }
-    expectedSearchRows.delete(idBytes.toString('hex'))
+  assertSearchIndexBounded(database)
+  const integrity = database
+    .prepare("SELECT integrity_check = 'ok' AS valid FROM pragma_integrity_check('record_search') LIMIT 1")
+    .get() as { valid?: unknown } | undefined
+  if (integrity?.valid !== 1) {
+    throw new CacheSchemaMismatch('The cache search index is inconsistent.')
   }
-  if (expectedSearchRows.size !== 0) {
+  cacheReadTestHooks.beforeIntegrityTextRead?.('record-search')
+  // Sort keys only: including full FTS documents here would retain them in SQLite's sorter.
+  const searchKeys = database.prepare(`SELECT rowid AS search_rowid, CAST(id AS BLOB) AS id_bytes
+    FROM record_search ORDER BY CAST(id AS BLOB), rowid LIMIT ?`)
+  searchKeys.setReadBigInts(true)
+  const searchRows = searchKeys.iterate(maximumRows) as Iterable<{
+    id_bytes?: unknown
+    search_rowid?: unknown
+  }>
+  const searchContent = database.prepare(`SELECT
+      CAST(id AS BLOB) = CAST(? AS BLOB) AND CAST(text AS BLOB) = CAST(? AS BLOB)
+        AND CAST(preview AS BLOB) = CAST(? AS BLOB) AS matches
+    FROM record_search WHERE rowid = ?`)
+  let searchRowsRead = 0
+  for (const row of searchRows) {
+    if (!(row.id_bytes instanceof Uint8Array) || typeof row.search_rowid !== 'bigint') {
+      throw new CacheSchemaMismatch('The cache record and search tables are inconsistent.')
+    }
+    const id = Buffer.from(row.id_bytes).toString('utf8')
+    const canonical = snapshot.byId.get(id)
+    if (canonical === undefined || !members.has(id) || Buffer.compare(row.id_bytes, Buffer.from(id, 'utf8')) !== 0) {
+      throw new CacheSchemaMismatch('The cache record and search tables are inconsistent.')
+    }
+    const { summary } = snapshot.recordFacts(canonical).projection
+    const content = searchContent.get(
+      id,
+      searchDocumentForRecord(canonical, summary),
+      searchPreviewForRecord(canonical, summary),
+      row.search_rowid,
+    ) as { matches?: unknown } | undefined
+    if (content?.matches !== 1) {
+      throw new CacheSchemaMismatch('The cache record and search tables are inconsistent.')
+    }
+    members.delete(id)
+    searchRowsRead += 1
+  }
+  if (searchRowsRead !== searchProbe.rows || members.size !== 0) {
     throw new CacheSchemaMismatch('The cache record and search tables are inconsistent.')
   }
 }

--- a/src/record-projection.ts
+++ b/src/record-projection.ts
@@ -13,14 +13,14 @@ export const summaryForRecord = (record: BrainRecord) => {
   return null
 }
 
-const searchDocumentForRecord = (record: BrainRecord, summary: string | null) =>
+export const searchDocumentForRecord = (record: BrainRecord, summary: string | null) =>
   normalizeSearchText(
     [record.kind, record.subject, record.source, summary, JSON.stringify(record.payload), record.searchText ?? '']
       .filter((value): value is string => typeof value === 'string' && value.length > 0)
       .join('\n'),
   )
 
-const searchPreviewForRecord = (record: BrainRecord, summary: string | null) => {
+export const searchPreviewForRecord = (record: BrainRecord, summary: string | null) => {
   const preview = normalizeSearchText(
     [record.kind, record.subject, record.source, summary]
       .filter((value): value is string => typeof value === 'string' && value.length > 0)

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -7550,7 +7550,15 @@ describe('SQLite cache and reads', () => {
     mutateCache(root, database => {
       const stored = database.prepare('SELECT text FROM record_search').get()
       assert.ok(typeof stored?.text === 'string')
-      database.prepare('UPDATE record_search SET text = ?').run('wrongpostingmarker')
+      const statistics = () => ({
+        sizes: database.prepare('SELECT sz FROM record_search_docsize').get(),
+        totals: database.prepare('SELECT block FROM record_search_data WHERE id = 1').get(),
+      })
+      const before = statistics()
+      const wrongTerms = stored.text.replaceAll('corruption', 'wrongpostingmarker')
+      assert.notEqual(wrongTerms, stored.text)
+      database.prepare('UPDATE record_search SET text = ?').run(wrongTerms)
+      assert.deepEqual(statistics(), before)
       database.enableDefensive(false)
       database.prepare('UPDATE record_search_content SET c1 = ?').run(stored.text)
     })

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -7501,6 +7501,178 @@ describe('SQLite cache and reads', () => {
     }
   })
 
+  test('finishes strict row comparisons before advancing the SQLite iterator', () => {
+    const root = createRoot()
+    addCacheRecord(root)
+    api.addRecord({
+      id: 'cache-record-second',
+      kind: 'context',
+      payload: { summary: 'Second cache record' },
+      root,
+      source: 'agent',
+      subject: 'cache.validation.second',
+    })
+    const counts = { records: 0, search: 0 }
+    const { iterate } = StatementSync.prototype
+    const observed = mock.method(
+      StatementSync.prototype,
+      'iterate',
+      function* observedRows(this: StatementSync, ...parameters: Parameters<typeof iterate>) {
+        for (const row of iterate.apply(this, parameters)) {
+          const recordRow = Object.hasOwn(row, 'id') && Object.hasOwn(row, 'active')
+          const searchRow = Object.hasOwn(row, 'id_bytes')
+          if (recordRow || searchRow) {
+            counts[recordRow ? 'records' : 'search'] += 1
+            const { proxy, revoke } = Proxy.revocable(row, {})
+            try {
+              yield proxy
+            } finally {
+              revoke()
+            }
+          } else {
+            yield row
+          }
+        }
+      },
+    )
+
+    try {
+      assert.deepEqual(api.prepare({ root }), { hydrated: false, recordsIndexed: 2 })
+      assert.deepEqual(counts, { records: 2, search: 2 })
+    } finally {
+      observed.mock.restore()
+    }
+  })
+
+  test('recovers corrupt FTS postings even when their stored projection remains intact', () => {
+    const root = createRoot()
+    const expected = addCacheRecord(root)
+    mutateCache(root, database => {
+      const stored = database.prepare('SELECT text FROM record_search').get()
+      assert.ok(typeof stored?.text === 'string')
+      database.prepare('UPDATE record_search SET text = ?').run('wrongpostingmarker')
+      database.enableDefensive(false)
+      database.prepare('UPDATE record_search_content SET c1 = ?').run(stored.text)
+    })
+    let rebuilds = 0
+    cacheReadTestHooks.afterDisposableCacheRecoveryRebuild = () => {
+      rebuilds += 1
+    }
+
+    assert.deepEqual(api.prepare({ root }), { hydrated: true, recordsIndexed: 1 })
+    assert.equal(rebuilds, 1)
+    assert.deepEqual(api.searchRecords({ query: 'corruption', root }), [expected])
+  })
+
+  test('rejects oversized posting blocks and auxiliary values before native FTS validation', () => {
+    for (const mutation of [
+      'UPDATE record_search_data SET block = zeroblob(1052673) WHERE id > 10',
+      "UPDATE record_search_data SET block = replace(hex(zeroblob(1052673)), '00', 'x') WHERE id > 10",
+      'UPDATE record_search_docsize SET sz = zeroblob(1052673)',
+      "INSERT INTO record_search_config(k, v) VALUES ('private-padding', replace(hex(zeroblob(1052673)), '00', 'x'))",
+    ]) {
+      const root = createRoot()
+      addCacheRecord(root)
+      mutateCache(root, database => {
+        database.enableDefensive(false)
+        database.exec(mutation)
+      })
+      let recovered = false
+      let nativeChecksBeforeRecovery = 0
+      cacheReadTestHooks.afterDisposableCacheRecoveryRebuild = () => {
+        recovered = true
+      }
+      const { prepare } = DatabaseSync.prototype
+      const observed = mock.method(
+        DatabaseSync.prototype,
+        'prepare',
+        function observe(this: DatabaseSync, sql: string) {
+          if (!recovered && sql.includes('pragma_integrity_check')) {
+            nativeChecksBeforeRecovery += 1
+          }
+          return prepare.call(this, sql)
+        },
+      )
+
+      try {
+        assert.deepEqual(api.prepare({ root }), { hydrated: true, recordsIndexed: 1 })
+        assert.equal(nativeChecksBeforeRecovery, 0)
+      } finally {
+        observed.mock.restore()
+      }
+    }
+  })
+
+  test('accepts reordered cached JSON with equivalent signed-zero values without rebuilding', () => {
+    const root = createRoot()
+    const expected = api.addRecord({
+      confidence: 0,
+      id: 'cached-json-normalisation',
+      kind: 'context',
+      payload: { numbers: [0, { zero: 0 }], summary: 'Numeric cache equivalence' },
+      root,
+      source: 'agent',
+      subject: 'cache.normalisation',
+    })
+    mutateCache(root, database => {
+      const row = database.prepare('SELECT record_json FROM records').get()
+      assert.ok(typeof row?.record_json === 'string')
+      const parsed = JSON.parse(row.record_json) as Record<string, unknown>
+      const reordered = Object.fromEntries(Object.entries(parsed).reverse())
+      const encoded = JSON.stringify(reordered).replaceAll('":0', '":-0').replace('[0,', '[-0,')
+      database.prepare('UPDATE records SET record_json = ?').run(encoded)
+    })
+
+    assert.deepEqual(api.prepare({ root }), { hydrated: false, recordsIndexed: 1 })
+    assert.deepEqual(api.listRecords({ root }), [expected])
+  })
+
+  test('rejects invalid cached JSON and scalar bytes that decode to canonical replacement characters', () => {
+    for (const column of ['record_json', 'subject']) {
+      const root = createRoot()
+      const expected = api.addRecord({
+        id: 'cached-record-encoding',
+        kind: 'context',
+        payload: { marker: '�' },
+        root,
+        source: 'agent',
+        subject: 'cache.�',
+      })
+      mutateCache(root, database => {
+        const row = database.prepare(`SELECT CAST(${column} AS BLOB) AS bytes FROM records`).get()
+        assert.ok(row?.bytes instanceof Uint8Array)
+        const bytes = Buffer.from(row.bytes)
+        const replacement = Buffer.from('�', 'utf8')
+        const offset = bytes.indexOf(replacement)
+        assert.notEqual(offset, -1)
+        const invalid = Buffer.concat([
+          bytes.subarray(0, offset),
+          Buffer.from([0x80]),
+          bytes.subarray(offset + replacement.length),
+        ])
+        database.prepare(`UPDATE records SET ${column} = CAST(? AS TEXT)`).run(invalid)
+      })
+
+      assert.deepEqual(api.prepare({ root }), { hydrated: true, recordsIndexed: 1 }, column)
+      assert.deepEqual(api.listRecords({ root }), [expected], column)
+    }
+  })
+
+  test('keeps rejecting canonical scalar text that cannot round-trip through SQLite UTF-8', () => {
+    const root = createRoot()
+    api.addRecord({
+      id: 'unpaired-scalar',
+      kind: 'context',
+      payload: { summary: 'Unpaired scalar encoding' },
+      root,
+      source: 'agent',
+      subject: 'cache.\ud800',
+    })
+
+    assert.deepEqual(api.prepare({ root }), { hydrated: true, recordsIndexed: 1 })
+    assert.throws(() => api.listRecords({ root }), { code: 'INTERNAL_ERROR' })
+  })
+
   test('bounds cached record validation before transferring untrusted rows', () => {
     const cases = [
       {


### PR DESCRIPTION
## Summary

Cache-backed reads currently retain a second parsed record corpus and a complete map of expected FTS buffers. This change compares records and search projections incrementally against the accepted immutable `VerifiedCorpus`, retaining only bounded membership and active-state information.

Native read-only FTS integrity checking now detects corrupt postings even when stored text still matches the canonical projection. Numeric shadow-storage admission bounds row counts, individual values and aggregate bytes before that check.

## Problem

Strict validation retains both canonical records and their parsed SQLite copies, plus every expected FTS body. The 1,000-record strict-read baseline peaks at 187,793,408 bytes.

## Design

Prepared SQLite predicates compare matching canonical JSON and scalar bytes without transferring document text. Alternative equivalent JSON retains the existing parser and equality checks. Validation and the requested query stay in the existing verified transaction. Direct-column `octet_length` bounds native inputs without loading whole values to count their bytes.

## Scope

- Stream records in primary-key order and sort only FTS IDs/rowids. Compare canonical JSON, scalar fields and search projection bytes inside SQLite; preserve the existing parser for equivalent alternate JSON representations.
- Preserve arbitrary canonical predecessor subsets for writer replacement, including their own active flags and path-ordered raw fingerprints.
- Generate strict-validation body/preview values without warming the corpus-wide memoised projections.
- Reject malformed cached UTF-8 that would otherwise decode to canonical replacement characters, while preserving previous lone-surrogate scalar behaviour.
- Add six complementary regressions for row lifetime, corrupt postings, native input admission, JSON normalisation and encoding boundaries.
- Replace the durable VerifiedCorpus architecture record with `89820a16-b53f-4109-acc8-c656c4fb2b06`.

## Deliberately excluded

Canonical/artifact proof-pass changes belong to MAR-2788. Schema minimisation and removal of `record_json` belong to MAR-2789. Existing proof passes, schema 3, search ranking and snippets remain unchanged.

## Compatibility

The synchronous ESM API, CLI output, Node 24.15.0 minimum, zero runtime dependencies and public product bounds remain unchanged. Minimum-Node tests against the integrity-pinned published `encephalon@0.3.0` passed upgrade and downgrade (schema 2 → 3 → 2), preserving all six durable files byte-for-byte. Packed CLI prepare/list/show/search/gather/hydrate each recovered from wrong postings with intact stored text.

## Performance

Base: `e84074679d3e585dd264db805bcdbf8844c03d3a`. Measured implementation: `5b39970d68dcd09215027f9082acf3daedd94929`. Final local head: `0f5b55ff88a9b01d364101fa3aa9d226ad747750`; its only additional change strengthens a regression test. Production source and benchmark harness are identical to the measured implementation.

One macOS arm64 runner, Node 26.5.0, identical accepted MAR-2784 harness and fixture, 20 alternating samples plus two warmups: 15 workloads, 600 raw reports, all 53 regression metrics passed. Harness SHA-256: `7143ad061631aba5380340cebdd622c3c1052dd2ea5a861180b94dbb530531a2`.

| Metric | Base | Head |
|---|---:|---:|
| Strict-read median | 417.939 ms | 419.388 ms |
| Strict-read p95 | 426.459 ms | 441.474 ms |
| Strict-read peak RSS | 187,793,408 B | 153,075,712 B |
| Cache size | 8,364,032 B | 8,364,032 B |
| Packed JavaScript | 913,327 B | 920,217 B |
| Declarations | 26,529 B | 26,734 B |
| Tarball | 365,646 B | 367,265 B |

Peak RSS fell **18.4872%**. Isaac accepted this measured improvement on 10 September 2026. Linear now records that acceptance for MAR-2787; the combined 30% target carries into MAR-2788 against the same pre-MAR-2787 baseline. Existing regression budgets remain unchanged.

## Verification

All local scripts passed: build, lint, four typechecks, 822 runtime tests (three existing skips), 91 tooling tests, representative benchmark, generated version, package/publish guard and canonical validation (46 records). Additional minimum-Node tests passed.

Maximum-writer admission evidence uses three 1,000-record corpora at 8,192,000 canonical bytes, including unique terms, repeated positions and Unicode expansion. All remain fresh after writing. Twenty-four overwrites of the unique-term corpus also pass; the largest observed posting storage is 53,034,722 bytes, below the admission budget.

- `bun run build`, `bun run lint`, `bun run typecheck`, `bun run test`, `bun run test:tooling`: passed. Fresh lint, all four typechecks and both test scripts also passed after the final test refinement.
- `bun run benchmark:check`, `bun run check:generated`, `node dist/cli.mjs validate --root .`, `git diff --check`: passed.
- `node scripts/check-package.ts --retain-tarball package-artifacts`: exact final-head package retained and verified, 367,265 bytes, SHA-256 `76fd621ed98542bffbd8397ecc53bccb1352af6d1f544bf023adba27cc7d03b5`.
- `node scripts/check-publish.ts package-artifacts/encephalon-0.3.0.tgz`: guard passed with the expected already-published-version refusal; no real publication.
- Matched benchmark audit: 600 raw reports, 53 metrics, no regression-budget violations.
- Native SQL byte-equality oracle: 108 cases on each of Node 24.15.0 and 26.5.0.
- Independent Pro review completed; native input-admission findings were corrected and verified.

Exact-head CI and Greptile 5/5 are required before merging, with the branch containing latest main.

## Risk and rollback

Native FTS admission can rebuild a disposable index whose accumulated storage exceeds its explicit resource budget. Representative maximum corpora and overwrite histories pass; these measurements are not a universal bound on every possible writer history. Malformed cache data follows bounded recovery or fails closed. Rollback restores the previous validator without a canonical migration.

## Linear

Linear: https://linear.app/marcoappio/issue/MAR-2787/cache-stream-strict-cache-and-fts-equivalence-against-verifiedcorpus


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reduces strict cache-validation memory usage by streaming record and FTS comparisons against the immutable `VerifiedCorpus`.

- Compares canonical records and search projections incrementally inside SQLite.
- Validates FTS shadow-storage bounds and native index integrity before accepting cached search data.
- Preserves predecessor-subset fingerprints, active-state semantics, alternate JSON representations, and encoding boundaries.
- Adds focused regression coverage for row lifetimes, corrupt postings, bounds, normalization, and malformed UTF-8.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The streaming record comparisons, predecessor-subset handling, encoding checks, and FTS integrity validation remain consistent with the cache writer and recovery contracts.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/cache.ts | Reworks strict cache equivalence into bounded streaming comparisons and adds native FTS integrity and shadow-storage admission checks; no actionable defect was established. |
| src/record-projection.ts | Exports existing projection helpers so strict validation can compute individual projections without warming corpus-wide memoized values. |
| test/cache.test.ts | Adds regressions covering iterator row lifetime, corrupt FTS postings, native-input bounds, JSON equivalence, and malformed encoding behavior. |
| encephalon/architecture/89820a16-b53f-4109-acc8-c656c4fb2b06.json | Records the streaming `VerifiedCorpus` cache-validation architecture and supersedes the previous durable architecture entry. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Open verified cache transaction] --> B[Probe records and metadata bounds]
  B --> C[Stream records by binary ID]
  C --> D[Compare JSON, scalar bytes, active state, and fingerprint]
  D --> E[Probe FTS content and shadow-table bounds]
  E --> F[Run native FTS integrity check]
  F --> G[Stream FTS keys and compare projections]
  G --> H{All members matched?}
  H -->|Yes| I[Execute requested cache query]
  H -->|No| J[Quarantine and rebuild disposable cache]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["\[MAR-2787\] Prove posting validation with..."](https://github.com/isaachinman/encephalon/commit/0f5b55ff88a9b01d364101fa3aa9d226ad747750) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62613906)</sub>

<!-- /greptile_comment -->