### PR TITLE
[MAR-2789] Reduce SQLite to its search and ordering projection

### DIFF
--- a/encephalon/architecture/07a820c8-c399-4c7c-8bbc-7a20be8683f0.json
+++ b/encephalon/architecture/07a820c8-c399-4c7c-8bbc-7a20be8683f0.json
@@ -1,0 +1,39 @@
+{
+  "createdAt": "2026-09-10T16:35:32.130Z",
+  "id": "07a820c8-c399-4c7c-8bbc-7a20be8683f0",
+  "kind": "architecture",
+  "payload": {
+    "summary": "Reuse one immutable verified canonical corpus and a minimal SQLite identity, filter, ordering and FTS projection for each accepted operation.",
+    "authority": [
+      "Reuse ID, case-path, supersession, active-head and artifact indexes across validation, planning and cache operations.",
+      "Bind relative canonical paths to accepted raw SHA-256 witnesses with the domain-separated version-2 fingerprint; do not recursively hash normalised payloads.",
+      "Freeze owned payloads during parser exit actions, preserve mutable independent public results, and capture fixed publication evidence for committed assertions."
+    ],
+    "cache": [
+      "Schema 4 stores records(rowid, id, kind, subject, created_at, active) and ordinary FTS5(text, preview), linked by integer rowid. IDs are unique; writer replacement assigns and publishes both tables and generation metadata in one transaction. Keep WAL synchronous FULL.",
+      "Fresh reads require complete canonical equality in the same verified read transaction as the query. Stream bounded record identities and active bits, prove retained scalar bytes against canonical records, and bind each FTS rowid to exactly one canonical member.",
+      "List, show and full search select ordered IDs and resolve them through that operation's accepted byId map. Charge the existing serialised full-response bytes before cloning each selected record. Compact reads select ID, rank and bounded-preview snippet, deriving remaining fields from canonical facts.",
+      "Never store or parse a second full record JSON corpus in SQLite. Preserve independent mutable result occurrences, existing ordering, filters, Unicode error boundaries and response accounting.",
+      "Compute strict-validation body and preview projections transiently without populating corpus-wide memoised strings. Bound posting and auxiliary shadow rows and storage before native read-only FTS integrity checking.",
+      "Writer predecessors may be validated canonical subsets: derive their own active flags and fingerprint accepted member witnesses in canonical path order before replacement. Full reads separately require complete generation metadata.",
+      "Validate fixed application_id, user_version and metadata schemaVersion, plus the exact complete owned schema. Derive trusted DDL and implicit FTS objects from a short-lived in-memory database using the current SQLite runtime; compare inside SQLite without transferring untrusted schema SQL. Quarantine incompatible generations before rebuilding.",
+      "Reuse a replacement corpus during disposable recovery only after its fixed generation assertion succeeds."
+    ],
+    "scope": [
+      "Preserve graph/error budgets, bounded directory entry generations, numeric-first SQL admission and independent mutable public results.",
+      "Currentness compares retained filesystem observations after initial byte verification; it is not a second content read or an inter-operation metadata-only trust shortcut.",
+      "Keep cache containment, sidecar, hard-link, lock, quarantine and error-precedence protections. No global corpus cache or new public exports."
+    ],
+    "filesystem": [
+      "Read and hash accepted canonical bytes once per unchanged attempt. Closing assertions compare retained full metadata through no-follow descriptor/path checks and bounded canonical root/kind generation checks; they never refresh evidence from a changed generation.",
+      "Probe rejected unreadable evidence again before acceptance. Only accepting an authorised cleanup-induced ctime change rereads canonical bytes and verifies the original digest.",
+      "Capture each unique artifact and parent-linked ancestor once. Retain exact pathname metadata or absence for invalid boundaries; compare shared pathname expectations instead of overwriting them.",
+      "Close artifact evidence with parent-first directory checks, unique entry comparisons and child-first directory checks ending at the brain anchor. Retain the complete relevant ancestor chain for operational open-error classification.",
+      "Keep proof maps private and fixed after collection. Reuse their assertion at accepted query/publication boundaries, preserving fixed publication prefixes, primary-before-close errors and whole-attempt retry limits."
+    ]
+  },
+  "searchText": "minimal SQLite schema canonical corpus record_json removal integer FTS identity exact owned schema streaming proof MAR-2789",
+  "source": "agent",
+  "subject": "canonical.verified-corpus",
+  "supersedes": ["06a643f1-d077-4556-91e8-0929bb6c3f34"]
+}

--- a/encephalon/architecture/59c66755-8eb0-4808-91cd-5ccc26bcbccc.json
+++ b/encephalon/architecture/59c66755-8eb0-4808-91cd-5ccc26bcbccc.json
@@ -1,0 +1,14 @@
+{
+  "createdAt": "2026-09-10T16:47:16.495Z",
+  "id": "59c66755-8eb0-4808-91cd-5ccc26bcbccc",
+  "kind": "architecture",
+  "payload": {
+    "summary": "Verify ordinary SQLite record indexes as well as canonical rows and FTS before trusting selection or ordering.",
+    "problem": "An empty replacement rootpage for records_active_order can preserve exact owned schema, canonical rows, metadata and FTS while causing an indexed list query to omit a canonical record.",
+    "decision": "After bounded scalar admission, require read-only pragma_integrity_check for records and its associated indexes inside the verified transaction. Keep the separate bounded FTS native check and exact canonical byte proof. Transfer only the numeric success result and quarantine failures.",
+    "verification": "A deterministic missing-index-entry fixture preserves the logical cache projection, reproduces an empty public list without this check, then proves one quarantine restores the canonical result."
+  },
+  "searchText": "SQLite ordinary index integrity missing ordering entry canonical equivalence MAR-2789",
+  "source": "agent",
+  "subject": "cache.index-integrity"
+}

--- a/encephalon/architecture/b7ab828a-ffcc-43f0-9640-5975cc515da1.json
+++ b/encephalon/architecture/b7ab828a-ffcc-43f0-9640-5975cc515da1.json
@@ -1,0 +1,14 @@
+{
+  "createdAt": "2026-09-10T17:21:42.985Z",
+  "id": "b7ab828a-ffcc-43f0-9640-5975cc515da1",
+  "kind": "architecture",
+  "payload": {
+    "summary": "Drive full and compact SQLite searches from FTS matches before resolving integer record identities.",
+    "problem": "Node 24.15.0 SQLite 3.51.3 chooses the active-record index before the integer FTS join, repeating MATCH per active record. Node 26.5.0 SQLite 3.53.4 chooses FTS first; a newer-runtime benchmark alone missed the regression.",
+    "decision": "Use CROSS JOIN for the two FTS-to-record search queries to preserve FTS-first loop order. Keep all existing active/kind predicates, ranking, tie-breaks, snippets and limits.",
+    "verification": "A query-plan regression fails on Node 24 before the change and passes after it. The accepted 1000-record fixture produces identical query results with either join; the minimum-runtime diagnostic reduced the affected query from approximately 24 ms to 0.7 ms. Required final matched campaigns must confirm whole-operation budgets."
+  },
+  "searchText": "SQLite FTS first integer join ordering minimum Node 24 query plan MAR-2789",
+  "source": "agent",
+  "subject": "cache.search-join-order"
+}

--- a/scripts/release-compatibility.test.ts
+++ b/scripts/release-compatibility.test.ts
@@ -1179,7 +1179,7 @@ describe('release compatibility process fixture', () => {
     try {
       mkdirSync(fixtureRoot)
       const oracle = buildStandInTarball(temporaryRoot, '0.2.0', '1')
-      const candidate = buildStandInTarball(temporaryRoot, '0.3.0', '3')
+      const candidate = buildStandInTarball(temporaryRoot, '0.3.0', '4')
       const oracleDigests = packageTarballDigests(oracle.tarball)
       const candidateDigests = packageTarballDigests(candidate.tarball)
       writeFileSync(resolve(oracle.packageRoot, 'dist', 'index.mjs'), 'throw new Error("unpacked oracle executed")\n')
@@ -1233,8 +1233,8 @@ describe('release compatibility process fixture', () => {
       assert.deepEqual(report.candidate.digests, candidateDigests)
       assert.equal(report.oracle.version, '0.2.0')
       assert.equal(report.candidate.version, '0.3.0')
-      assert.deepEqual(report.upgrade.schemas, { after: '3', before: '1' })
-      assert.deepEqual(report.downgrade.schemas, { after: '1', before: '3' })
+      assert.deepEqual(report.upgrade.schemas, { after: '4', before: '1' })
+      assert.deepEqual(report.downgrade.schemas, { after: '1', before: '4' })
       assert.equal(report.upgrade.durableState, 'identical')
       assert.equal(report.downgrade.durableState, 'identical')
       assert.deepEqual(report.upgrade.resultLimits.api, expectedCandidateLimits)
@@ -1407,7 +1407,7 @@ describe('release compatibility process fixture', () => {
     try {
       mkdirSync(fixtureRoot)
       const oracle = buildStandInTarball(temporaryRoot, '0.2.0', '1')
-      const candidate = buildStandInTarball(temporaryRoot, '0.3.0', '3')
+      const candidate = buildStandInTarball(temporaryRoot, '0.3.0', '4')
       const oracleDigests = packageTarballDigests(oracle.tarball)
 
       assert.throws(() =>
@@ -1439,7 +1439,7 @@ describe('release compatibility process fixture', () => {
     try {
       mkdirSync(fixtureRoot)
       const oracle = buildStandInTarball(temporaryRoot, '0.2.0', '1')
-      const candidate = buildStandInTarball(temporaryRoot, '0.3.0', '3')
+      const candidate = buildStandInTarball(temporaryRoot, '0.3.0', '4')
       const oracleDigests = packageTarballDigests(oracle.tarball)
 
       assert.throws(
@@ -1478,7 +1478,7 @@ describe('release compatibility process fixture', () => {
     try {
       mkdirSync(fixtureRoot)
       const oracle = buildStandInTarball(temporaryRoot, '0.2.0', '1')
-      const candidate = buildStandInTarball(temporaryRoot, '0.3.1', '3')
+      const candidate = buildStandInTarball(temporaryRoot, '0.3.1', '4')
       const oracleDigests = packageTarballDigests(oracle.tarball)
 
       assert.throws(
@@ -1521,7 +1521,7 @@ describe('release compatibility process fixture group B', () => {
       try {
         mkdirSync(fixtureRoot)
         const oracle = buildStandInTarball(temporaryRoot, '0.2.0', '1')
-        const candidate = buildStandInTarball(temporaryRoot, behaviour, '3')
+        const candidate = buildStandInTarball(temporaryRoot, behaviour, '4')
         const oracleDigests = packageTarballDigests(oracle.tarball)
 
         assert.throws(() =>
@@ -1552,7 +1552,7 @@ describe('release compatibility process fixture group B', () => {
     try {
       mkdirSync(fixtureRoot)
       const oracle = buildStandInTarball(temporaryRoot, '0.2.0', '1')
-      const candidate = buildStandInTarball(temporaryRoot, '0.3.0-hostile-added-path', '3')
+      const candidate = buildStandInTarball(temporaryRoot, '0.3.0-hostile-added-path', '4')
       const oracleDigests = packageTarballDigests(oracle.tarball)
 
       assert.throws(() =>
@@ -1586,7 +1586,7 @@ describe('release compatibility process fixture group B', () => {
     try {
       mkdirSync(fixtureRoot)
       const oracle = buildStandInTarball(temporaryRoot, '0.2.0', '1')
-      const candidate = buildStandInTarball(temporaryRoot, '0.3.0-shape-drift', '3')
+      const candidate = buildStandInTarball(temporaryRoot, '0.3.0-shape-drift', '4')
       const oracleDigests = packageTarballDigests(oracle.tarball)
 
       assert.throws(
@@ -1620,7 +1620,7 @@ describe('release compatibility process fixture group C', () => {
     try {
       mkdirSync(fixtureRoot)
       const oracle = buildStandInTarball(temporaryRoot, '0.2.0', '1')
-      const candidate = buildStandInTarball(temporaryRoot, '0.3.0-budget-drift', '3')
+      const candidate = buildStandInTarball(temporaryRoot, '0.3.0-budget-drift', '4')
       const oracleDigests = packageTarballDigests(oracle.tarball)
 
       assert.throws(
@@ -1652,7 +1652,7 @@ describe('release compatibility process fixture group C', () => {
     try {
       mkdirSync(fixtureRoot)
       const oracle = buildStandInTarball(temporaryRoot, '0.2.0', '1')
-      const candidate = buildStandInTarball(temporaryRoot, '0.3.0-coverage-drift', '3')
+      const candidate = buildStandInTarball(temporaryRoot, '0.3.0-coverage-drift', '4')
       const oracleDigests = packageTarballDigests(oracle.tarball)
 
       assert.throws(
@@ -1684,7 +1684,7 @@ describe('release compatibility process fixture group C', () => {
     try {
       mkdirSync(fixtureRoot)
       const oracle = buildStandInTarball(temporaryRoot, '0.2.0', '1')
-      const candidate = buildStandInTarball(temporaryRoot, '0.3.0-forged-witness', '3')
+      const candidate = buildStandInTarball(temporaryRoot, '0.3.0-forged-witness', '4')
       const oracleDigests = packageTarballDigests(oracle.tarball)
 
       assert.throws(
@@ -1716,7 +1716,7 @@ describe('release compatibility process fixture group C', () => {
     try {
       mkdirSync(fixtureRoot)
       const oracle = buildStandInTarball(temporaryRoot, '0.2.0', '1')
-      const candidate = buildStandInTarball(temporaryRoot, '0.3.0-forged-export-only', '3')
+      const candidate = buildStandInTarball(temporaryRoot, '0.3.0-forged-export-only', '4')
       const oracleDigests = packageTarballDigests(oracle.tarball)
 
       assert.doesNotThrow(() =>
@@ -1752,7 +1752,7 @@ describe('release compatibility process fixture group A preloads', () => {
     try {
       mkdirSync(fixtureRoot)
       const oracle = buildStandInTarball(temporaryRoot, '0.2.0-environment-witness', '1')
-      const candidate = buildStandInTarball(temporaryRoot, '0.3.0-environment-witness', '3')
+      const candidate = buildStandInTarball(temporaryRoot, '0.3.0-environment-witness', '4')
       const oracleDigests = packageTarballDigests(oracle.tarball)
       writeFileSync(preload, `require('node:fs').appendFileSync(${JSON.stringify(marker)}, 'loaded\\n')\n`)
       process.env.NODE_OPTIONS = `--require=${preload}`
@@ -1796,7 +1796,7 @@ describe('release compatibility process fixture group A preloads', () => {
     try {
       mkdirSync(fixtureRoot)
       const oracle = buildStandInTarball(temporaryRoot, '0.2.0', '1')
-      const candidate = buildStandInTarball(temporaryRoot, '0.3.0-environment-mutation', '3')
+      const candidate = buildStandInTarball(temporaryRoot, '0.3.0-environment-mutation', '4')
       const oracleDigests = packageTarballDigests(oracle.tarball)
 
       assert.doesNotThrow(() =>

--- a/scripts/release-compatibility.ts
+++ b/scripts/release-compatibility.ts
@@ -1394,8 +1394,8 @@ export const runReleaseCompatibility = (options: ReleaseCompatibilityOptions): R
     assertCandidateCliSurface(oracleCliSurface, upgradeCli.surface)
     assertCandidateIndependentBudgets(upgradeIndependentBudgets)
     assertDurableSnapshotsEqual(durable, captureDurableSnapshot(fixtureRoot))
-    if (upgradeApi.schemaBefore !== '1' || upgradeApi.schemaAfter !== '3') {
-      throw new Error('The candidate package did not rebuild cache schema 1 as schema 3.')
+    if (upgradeApi.schemaBefore !== '1' || upgradeApi.schemaAfter !== '4') {
+      throw new Error('The candidate package did not rebuild cache schema 1 as schema 4.')
     }
 
     options.hooks?.beforeOracleDowngrade?.(oracle.path)
@@ -1421,8 +1421,8 @@ export const runReleaseCompatibility = (options: ReleaseCompatibilityOptions): R
       'The downgraded oracle independent budget evidence',
     )
     assertDurableSnapshotsEqual(durable, captureDurableSnapshot(fixtureRoot))
-    if (downgradeApi.schemaBefore !== '3' || downgradeApi.schemaAfter !== '1') {
-      throw new Error('The published oracle did not rebuild cache schema 3 as schema 1 after downgrade.')
+    if (downgradeApi.schemaBefore !== '4' || downgradeApi.schemaAfter !== '1') {
+      throw new Error('The published oracle did not rebuild cache schema 4 as schema 1 after downgrade.')
     }
     if (initialImport.version !== initial.version || downgradeImport.version !== initial.version) {
       throw new Error('The published oracle process did not execute the installed oracle package version.')

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -831,6 +831,12 @@ const assertCacheContentConsistent = (database: DatabaseSync, metadata: Metadata
   ) {
     throw new CacheSchemaMismatch('The cache record table does not match its metadata.')
   }
+  const recordsIntegrity = database
+    .prepare("SELECT integrity_check = 'ok' AS valid FROM pragma_integrity_check('records') LIMIT 1")
+    .get()
+  if (recordsIntegrity?.valid !== 1) {
+    throw new CacheSchemaMismatch('The cache record indexes are inconsistent.')
+  }
   cacheReadTestHooks.beforeIntegrityTextRead?.('records')
   const recordKeys = database.prepare(
     'SELECT rowid, CAST(id AS BLOB) AS id_bytes, active FROM records ORDER BY id LIMIT ?',

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,9 +1,7 @@
-import { isUtf8 } from 'node:buffer'
 import { type BigIntStats, lstatSync, realpathSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { resolve } from 'node:path'
 import type { DatabaseSync } from 'node:sqlite'
-import { isDeepStrictEqual } from 'node:util'
 import {
   parseCompactSearchRecordsInput,
   parseFullSearchRecordsInput,
@@ -45,14 +43,13 @@ import { recordCorpusFingerprint } from './record-corpus-fingerprint.ts'
 import { MAX_SEARCH_PREVIEW_BYTES, searchDocumentForRecord, searchPreviewForRecord } from './record-projection.ts'
 import {
   canonicalCacheManifest,
-  canonicalRecordPath,
   type RecordReadHooks,
   readValidatedRecordSnapshotResolved,
   type VerifiedCorpus,
 } from './records.ts'
 import { resolveRepository } from './repository.ts'
 import { createResponseByteBudget, type ResponseByteBudget } from './response-budget.ts'
-import { parseRecordFile, validateArtifactPath } from './schema.ts'
+import { validateArtifactPath } from './schema.ts'
 import { literalMatchQuery, MAX_NFC_UTF8_EXPANSION_FACTOR } from './search-text.ts'
 import { classifySQLiteError } from './sqlite-error.ts'
 import type {
@@ -68,24 +65,23 @@ import type {
   ShowRecordInput,
 } from './types.ts'
 
-const SCHEMA_VERSION = '3'
+const SCHEMA_VERSION = '4'
+const CACHE_APPLICATION_ID = 0x45_4e_43_50
 const MAX_REPOSITORY_CHANGE_RETRIES = 3
 const MAX_GATHER_SEARCHES = OPERATION_BUDGETS.gatherSearches.maximum
 const MAX_GATHER_SHOWS = OPERATION_BUDGETS.gatherShows.maximum
 const SQLITE_BUSY_TIMEOUT_MILLISECONDS = 1000
 const MAX_CACHE_METADATA_BYTES = 1024 * 1024
 const MAX_CACHE_SCHEMA_BYTES = 4 * 1024
-const MAX_CACHE_RECORD_OVERHEAD_BYTES = 4096
-const MAX_CACHE_RECORD_BYTES = CANONICAL_BUDGETS.recordBytes + MAX_CACHE_RECORD_OVERHEAD_BYTES
-const MAX_CACHE_RECORD_JSON_BYTES =
-  CANONICAL_BUDGETS.recordJsonBytes + CANONICAL_BUDGETS.records * MAX_CACHE_RECORD_OVERHEAD_BYTES
-const MAX_CACHE_RECORD_TEXT_BYTES = MAX_CACHE_RECORD_JSON_BYTES * 2
+// Search text contains canonical fields and the flattened payload, with NFC expansion.
+const MAX_CACHE_SEARCH_SOURCE_BYTES = CANONICAL_BUDGETS.recordBytes + 4096
+const MAX_CACHE_SEARCH_SOURCE_AGGREGATE_BYTES = CANONICAL_BUDGETS.recordJsonBytes + CANONICAL_BUDGETS.records * 4096
 const MAX_CACHE_SEARCH_DOCUMENT_DUPLICATION_FACTOR = 2
 const MAX_CACHE_SEARCH_DOCUMENT_BYTES =
-  MAX_CACHE_RECORD_BYTES * MAX_CACHE_SEARCH_DOCUMENT_DUPLICATION_FACTOR * MAX_NFC_UTF8_EXPANSION_FACTOR
+  MAX_CACHE_SEARCH_SOURCE_BYTES * MAX_CACHE_SEARCH_DOCUMENT_DUPLICATION_FACTOR * MAX_NFC_UTF8_EXPANSION_FACTOR
 const MAX_CACHE_SEARCH_DOCUMENT_AGGREGATE_BYTES =
-  MAX_CACHE_RECORD_JSON_BYTES * MAX_CACHE_SEARCH_DOCUMENT_DUPLICATION_FACTOR * MAX_NFC_UTF8_EXPANSION_FACTOR
-const MAX_CACHE_FTS_ID_BYTES = CANONICAL_BUDGETS.records * 255
+  MAX_CACHE_SEARCH_SOURCE_AGGREGATE_BYTES * MAX_CACHE_SEARCH_DOCUMENT_DUPLICATION_FACTOR * MAX_NFC_UTF8_EXPANSION_FACTOR
+
 const MAX_CACHE_SEARCH_PREVIEW_BYTES = MAX_SEARCH_PREVIEW_BYTES
 const MAX_CACHE_SEARCH_PREVIEW_AGGREGATE_BYTES = CANONICAL_BUDGETS.records * MAX_CACHE_SEARCH_PREVIEW_BYTES
 const MAX_CACHE_SEARCH_INDEX_BYTES = MAX_CACHE_SEARCH_DOCUMENT_AGGREGATE_BYTES * 2
@@ -132,36 +128,16 @@ type ManifestEntry = {
   ctimeNanoseconds?: string
 }
 
-type RecordRow = {
-  record_json: unknown
-  record_bytes?: unknown
-}
+type RecordRow = { id?: unknown }
 
-type CompactRow = {
-  id: unknown
-  kind: unknown
-  subject: unknown
-  path: unknown
-  summary: unknown
-  rank: unknown
-  snippet: unknown
+type CompactRow = RecordRow & {
+  rank?: unknown
+  snippet?: unknown
 }
 
 type SearchStatementInput = Pick<SearchRecordsInput, 'includeSuperseded' | 'kind' | 'limit'>
 
-type CacheIntegrityProbeName =
-  | 'metadata'
-  | 'metadata-columns'
-  | 'metadata-schema'
-  | 'records'
-  | 'records-active-order-index'
-  | 'records-columns'
-  | 'records-indexes'
-  | 'records-kind-subject-index'
-  | 'records-schema'
-  | 'record-search'
-  | 'record-search-columns'
-  | 'record-search-schema'
+type CacheIntegrityProbeName = 'metadata' | 'records' | 'record-search' | 'schema'
 
 type CacheIntegrityProbe = {
   exceeds_aggregate_bytes?: unknown
@@ -178,126 +154,17 @@ type CacheIntegrityObservation = {
   rows: number
 }
 
-type ExpectedOrdinaryColumn = Readonly<{
-  constraint?: string
-  name: string
-  notNull: 0 | 1
-  primaryKeyPosition: 0 | 1
-  type: 'INTEGER' | 'TEXT'
-}>
-
-type ExpectedIndexColumn = Readonly<{
-  collation: 'BINARY'
-  descending: 0 | 1
-  name: string
-}>
-
-const METADATA_COLUMNS = [
-  { name: 'key', notNull: 0, primaryKeyPosition: 1, type: 'TEXT' },
-  { name: 'value', notNull: 1, primaryKeyPosition: 0, type: 'TEXT' },
-] as const satisfies readonly ExpectedOrdinaryColumn[]
-
-const RECORD_COLUMNS = [
-  { name: 'id', notNull: 0, primaryKeyPosition: 1, type: 'TEXT' },
-  { name: 'kind', notNull: 1, primaryKeyPosition: 0, type: 'TEXT' },
-  { name: 'subject', notNull: 1, primaryKeyPosition: 0, type: 'TEXT' },
-  { name: 'source', notNull: 1, primaryKeyPosition: 0, type: 'TEXT' },
-  { name: 'created_at', notNull: 1, primaryKeyPosition: 0, type: 'TEXT' },
-  { name: 'path', notNull: 1, primaryKeyPosition: 0, type: 'TEXT' },
-  {
-    constraint: 'CHECK (active IN (0, 1))',
-    name: 'active',
-    notNull: 1,
-    primaryKeyPosition: 0,
-    type: 'INTEGER',
-  },
-  { name: 'summary', notNull: 0, primaryKeyPosition: 0, type: 'TEXT' },
-  { name: 'record_json', notNull: 1, primaryKeyPosition: 0, type: 'TEXT' },
-] as const satisfies readonly ExpectedOrdinaryColumn[]
-
-const ordinaryTableDefinition = (columns: readonly ExpectedOrdinaryColumn[]) => `(
-${columns
-  .map(
-    column =>
-      `  ${[
-        column.name,
-        column.type,
-        column.primaryKeyPosition === 1 ? 'PRIMARY KEY' : undefined,
-        column.notNull === 1 ? 'NOT NULL' : undefined,
-        column.constraint,
-      ]
-        .filter(part => part !== undefined)
-        .join(' ')}`,
-  )
-  .join(',\n')}
-)`
-
-const METADATA_TABLE_DEFINITION = ordinaryTableDefinition(METADATA_COLUMNS)
-const RECORDS_TABLE_DEFINITION = ordinaryTableDefinition(RECORD_COLUMNS)
-
-const RECORDS_INDEXES = [
-  {
-    columns: [
-      { collation: 'BINARY', descending: 0, name: 'active' },
-      { collation: 'BINARY', descending: 1, name: 'created_at' },
-      { collation: 'BINARY', descending: 1, name: 'id' },
-    ],
-    name: 'records_active_order',
-    probeName: 'records-active-order-index',
-  },
-  {
-    columns: [
-      { collation: 'BINARY', descending: 0, name: 'kind' },
-      { collation: 'BINARY', descending: 0, name: 'subject' },
-    ],
-    name: 'records_kind_subject',
-    probeName: 'records-kind-subject-index',
-  },
-] as const satisfies readonly {
-  columns: readonly ExpectedIndexColumn[]
-  name: string
-  probeName: CacheIntegrityProbeName
-}[]
-
-const RECORDS_INDEX_DEFINITIONS = RECORDS_INDEXES.map(
-  index =>
-    `CREATE INDEX ${index.name} ON records(${index.columns
-      .map(column => `${column.name}${column.descending === 1 ? ' DESC' : ''}`)
-      .join(', ')})`,
-).join(';\n')
-
-const RECORD_SEARCH_DEFINITION = 'fts5(id UNINDEXED, text, preview)'
-
-const schemaTokenPattern =
-  /\s+|--[^\r\n]*|\/\*[\s\S]*?\*\/|'(?:''|[^'])*'|"(?:""|[^"])*"|`(?:``|[^`])*`|\[(?:\]\]|[^\]])*\]|[A-Za-z_][A-Za-z0-9_]*|\d+|[(),]|\S/g
-
-const schemaToken = (token: string) => {
-  if (/^\s+$|^--|^\/\*/.test(token)) {
-    return []
-  }
-  if (token.startsWith('"')) {
-    return [token.slice(1, -1).replaceAll('""', '"').toLowerCase()]
-  }
-  if (token.startsWith('`')) {
-    return [token.slice(1, -1).replaceAll('``', '`').toLowerCase()]
-  }
-  if (token.startsWith('[')) {
-    return [token.slice(1, -1).replaceAll(']]', ']').toLowerCase()]
-  }
-  return [token.toLowerCase()]
-}
-
-const ownedSchemaTokens = (sql: string) => {
-  const tokens = [...sql.matchAll(schemaTokenPattern)].flatMap(match => schemaToken(match[0]))
-  const tableIndex = tokens.indexOf('table')
-  const optionalClause = tokens.slice(tableIndex + 1, tableIndex + 4).join(' ')
-  return optionalClause === 'if not exists'
-    ? [...tokens.slice(0, tableIndex + 1), ...tokens.slice(tableIndex + 4)]
-    : tokens
-}
-
-const sameOwnedSchema = (actual: string, expected: string) =>
-  JSON.stringify(ownedSchemaTokens(actual)) === JSON.stringify(ownedSchemaTokens(expected))
+// These columns support identity joins, filtering and deterministic ordering. Full values,
+// paths and summaries belong to the operation's verified canonical corpus.
+const CACHE_SCHEMA = [
+  'CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)',
+  `CREATE TABLE records (rowid INTEGER PRIMARY KEY, id TEXT NOT NULL UNIQUE,
+    kind TEXT NOT NULL, subject TEXT NOT NULL, created_at TEXT NOT NULL,
+    active INTEGER NOT NULL CHECK (active IN (0, 1)))`,
+  'CREATE INDEX records_active_order ON records(active, created_at DESC, id DESC)',
+  'CREATE INDEX records_kind_subject ON records(kind, subject)',
+  'CREATE VIRTUAL TABLE record_search USING fts5(text, preview)',
+] as const
 
 type CacheReadTestHooks = {
   afterCanonicalCacheEqualityValidation?: (() => void) | undefined
@@ -419,319 +286,6 @@ const readIntegrityProbe = (
   return observation
 }
 
-const assertTableColumns = (database: DatabaseSync, table: 'record_search', expected: readonly string[]) => {
-  const maximumRows = expected.length + 1
-  const maximumNameBytes = Math.max(...expected.map(name => Buffer.byteLength(name, 'utf8')))
-  const probeName = `${table.replace('_', '-')}-columns` as CacheIntegrityProbeName
-  const probe = readIntegrityProbe(
-    probeName,
-    database
-      .prepare(
-        `SELECT
-          COUNT(*) AS row_count,
-          0 AS exceeds_aggregate_bytes,
-          CASE WHEN TOTAL(invalid_type) > 0 THEN 1 ELSE 0 END AS has_invalid_type,
-          CASE WHEN TOTAL(oversized) > 0 THEN 1 ELSE 0 END AS has_oversized_value
-        FROM (
-          SELECT
-            CASE WHEN typeof(name) = 'text' THEN 0 ELSE 1 END AS invalid_type,
-            CASE WHEN typeof(name) = 'text' AND length(CAST(name AS BLOB)) <= ? THEN 0 ELSE 1 END AS oversized
-          FROM pragma_table_info(?)
-          LIMIT ?
-        )`,
-      )
-      .get(maximumNameBytes, table, maximumRows) as CacheIntegrityProbe | undefined,
-    maximumRows,
-  )
-  if (
-    probe.rows !== expected.length ||
-    probe.exceedsAggregateBytes !== 0 ||
-    probe.hasInvalidType !== 0 ||
-    probe.hasOversizedValue !== 0
-  ) {
-    throw new CacheSchemaMismatch(`The ${table} cache table has an incompatible schema.`)
-  }
-  cacheReadTestHooks.beforeIntegrityTextRead?.(probeName)
-  const columns = database
-    .prepare('SELECT name FROM pragma_table_info(?) LIMIT ?')
-    .iterate(table, maximumRows) as Iterable<{
-    name?: unknown
-  }>
-  const names = [...columns].map(column => column.name)
-  if (JSON.stringify(names) !== JSON.stringify(expected)) {
-    throw new CacheSchemaMismatch(`The ${table} cache table has an incompatible schema.`)
-  }
-}
-
-const assertOrdinaryTableSchema = (
-  database: DatabaseSync,
-  table: 'metadata' | 'records',
-  expected: readonly ExpectedOrdinaryColumn[],
-) => {
-  const maximumRows = expected.length + 1
-  const maximumNameBytes = Math.max(...expected.map(column => Buffer.byteLength(column.name, 'utf8')))
-  const maximumTypeBytes = Math.max(...expected.map(column => Buffer.byteLength(column.type, 'utf8')))
-  const probeName = `${table.replace('_', '-')}-columns` as CacheIntegrityProbeName
-  const probe = readIntegrityProbe(
-    probeName,
-    database
-      .prepare(
-        `SELECT
-          COUNT(*) AS row_count,
-          0 AS exceeds_aggregate_bytes,
-          CASE WHEN TOTAL(invalid_type) > 0
-                    OR (SELECT COUNT(*) FROM (
-                      SELECT 1
-                      FROM pragma_table_list
-                      WHERE schema = 'main' AND name = ?1 AND type = 'table'
-                      LIMIT 2
-                    )) != 1
-               THEN 1 ELSE 0 END AS has_invalid_type,
-          CASE WHEN TOTAL(oversized) > 0 THEN 1 ELSE 0 END AS has_oversized_value
-        FROM (
-          SELECT
-            CASE WHEN typeof(cid) = 'integer'
-                       AND typeof(name) = 'text'
-                       AND typeof(type) = 'text'
-                       AND typeof("notnull") = 'integer'
-                       AND "notnull" IN (0, 1)
-                       AND dflt_value IS NULL
-                       AND typeof(pk) = 'integer'
-                       AND pk IN (0, 1)
-                       AND typeof(hidden) = 'integer'
-                       AND hidden = 0
-                 THEN 0 ELSE 1 END AS invalid_type,
-            CASE WHEN typeof(name) = 'text' AND length(CAST(name AS BLOB)) <= ?2
-                       AND typeof(type) = 'text' AND length(CAST(type AS BLOB)) <= ?3
-                 THEN 0 ELSE 1 END AS oversized
-          FROM pragma_table_xinfo(?1)
-          LIMIT ?4
-        )`,
-      )
-      .get(table, maximumNameBytes, maximumTypeBytes, maximumRows) as CacheIntegrityProbe | undefined,
-    maximumRows,
-  )
-  if (
-    probe.rows !== expected.length ||
-    probe.exceedsAggregateBytes !== 0 ||
-    probe.hasInvalidType !== 0 ||
-    probe.hasOversizedValue !== 0
-  ) {
-    throw new CacheSchemaMismatch(`The ${table} cache table has an incompatible schema.`)
-  }
-  cacheReadTestHooks.beforeIntegrityTextRead?.(probeName)
-  const columns = database
-    .prepare(
-      `SELECT
-        cid,
-        name,
-        upper(type) AS type,
-        "notnull" AS not_null,
-        pk,
-        hidden,
-        CASE WHEN dflt_value IS NULL THEN 1 ELSE 0 END AS default_absent
-      FROM pragma_table_xinfo(?)
-      ORDER BY cid
-      LIMIT ?`,
-    )
-    .iterate(table, maximumRows) as Iterable<{
-    cid?: unknown
-    default_absent?: unknown
-    hidden?: unknown
-    name?: unknown
-    not_null?: unknown
-    pk?: unknown
-    type?: unknown
-  }>
-  const descriptors = [...columns].map(column => ({
-    defaultAbsent: column.default_absent,
-    hidden: column.hidden,
-    name: column.name,
-    notNull: column.not_null,
-    primaryKeyPosition: column.pk,
-    type: column.type,
-  }))
-  const expectedDescriptors = expected.map(column => ({
-    defaultAbsent: 1,
-    hidden: 0,
-    name: column.name,
-    notNull: column.notNull,
-    primaryKeyPosition: column.primaryKeyPosition,
-    type: column.type,
-  }))
-  if (JSON.stringify(descriptors) !== JSON.stringify(expectedDescriptors)) {
-    throw new CacheSchemaMismatch(`The ${table} cache table has an incompatible schema.`)
-  }
-}
-
-const assertOrdinaryTableDefinition = (database: DatabaseSync, table: 'metadata' | 'records', definition: string) => {
-  const probeName = `${table}-schema` as CacheIntegrityProbeName
-  const probe = readIntegrityProbe(
-    probeName,
-    database
-      .prepare(
-        `SELECT
-          COUNT(*) AS row_count,
-          0 AS exceeds_aggregate_bytes,
-          CASE WHEN TOTAL(invalid_type) > 0 THEN 1 ELSE 0 END AS has_invalid_type,
-          CASE WHEN TOTAL(oversized) > 0 THEN 1 ELSE 0 END AS has_oversized_value
-        FROM (
-          SELECT
-            CASE WHEN typeof(sql) = 'text' THEN 0 ELSE 1 END AS invalid_type,
-            CASE WHEN typeof(sql) = 'text' AND length(CAST(sql AS BLOB)) <= ?1
-                 THEN 0 ELSE 1 END AS oversized
-          FROM sqlite_schema
-          WHERE type = 'table' AND name = ?2
-          LIMIT 2
-        )`,
-      )
-      .get(MAX_CACHE_SCHEMA_BYTES, table) as CacheIntegrityProbe | undefined,
-    2,
-  )
-  if (
-    probe.rows !== 1 ||
-    probe.exceedsAggregateBytes !== 0 ||
-    probe.hasInvalidType !== 0 ||
-    probe.hasOversizedValue !== 0
-  ) {
-    throw new CacheSchemaMismatch(`The ${table} cache table has an incompatible schema.`)
-  }
-  cacheReadTestHooks.beforeIntegrityTextRead?.(probeName)
-  const row = database.prepare("SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = ? LIMIT 2").get(table) as
-    | { sql?: unknown }
-    | undefined
-  if (typeof row?.sql !== 'string' || !sameOwnedSchema(row.sql, `CREATE TABLE ${table} ${definition}`)) {
-    throw new CacheSchemaMismatch(`The ${table} cache table has an incompatible schema.`)
-  }
-}
-
-const assertRecordsIndex = (
-  database: DatabaseSync,
-  name: string,
-  probeName: CacheIntegrityProbeName,
-  expected: readonly ExpectedIndexColumn[],
-) => {
-  const maximumRows = expected.length + 1
-  const maximumNameBytes = Math.max(...expected.map(column => Buffer.byteLength(column.name, 'utf8')))
-  const maximumCollationBytes = Buffer.byteLength('BINARY', 'utf8')
-  const probe = readIntegrityProbe(
-    probeName,
-    database
-      .prepare(
-        `SELECT
-          COUNT(*) AS row_count,
-          0 AS exceeds_aggregate_bytes,
-          CASE WHEN TOTAL(invalid_type) > 0 THEN 1 ELSE 0 END AS has_invalid_type,
-          CASE WHEN TOTAL(oversized) > 0 THEN 1 ELSE 0 END AS has_oversized_value
-        FROM (
-          SELECT
-            CASE WHEN typeof(seqno) = 'integer'
-                       AND typeof(cid) = 'integer'
-                       AND cid >= 0
-                       AND typeof(name) = 'text'
-                       AND typeof(desc) = 'integer'
-                       AND desc IN (0, 1)
-                       AND typeof(coll) = 'text'
-                       AND key = 1
-                 THEN 0 ELSE 1 END AS invalid_type,
-            CASE WHEN typeof(name) = 'text' AND length(CAST(name AS BLOB)) <= ?2
-                       AND typeof(coll) = 'text' AND length(CAST(coll AS BLOB)) <= ?3
-                 THEN 0 ELSE 1 END AS oversized
-          FROM pragma_index_xinfo(?1)
-          WHERE key = 1
-          ORDER BY seqno
-          LIMIT ?4
-        )`,
-      )
-      .get(name, maximumNameBytes, maximumCollationBytes, maximumRows) as CacheIntegrityProbe | undefined,
-    maximumRows,
-  )
-  if (
-    probe.rows !== expected.length ||
-    probe.exceedsAggregateBytes !== 0 ||
-    probe.hasInvalidType !== 0 ||
-    probe.hasOversizedValue !== 0
-  ) {
-    throw new CacheSchemaMismatch(`The ${name} cache index has an incompatible schema.`)
-  }
-  cacheReadTestHooks.beforeIntegrityTextRead?.(probeName)
-  const rows = database
-    .prepare(
-      `SELECT name, desc AS descending, upper(coll) AS collation
-       FROM pragma_index_xinfo(?)
-       WHERE key = 1
-       ORDER BY seqno
-       LIMIT ?`,
-    )
-    .iterate(name, maximumRows) as Iterable<{
-    collation?: unknown
-    descending?: unknown
-    name?: unknown
-  }>
-  const observed = [...rows].map(row => ({
-    collation: row.collation,
-    descending: row.descending,
-    name: row.name,
-  }))
-  if (JSON.stringify(observed) !== JSON.stringify(expected)) {
-    throw new CacheSchemaMismatch(`The ${name} cache index has an incompatible schema.`)
-  }
-}
-
-const assertRecordsIndexes = (database: DatabaseSync) => {
-  const maximumRows = RECORDS_INDEXES.length + 1
-  const maximumNameBytes = Math.max(...RECORDS_INDEXES.map(index => Buffer.byteLength(index.name, 'utf8')))
-  const probe = readIntegrityProbe(
-    'records-indexes',
-    database
-      .prepare(
-        `SELECT
-          COUNT(*) AS row_count,
-          0 AS exceeds_aggregate_bytes,
-          CASE WHEN TOTAL(invalid_type) > 0 THEN 1 ELSE 0 END AS has_invalid_type,
-          CASE WHEN TOTAL(oversized) > 0 THEN 1 ELSE 0 END AS has_oversized_value
-        FROM (
-          SELECT
-            CASE WHEN typeof(name) = 'text'
-                       AND typeof("unique") = 'integer'
-                       AND "unique" = 0
-                       AND origin = 'c'
-                       AND typeof(partial) = 'integer'
-                       AND partial = 0
-                 THEN 0 ELSE 1 END AS invalid_type,
-            CASE WHEN typeof(name) = 'text' AND length(CAST(name AS BLOB)) <= ?
-                 THEN 0 ELSE 1 END AS oversized
-          FROM pragma_index_list('records')
-          WHERE origin = 'c'
-          LIMIT ?
-        )`,
-      )
-      .get(maximumNameBytes, maximumRows) as CacheIntegrityProbe | undefined,
-    maximumRows,
-  )
-  if (
-    probe.rows !== RECORDS_INDEXES.length ||
-    probe.exceedsAggregateBytes !== 0 ||
-    probe.hasInvalidType !== 0 ||
-    probe.hasOversizedValue !== 0
-  ) {
-    throw new CacheSchemaMismatch('The records cache indexes have an incompatible schema.')
-  }
-  cacheReadTestHooks.beforeIntegrityTextRead?.('records-indexes')
-  const names = [
-    ...(database
-      .prepare("SELECT name FROM pragma_index_list('records') WHERE origin = 'c' ORDER BY name LIMIT ?")
-      .iterate(maximumRows) as Iterable<{ name?: unknown }>),
-  ].map(row => row.name)
-  const expectedNames = RECORDS_INDEXES.map(index => index.name).toSorted()
-  if (JSON.stringify(names) !== JSON.stringify(expectedNames)) {
-    throw new CacheSchemaMismatch('The records cache indexes have an incompatible schema.')
-  }
-  for (const index of RECORDS_INDEXES) {
-    assertRecordsIndex(database, index.name, index.probeName, index.columns)
-  }
-}
-
 const verifySQLiteFeatures = (DatabaseConstructor: SQLiteModule['DatabaseSync']) => {
   if (sqliteFeaturesVerified) {
     return
@@ -758,51 +312,47 @@ const verifySQLiteFeatures = (DatabaseConstructor: SQLiteModule['DatabaseSync'])
 }
 
 const assertCacheSchemaUnchecked = (database: DatabaseSync) => {
-  assertOrdinaryTableSchema(database, 'metadata', METADATA_COLUMNS)
-  assertOrdinaryTableDefinition(database, 'metadata', METADATA_TABLE_DEFINITION)
-  assertOrdinaryTableSchema(database, 'records', RECORD_COLUMNS)
-  assertOrdinaryTableDefinition(database, 'records', RECORDS_TABLE_DEFINITION)
-  assertRecordsIndexes(database)
-  const searchSchemaProbe = readIntegrityProbe(
-    'record-search-schema',
+  const version = database.prepare('SELECT * FROM pragma_application_id(), pragma_user_version()').get()
+  if (version?.application_id !== CACHE_APPLICATION_ID || version?.user_version !== Number(SCHEMA_VERSION)) {
+    throw new CacheSchemaMismatch('The cache schema version is incompatible.')
+  }
+  // Ask this SQLite runtime for its trusted normalised DDL, including implicit indexes
+  // and FTS shadow objects. Never interpret or transfer the cache's untrusted schema SQL.
+  const reference = new (loadSQLite().DatabaseSync)(':memory:')
+  const expected = (() => {
+    try {
+      createCacheSchema(reference)
+      return Array.from(reference.prepare('SELECT type, name, tbl_name, sql FROM sqlite_schema').iterate()) as Array<{
+        type: string
+        name: string
+        tbl_name: string
+        sql: string | null
+      }>
+    } finally {
+      reference.close()
+    }
+  })()
+  const maximumRows = expected.length + 1
+  const probe = readIntegrityProbe(
+    'schema',
     database
-      .prepare(
-        `SELECT
-          COUNT(*) AS row_count,
-          0 AS exceeds_aggregate_bytes,
-          CASE WHEN TOTAL(invalid_type) > 0 THEN 1 ELSE 0 END AS has_invalid_type,
-          CASE WHEN TOTAL(oversized) > 0 THEN 1 ELSE 0 END AS has_oversized_value
-        FROM (
-          SELECT
-            CASE WHEN typeof(sql) = 'text' THEN 0 ELSE 1 END AS invalid_type,
-            CASE WHEN typeof(sql) = 'text' AND length(CAST(sql AS BLOB)) <= ? THEN 0 ELSE 1 END AS oversized
-          FROM sqlite_master
-          WHERE type = 'table' AND name = 'record_search'
-          LIMIT 2
-        )`,
-      )
-      .get(MAX_CACHE_SCHEMA_BYTES) as CacheIntegrityProbe | undefined,
-    2,
+      .prepare(`SELECT COUNT(*) AS row_count,
+      0 AS exceeds_aggregate_bytes, 0 AS has_invalid_type,
+      CASE WHEN MAX(octet_length(sql)) > ? THEN 1 ELSE 0 END AS has_oversized_value
+      FROM (SELECT sql FROM sqlite_schema LIMIT ?)`)
+      .get(MAX_CACHE_SCHEMA_BYTES, maximumRows) as CacheIntegrityProbe | undefined,
+    maximumRows,
   )
-  if (
-    searchSchemaProbe.rows !== 1 ||
-    searchSchemaProbe.exceedsAggregateBytes !== 0 ||
-    searchSchemaProbe.hasInvalidType !== 0 ||
-    searchSchemaProbe.hasOversizedValue !== 0
-  ) {
-    throw new CacheSchemaMismatch('The record_search cache table is not an FTS5 table.')
+  if (probe.rows !== expected.length || probe.hasOversizedValue !== 0) {
+    throw new CacheSchemaMismatch('The cache has an incompatible owned schema.')
   }
-  cacheReadTestHooks.beforeIntegrityTextRead?.('record-search-schema')
-  const searchSchema = database
-    .prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'record_search' LIMIT 2")
-    .get() as { sql?: unknown } | undefined
-  if (
-    typeof searchSchema?.sql !== 'string' ||
-    !sameOwnedSchema(searchSchema.sql, `CREATE VIRTUAL TABLE record_search USING ${RECORD_SEARCH_DEFINITION}`)
-  ) {
-    throw new CacheSchemaMismatch('The record_search cache table is not an FTS5 table.')
+  const match = database.prepare(`SELECT COUNT(*) AS matches FROM sqlite_schema
+    WHERE type = ? AND name = ? AND tbl_name = ? AND sql IS ?`)
+  for (const object of expected) {
+    if (match.get(object.type, object.name, object.tbl_name, object.sql)?.matches !== 1) {
+      throw new CacheSchemaMismatch('The cache has an incompatible owned schema.')
+    }
   }
-  assertTableColumns(database, 'record_search', ['id', 'text', 'preview'])
 }
 
 const assertCacheSchema = (database: DatabaseSync) => {
@@ -822,12 +372,8 @@ const assertCacheSchema = (database: DatabaseSync) => {
 }
 
 const createCacheSchema = (database: DatabaseSync) => {
-  database.exec(`
-    CREATE TABLE metadata ${METADATA_TABLE_DEFINITION};
-    CREATE TABLE records ${RECORDS_TABLE_DEFINITION};
-    ${RECORDS_INDEX_DEFINITIONS};
-    CREATE VIRTUAL TABLE record_search USING ${RECORD_SEARCH_DEFINITION};
-  `)
+  database.exec(`PRAGMA application_id = ${CACHE_APPLICATION_ID}; PRAGMA user_version = ${SCHEMA_VERSION};
+    ${CACHE_SCHEMA.join(';')};`)
 }
 
 const assertCacheTransaction = (database: DatabaseSync, validate: (opened: DatabaseSync) => void): void => {
@@ -1085,26 +631,6 @@ const validateCachedArtifactPath = (value: unknown) => {
   }
 }
 
-const parseCachedRecord = (value: unknown): BrainRecord => {
-  const parsed = parseCacheJson(value, MAX_CACHE_RECORD_BYTES)
-  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    throw new CacheSchemaMismatch('Cached record JSON must be an object.')
-  }
-  const { path, ...recordFile } = parsed as Record<string, unknown>
-  if (typeof path !== 'string') {
-    throw new CacheSchemaMismatch('Cached record JSON must include a runtime path.')
-  }
-  try {
-    const record = parseRecordFile(recordFile)
-    if (path === canonicalRecordPath(record)) {
-      return { ...record, path }
-    }
-  } catch {
-    // Normalise every cached-row validation failure into disposable cache corruption.
-  }
-  throw new CacheSchemaMismatch('Cached record JSON does not match the canonical record schema.')
-}
-
 const readMetadata = (database: DatabaseSync): Metadata | undefined => {
   const maximumRows = METADATA_KEYS.length + 1
   const maximumKeyBytes = Math.max(...METADATA_KEYS.map(key => Buffer.byteLength(key, 'utf8')))
@@ -1180,6 +706,7 @@ const readMetadata = (database: DatabaseSync): Metadata | undefined => {
   const artifactPaths = parseCacheJson(artifactPathsValue, MAX_CACHE_METADATA_BYTES)
   const recordsIndexed = /^(?:0|[1-9]\d*)$/.test(recordsIndexedValue) ? Number(recordsIndexedValue) : Number.NaN
   if (
+    schemaVersion !== SCHEMA_VERSION ||
     !Array.isArray(artifactPaths) ||
     artifactPaths.length > CANONICAL_BUDGETS.records ||
     (recordFingerprint !== undefined && !/^[0-9a-f]{64}$/u.test(recordFingerprint)) ||
@@ -1262,7 +789,7 @@ const assertSearchIndexBounded = (database: DatabaseSync) => {
         typeof row.bytes !== 'number' ||
         !Number.isSafeInteger(row.bytes) ||
         row.bytes < 0 ||
-        row.bytes > MAX_CACHE_RECORD_BYTES ||
+        row.bytes > MAX_CACHE_SEARCH_SOURCE_BYTES ||
         row.bytes > MAX_CACHE_SEARCH_INDEX_BYTES - totalBytes
       ) {
         throw new CacheSchemaMismatch('The cache search index exceeds its storage bounds.')
@@ -1277,51 +804,20 @@ const assertCacheContentConsistent = (database: DatabaseSync, metadata: Metadata
   const recordsProbe = readIntegrityProbe(
     'records',
     database
-      .prepare(
-        `SELECT
-          COUNT(*) AS row_count,
-          CASE WHEN TOTAL(record_json_bytes) > ?1 OR TOTAL(record_text_bytes) > ?2
-            THEN 1 ELSE 0 END AS exceeds_aggregate_bytes,
-          CASE WHEN TOTAL(invalid_type) > 0 THEN 1 ELSE 0 END AS has_invalid_type,
-          CASE WHEN TOTAL(oversized) > 0 THEN 1 ELSE 0 END AS has_oversized_value
-        FROM (
-          SELECT
-            CASE WHEN typeof(id) = 'text'
-                       AND typeof(kind) = 'text'
-                       AND typeof(subject) = 'text'
-                       AND typeof(source) = 'text'
-                       AND typeof(created_at) = 'text'
-                       AND typeof(path) = 'text'
-                       AND typeof(active) = 'integer'
-                       AND active IN (0, 1)
-                       AND typeof(summary) IN ('null', 'text')
-                       AND typeof(record_json) = 'text'
-                 THEN 0 ELSE 1 END AS invalid_type,
-            CASE WHEN typeof(id) = 'text' AND length(CAST(id AS BLOB)) <= ?3
-                       AND typeof(kind) = 'text' AND length(CAST(kind AS BLOB)) <= ?3
-                       AND typeof(subject) = 'text' AND length(CAST(subject AS BLOB)) <= ?3
-                       AND typeof(source) = 'text' AND length(CAST(source AS BLOB)) <= ?3
-                       AND typeof(created_at) = 'text' AND length(CAST(created_at AS BLOB)) <= ?3
-                       AND typeof(path) = 'text' AND length(CAST(path AS BLOB)) <= ?3
-                       AND (typeof(summary) = 'null'
-                         OR (typeof(summary) = 'text' AND length(CAST(summary AS BLOB)) <= ?3))
-                       AND typeof(record_json) = 'text' AND length(CAST(record_json AS BLOB)) <= ?3
-                 THEN 0 ELSE 1 END AS oversized,
-            CASE WHEN typeof(record_json) = 'text'
-                 THEN length(CAST(record_json AS BLOB)) ELSE 0 END AS record_json_bytes,
-            (CASE WHEN typeof(id) = 'text' THEN length(CAST(id AS BLOB)) ELSE 0 END
-              + CASE WHEN typeof(kind) = 'text' THEN length(CAST(kind AS BLOB)) ELSE 0 END
-              + CASE WHEN typeof(subject) = 'text' THEN length(CAST(subject AS BLOB)) ELSE 0 END
-              + CASE WHEN typeof(source) = 'text' THEN length(CAST(source AS BLOB)) ELSE 0 END
-              + CASE WHEN typeof(created_at) = 'text' THEN length(CAST(created_at AS BLOB)) ELSE 0 END
-              + CASE WHEN typeof(path) = 'text' THEN length(CAST(path AS BLOB)) ELSE 0 END
-              + CASE WHEN typeof(summary) = 'text' THEN length(CAST(summary AS BLOB)) ELSE 0 END
-            ) AS record_text_bytes
-          FROM records
-          LIMIT ?4
-        )`,
-      )
-      .get(MAX_CACHE_RECORD_JSON_BYTES, MAX_CACHE_RECORD_TEXT_BYTES, MAX_CACHE_RECORD_BYTES, maximumRows) as
+      .prepare(`SELECT COUNT(*) AS row_count,
+      CASE WHEN TOTAL(text_bytes) > ?1 THEN 1 ELSE 0 END AS exceeds_aggregate_bytes,
+      CASE WHEN TOTAL(invalid_type) > 0 THEN 1 ELSE 0 END AS has_invalid_type,
+      CASE WHEN TOTAL(oversized) > 0 THEN 1 ELSE 0 END AS has_oversized_value
+      FROM (SELECT
+        CASE WHEN typeof(id) = 'text' AND typeof(kind) = 'text' AND typeof(subject) = 'text'
+          AND typeof(created_at) = 'text' AND typeof(active) = 'integer' AND active IN (0, 1)
+          THEN 0 ELSE 1 END AS invalid_type,
+        CASE WHEN octet_length(id) <= 255 AND octet_length(kind) <= 255
+          AND octet_length(subject) <= ?2 AND octet_length(created_at) <= ?2
+          THEN 0 ELSE 1 END AS oversized,
+        octet_length(id) + octet_length(kind) + octet_length(subject) + octet_length(created_at) AS text_bytes
+        FROM records LIMIT ?3)`)
+      .get(CANONICAL_BUDGETS.recordJsonBytes, CANONICAL_BUDGETS.recordBytes, maximumRows) as
       | CacheIntegrityProbe
       | undefined,
     maximumRows,
@@ -1336,76 +832,54 @@ const assertCacheContentConsistent = (database: DatabaseSync, metadata: Metadata
     throw new CacheSchemaMismatch('The cache record table does not match its metadata.')
   }
   cacheReadTestHooks.beforeIntegrityTextRead?.('records')
-  const recordRows = database
-    .prepare('SELECT id, active FROM records ORDER BY id COLLATE BINARY LIMIT ?')
-    .iterate(maximumRows) as Iterable<{
+  const recordKeys = database.prepare(
+    'SELECT rowid, CAST(id AS BLOB) AS id_bytes, active FROM records ORDER BY id LIMIT ?',
+  )
+  recordKeys.setReadBigInts(true)
+  const recordRows = recordKeys.iterate(maximumRows) as Iterable<{
+    rowid?: unknown
+    id_bytes?: unknown
     active?: unknown
-    id?: unknown
   }>
-  // One bounded identity/active-bit map also tracks unmatched FTS rows; it never retains documents.
+  // Only identities/active bits survive each streamed comparison, including for writer subsets.
   const members = new Map<string, 0 | 1>()
   const subsetSuperseded = recordsProbe.rows === snapshot.records.length ? undefined : new Set<string>()
   const representation = database.prepare(`SELECT
-    CASE WHEN CAST(record_json AS BLOB) = CAST(?1 AS BLOB) THEN NULL
-      ELSE CAST(record_json AS BLOB) END AS mismatch_bytes,
-    CAST(id AS BLOB) = CAST(?2 AS BLOB) AND CAST(kind AS BLOB) = CAST(?3 AS BLOB)
-      AND CAST(subject AS BLOB) = CAST(?4 AS BLOB) AND CAST(source AS BLOB) = CAST(?5 AS BLOB)
-      AND CAST(created_at AS BLOB) = CAST(?6 AS BLOB) AND CAST(path AS BLOB) = CAST(?7 AS BLOB)
-      AND (CAST(summary AS BLOB) IS CAST(?8 AS BLOB)) AS projection_matches
-    FROM records WHERE id = ?2`)
+    CAST(id AS BLOB) = CAST(?1 AS BLOB) AND CAST(kind AS BLOB) = CAST(?2 AS BLOB)
+      AND CAST(subject AS BLOB) = CAST(?3 AS BLOB) AND CAST(created_at AS BLOB) = CAST(?4 AS BLOB) AS matches
+    FROM records WHERE rowid = ?5`)
   for (const row of recordRows) {
-    const canonical = typeof row.id === 'string' ? snapshot.byId.get(row.id) : undefined
-    if (canonical === undefined || members.has(canonical.id)) {
+    const id = row.id_bytes instanceof Uint8Array ? Buffer.from(row.id_bytes).toString('utf8') : undefined
+    const canonical = id === undefined ? undefined : snapshot.byId.get(id)
+    if (canonical === undefined || members.has(canonical.id) || typeof row.rowid !== 'bigint') {
       throw new CacheSchemaMismatch('The cache record table does not match the canonical record corpus.')
     }
-    // The writer's exact representation needs no transfer or parse. Preserve structural and
-    // normalisation compatibility for other encodings with the existing bounded parser.
     const { summary } = snapshot.recordFacts(canonical).projection
-    const encoded = representation.get(
-      JSON.stringify(canonical),
-      canonical.id,
-      canonical.kind,
-      canonical.subject,
-      canonical.source,
-      canonical.createdAt,
-      canonical.path,
-      summary,
-    ) as { mismatch_bytes?: unknown; projection_matches?: unknown } | undefined
     if (
-      encoded === undefined ||
-      (encoded.mismatch_bytes !== null &&
-        !(
-          encoded.mismatch_bytes instanceof Uint8Array &&
-          isUtf8(encoded.mismatch_bytes) &&
-          isDeepStrictEqual(parseCachedRecord(Buffer.from(encoded.mismatch_bytes).toString('utf8')), canonical)
-        ))
-    ) {
-      throw new CacheSchemaMismatch('The cache record table does not match the canonical record corpus.')
-    }
-    // SQL bindings replace lone surrogates; byte equality must not relax the old scalar string equality.
-    if (
-      encoded.projection_matches !== 1 ||
-      !canonical.source.isWellFormed() ||
+      representation.get(canonical.id, canonical.kind, canonical.subject, canonical.createdAt, row.rowid)?.matches !==
+        1 ||
       !canonical.subject.isWellFormed() ||
+      !canonical.source.isWellFormed() ||
       (summary !== null && !summary.isWellFormed()) ||
-      (row.active !== 0 && row.active !== 1)
+      (row.active !== 0n && row.active !== 1n)
     ) {
-      throw new CacheSchemaMismatch('The cache record table does not match its canonical JSON.')
+      throw new CacheSchemaMismatch('The cache record projection does not match the canonical record corpus.')
     }
-    members.set(canonical.id, row.active)
+    members.set(canonical.id, row.active === 1n ? 1 : 0)
     if (subsetSuperseded !== undefined) {
-      for (const id of canonical.supersedes ?? []) {
-        subsetSuperseded.add(id)
+      for (const supersededId of canonical.supersedes ?? []) {
+        subsetSuperseded.add(supersededId)
       }
     }
   }
+
   if (members.size !== recordsProbe.rows) {
     throw new CacheSchemaMismatch('The cache record table does not match the canonical record corpus.')
   }
   const superseded = subsetSuperseded ?? snapshot.supersededIds
   for (const [id, active] of members) {
     if (active !== (superseded.has(id) ? 0 : 1)) {
-      throw new CacheSchemaMismatch('The cache record table does not match its canonical JSON.')
+      throw new CacheSchemaMismatch('The cache record projection does not match the canonical record corpus.')
     }
   }
   // A writer can replace a proper predecessor subset, but its active bits and raw witnesses
@@ -1420,39 +894,25 @@ const assertCacheContentConsistent = (database: DatabaseSync, metadata: Metadata
   const searchProbe = readIntegrityProbe(
     'record-search',
     database
-      .prepare(
-        `SELECT
-          COUNT(*) AS row_count,
-          CASE WHEN TOTAL(id_bytes) > ?1 OR TOTAL(text_bytes) > ?2 OR TOTAL(preview_bytes) > ?6
-            THEN 1 ELSE 0 END AS exceeds_aggregate_bytes,
-          CASE WHEN TOTAL(invalid_type) > 0 THEN 1 ELSE 0 END AS has_invalid_type,
-          CASE WHEN TOTAL(oversized) > 0 THEN 1 ELSE 0 END AS has_oversized_value
-        FROM (
-          SELECT
-            CASE WHEN typeof(id) = 'text' AND typeof(text) = 'text' AND typeof(preview) = 'text'
-                 THEN 0 ELSE 1 END AS invalid_type,
-            CASE WHEN typeof(id) = 'text' AND length(CAST(id AS BLOB)) <= ?3
-                       AND typeof(text) = 'text' AND length(CAST(text AS BLOB)) <= ?4
-                       AND typeof(preview) = 'text' AND length(CAST(preview AS BLOB)) <= ?7
-                 THEN 0 ELSE 1 END AS oversized,
-            CASE WHEN typeof(id) = 'text' THEN length(CAST(id AS BLOB)) ELSE 0 END AS id_bytes,
-            CASE WHEN typeof(text) = 'text' THEN length(CAST(text AS BLOB)) ELSE 0 END AS text_bytes,
-            CASE WHEN typeof(preview) = 'text' THEN length(CAST(preview AS BLOB)) ELSE 0 END AS preview_bytes
-          FROM record_search
-          LIMIT ?5
-        )`,
-      )
+      .prepare(`SELECT COUNT(*) AS row_count,
+      CASE WHEN TOTAL(text_bytes) > ?1 OR TOTAL(preview_bytes) > ?2 THEN 1 ELSE 0 END AS exceeds_aggregate_bytes,
+      CASE WHEN TOTAL(invalid_type) > 0 THEN 1 ELSE 0 END AS has_invalid_type,
+      CASE WHEN TOTAL(oversized) > 0 THEN 1 ELSE 0 END AS has_oversized_value
+      FROM (SELECT
+        CASE WHEN typeof(text) = 'text' AND typeof(preview) = 'text' THEN 0 ELSE 1 END AS invalid_type,
+        CASE WHEN octet_length(text) <= ?3 AND octet_length(preview) <= ?4 THEN 0 ELSE 1 END AS oversized,
+        octet_length(text) AS text_bytes, octet_length(preview) AS preview_bytes
+        FROM record_search LIMIT ?5)`)
       .get(
-        MAX_CACHE_FTS_ID_BYTES,
         MAX_CACHE_SEARCH_DOCUMENT_AGGREGATE_BYTES,
-        255,
-        MAX_CACHE_SEARCH_DOCUMENT_BYTES,
-        maximumRows,
         MAX_CACHE_SEARCH_PREVIEW_AGGREGATE_BYTES,
+        MAX_CACHE_SEARCH_DOCUMENT_BYTES,
         MAX_CACHE_SEARCH_PREVIEW_BYTES,
+        maximumRows,
       ) as CacheIntegrityProbe | undefined,
     maximumRows,
   )
+
   if (
     searchProbe.rows !== metadata.recordsIndexed ||
     searchProbe.rows >= maximumRows ||
@@ -1470,39 +930,32 @@ const assertCacheContentConsistent = (database: DatabaseSync, metadata: Metadata
     throw new CacheSchemaMismatch('The cache search index is inconsistent.')
   }
   cacheReadTestHooks.beforeIntegrityTextRead?.('record-search')
-  // Sort keys only: including full FTS documents here would retain them in SQLite's sorter.
-  const searchKeys = database.prepare(`SELECT rowid AS search_rowid, CAST(id AS BLOB) AS id_bytes
-    FROM record_search ORDER BY CAST(id AS BLOB), rowid LIMIT ?`)
+  // LEFT JOIN keeps orphans visible; only keys cross into JavaScript. Each records rowid is
+  // unique, so equal counts plus one consumed canonical member per FTS row prove a bijection.
+  const searchKeys = database.prepare(`SELECT record_search.rowid AS search_rowid, CAST(records.id AS BLOB) AS id_bytes
+    FROM record_search LEFT JOIN records ON records.rowid = record_search.rowid LIMIT ?`)
   searchKeys.setReadBigInts(true)
-  const searchRows = searchKeys.iterate(maximumRows) as Iterable<{
-    id_bytes?: unknown
-    search_rowid?: unknown
-  }>
-  const searchContent = database.prepare(`SELECT
-      CAST(id AS BLOB) = CAST(? AS BLOB) AND CAST(text AS BLOB) = CAST(? AS BLOB)
-        AND CAST(preview AS BLOB) = CAST(? AS BLOB) AS matches
-    FROM record_search WHERE rowid = ?`)
+  const searchRows = searchKeys.iterate(maximumRows) as Iterable<{ id_bytes?: unknown; search_rowid?: unknown }>
+  const searchContent = database.prepare(`SELECT CAST(text AS BLOB) = CAST(? AS BLOB)
+    AND CAST(preview AS BLOB) = CAST(? AS BLOB) AS matches FROM record_search WHERE rowid = ?`)
   let searchRowsRead = 0
   for (const row of searchRows) {
-    if (!(row.id_bytes instanceof Uint8Array) || typeof row.search_rowid !== 'bigint') {
-      throw new CacheSchemaMismatch('The cache record and search tables are inconsistent.')
-    }
-    const id = Buffer.from(row.id_bytes).toString('utf8')
-    const canonical = snapshot.byId.get(id)
-    if (canonical === undefined || !members.has(id) || Buffer.compare(row.id_bytes, Buffer.from(id, 'utf8')) !== 0) {
+    const id = row.id_bytes instanceof Uint8Array ? Buffer.from(row.id_bytes).toString('utf8') : undefined
+    const canonical = id === undefined ? undefined : snapshot.byId.get(id)
+    if (canonical === undefined || !members.has(canonical.id) || typeof row.search_rowid !== 'bigint') {
       throw new CacheSchemaMismatch('The cache record and search tables are inconsistent.')
     }
     const { summary } = snapshot.recordFacts(canonical).projection
-    const content = searchContent.get(
-      id,
-      searchDocumentForRecord(canonical, summary),
-      searchPreviewForRecord(canonical, summary),
-      row.search_rowid,
-    ) as { matches?: unknown } | undefined
-    if (content?.matches !== 1) {
+    if (
+      searchContent.get(
+        searchDocumentForRecord(canonical, summary),
+        searchPreviewForRecord(canonical, summary),
+        row.search_rowid,
+      )?.matches !== 1
+    ) {
       throw new CacheSchemaMismatch('The cache record and search tables are inconsistent.')
     }
-    members.delete(id)
+    members.delete(canonical.id)
     searchRowsRead += 1
   }
   if (searchRowsRead !== searchProbe.rows || members.size !== 0) {
@@ -1684,27 +1137,21 @@ const writeCacheSnapshot = (
       }
       assertCacheWriteSnapshotCurrent(snapshot)
       database.exec('DELETE FROM record_search; DELETE FROM records; DELETE FROM metadata;')
-      const insertRecord = database.prepare(`
-        INSERT INTO records(id, kind, subject, source, created_at, path, active, summary, record_json)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `)
-      const insertSearch = database.prepare('INSERT INTO record_search(id, text, preview) VALUES (?, ?, ?)')
+      const insertRecord = database.prepare(`INSERT INTO records(id, kind, subject, created_at, active)
+        VALUES (?, ?, ?, ?, ?)`)
+      const insertSearch = database.prepare('INSERT INTO record_search(rowid, text, preview) VALUES (?, ?, ?)')
       for (const record of snapshot.records) {
-        const projected = record
         const { projection } = snapshot.recordFacts(record)
-        insertRecord.run(
-          projected.id,
-          projected.kind,
-          projected.subject,
-          projected.source,
-          projected.createdAt,
-          projected.path,
-          snapshot.activeIds.has(projected.id) ? 1 : 0,
-          projection.summary,
-          JSON.stringify(record),
+        const { lastInsertRowid } = insertRecord.run(
+          record.id,
+          record.kind,
+          record.subject,
+          record.createdAt,
+          snapshot.activeIds.has(record.id) ? 1 : 0,
         )
-        insertSearch.run(projected.id, projection.text, projection.preview)
+        insertSearch.run(lastInsertRowid, projection.text, projection.preview)
       }
+
       writeMetadata(database, {
         artifactPaths,
         manifest: snapshot.manifest,
@@ -2034,7 +1481,7 @@ const runWithDisposableCacheRecovery = <Result>(
 
 type CachePreparationCompletion<Result> =
   | { kind: 'prepare' }
-  | { kind: 'read'; read: (database: DatabaseSync) => Result; state: CacheReadRecoveryState }
+  | { kind: 'read'; read: (database: DatabaseSync, corpus: VerifiedCorpus) => Result; state: CacheReadRecoveryState }
 
 type FreshCacheResult<Result> = { kind: 'fresh'; result: Result } | { kind: 'stale' }
 
@@ -2062,7 +1509,7 @@ const readFreshCacheResult = <Result>(
           const result = (() => {
             if (completion.kind === 'read') {
               cacheReadInstrumentation.beforeResultRead?.()
-              const read = completion.read(database)
+              const read = completion.read(database, snapshot)
               cacheReadInstrumentation.afterResultRead?.()
               return read
             }
@@ -2094,7 +1541,7 @@ function requireFreshCacheResult<Result>(
   location: CacheLocation,
   completion: {
     kind: 'read'
-    read: (database: DatabaseSync) => Result
+    read: (database: DatabaseSync, corpus: VerifiedCorpus) => Result
     state: CacheReadRecoveryState
   },
   expectedRebuild?: CompletedCacheRebuild,
@@ -2127,7 +1574,7 @@ function resolvePreparedCacheWithoutCorruptionRecovery<Result>(
   location: CacheLocation,
   completion: {
     kind: 'read'
-    read: (database: DatabaseSync) => Result
+    read: (database: DatabaseSync, corpus: VerifiedCorpus) => Result
     state: CacheReadRecoveryState
   },
   lockMode?: CacheRecoveryLockMode,
@@ -2293,11 +1740,14 @@ const compactResultLimit = (value: unknown) => positiveLimit(value, 'compactResu
 const readFreshCache = <Result>(
   root: string,
   location: CacheLocation,
-  read: (database: DatabaseSync) => Result,
+  read: (database: DatabaseSync, corpus: VerifiedCorpus) => Result,
   state: CacheReadRecoveryState,
 ) => requireFreshCacheResult(root, location, { kind: 'read', read, state }, state.rebuild)
 
-const withPreparedDatabase = <Result>(input: RootInput, read: (database: DatabaseSync) => Result) => {
+const withPreparedDatabase = <Result>(
+  input: RootInput,
+  read: (database: DatabaseSync, corpus: VerifiedCorpus) => Result,
+) => {
   const root = resolveRepository(input)
   const readState: CacheReadRecoveryState = {}
   try {
@@ -2321,32 +1771,29 @@ const withPreparedDatabase = <Result>(input: RootInput, read: (database: Databas
   }
 }
 
-const parseRecordRow = (row: RecordRow) => parseCachedRecord(row.record_json)
-
-const recordRowBytes = (row: RecordRow) => {
-  if (typeof row.record_bytes === 'number' && Number.isFinite(row.record_bytes) && row.record_bytes >= 0) {
-    return row.record_bytes
+const canonicalRecordFromRow = (row: RecordRow, corpus: VerifiedCorpus): BrainRecord => {
+  const record = typeof row.id === 'string' ? corpus.byId.get(row.id) : undefined
+  if (record !== undefined) {
+    return record
   }
-  if (typeof row.record_json === 'string') {
-    return byteLength(row.record_json)
-  }
-  return 0
+  throw new CacheSchemaMismatch('The cache returned an unknown canonical record identity.')
 }
 
-const parseRecordRowWithinBudget = (row: RecordRow, budget: ResponseByteBudget) => {
-  budget.chargeBytes(recordRowBytes(row))
-  return parseRecordRow(row)
+const materializeRecordRow = (row: RecordRow, corpus: VerifiedCorpus, budget: ResponseByteBudget) => {
+  const record = canonicalRecordFromRow(row, corpus)
+  budget.chargeBytes(byteLength(JSON.stringify(record)))
+  return structuredClone(record)
 }
 
-const parseRecordRowsWithinBudget = (rows: Iterable<RecordRow>) => {
+const materializeRecordRows = (rows: Iterable<RecordRow>, corpus: VerifiedCorpus) => {
   const budget = createResponseByteBudget('fullResponseBytes')
-  return Array.from(rows, row => parseRecordRowWithinBudget(row, budget))
+  return Array.from(rows, row => materializeRecordRow(row, corpus, budget))
 }
 
 export const listRecords = (input: ListRecordsInput = {}): BrainRecord[] => {
   const parsed = parseListRecordsInput(input)
   const limit = fullResultLimit(parsed.limit)
-  return withPreparedDatabase(parsed, database => {
+  return withPreparedDatabase(parsed, (database, corpus) => {
     const conditions = [
       parsed.includeSuperseded === true ? undefined : 'active = 1',
       parsed.kind === undefined ? undefined : 'kind = ?',
@@ -2359,24 +1806,20 @@ export const listRecords = (input: ListRecordsInput = {}): BrainRecord[] => {
     ]
     const where = conditions.length === 0 ? '' : `WHERE ${conditions.join(' AND ')}`
     const rows = database
-      .prepare(
-        `SELECT record_json, length(cast(record_json AS BLOB)) AS record_bytes FROM records ${where} ORDER BY created_at DESC, id DESC LIMIT ?`,
-      )
+      .prepare(`SELECT id FROM records ${where} ORDER BY created_at DESC, id DESC LIMIT ?`)
       .iterate(...parameters) as Iterable<RecordRow>
-    return parseRecordRowsWithinBudget(rows)
+    return materializeRecordRows(rows, corpus)
   })
 }
 
 export const showRecord = (input: ShowRecordInput): BrainRecord | null => {
   const parsed = parseShowRecordInput(input)
-  return withPreparedDatabase(parsed, database => {
+  return withPreparedDatabase(parsed, (database, corpus) => {
     const activeClause = parsed.activeOnly === true ? ' AND active = 1' : ''
-    const row = database
-      .prepare(
-        `SELECT record_json, length(cast(record_json AS BLOB)) AS record_bytes FROM records WHERE id = ?${activeClause}`,
-      )
-      .get(parsed.id) as RecordRow | undefined
-    return row === undefined ? null : parseRecordRowWithinBudget(row, createResponseByteBudget('fullResponseBytes'))
+    const row = database.prepare(`SELECT id FROM records WHERE id = ?${activeClause}`).get(parsed.id) as
+      | RecordRow
+      | undefined
+    return row === undefined ? null : materializeRecordRow(row, corpus, createResponseByteBudget('fullResponseBytes'))
   })
 }
 
@@ -2393,29 +1836,14 @@ const searchRows = (database: DatabaseSync, input: SearchRecordsInput, match: st
   return database
     .prepare(`
     SELECT
-      records.record_json,
-      length(cast(records.record_json AS BLOB)) AS record_bytes
+      records.id
     FROM record_search
-    JOIN records ON records.id = record_search.id
+    JOIN records ON records.rowid = record_search.rowid
     WHERE ${conditions.join(' AND ')}
     ORDER BY bm25(record_search) ASC, records.created_at DESC, records.id DESC
     LIMIT ?
   `)
     .iterate(...parameters) as Iterable<RecordRow>
-}
-
-const compactText = (value: unknown, field: string) => {
-  if (typeof value === 'string') {
-    return value
-  }
-  throw new CacheSchemaMismatch(`Cached compact ${field} must be text.`)
-}
-
-const compactSummary = (value: unknown) => {
-  if (value === null || typeof value === 'string') {
-    return value
-  }
-  throw new CacheSchemaMismatch('Cached compact summary must be text or null.')
 }
 
 const compactRank = (value: unknown) => {
@@ -2432,17 +1860,25 @@ const compactSnippet = (value: unknown) => {
   throw new CacheSchemaMismatch('Cached search snippet must be text.')
 }
 
-const compactRecordFromRow = (row: CompactRow): CompactBrainRecord => ({
-  id: compactText(row.id, 'id'),
-  kind: compactText(row.kind, 'kind'),
-  path: compactText(row.path, 'path'),
-  rank: compactRank(row.rank),
-  snippet: compactSnippet(row.snippet),
-  subject: compactText(row.subject, 'subject'),
-  summary: compactSummary(row.summary),
-})
+const compactRecordFromRow = (row: CompactRow, corpus: VerifiedCorpus): CompactBrainRecord => {
+  const record = canonicalRecordFromRow(row, corpus)
+  return {
+    id: record.id,
+    kind: record.kind,
+    path: record.path,
+    rank: compactRank(row.rank),
+    snippet: compactSnippet(row.snippet),
+    subject: record.subject,
+    summary: corpus.recordFacts(record).projection.summary,
+  }
+}
 
-const createCompactSearchReader = (database: DatabaseSync, input: SearchStatementInput, budget: ResponseByteBudget) => {
+const createCompactSearchReader = (
+  database: DatabaseSync,
+  corpus: VerifiedCorpus,
+  input: SearchStatementInput,
+  budget: ResponseByteBudget,
+) => {
   const conditions = [
     'record_search MATCH ?',
     input.includeSuperseded === true ? undefined : 'records.active = 1',
@@ -2453,14 +1889,10 @@ const createCompactSearchReader = (database: DatabaseSync, input: SearchStatemen
   const source = `
     SELECT
       records.id,
-      records.kind,
-      records.subject,
-      records.path,
-      records.summary,
       bm25(record_search) AS rank,
-      snippet(record_search, 2, '[', ']', '...', 16) AS snippet
+      snippet(record_search, 1, '[', ']', '...', 16) AS snippet
     FROM record_search
-    JOIN records ON records.id = record_search.id
+    JOIN records ON records.rowid = record_search.rowid
     WHERE ${conditions.join(' AND ')}
     ORDER BY rank ASC, records.created_at DESC, records.id DESC
     LIMIT ?
@@ -2472,7 +1904,7 @@ const createCompactSearchReader = (database: DatabaseSync, input: SearchStatemen
       return []
     }
     const records = Array.from(statement.iterate(match, ...kindParameters, limit) as Iterable<CompactRow>, row =>
-      budget.charge(compactRecordFromRow(row)),
+      budget.charge(compactRecordFromRow(row, corpus)),
     )
     cacheReadTestHooks.afterCompactSearchRead?.(query)
     return records
@@ -2484,8 +1916,8 @@ export const searchRecords = (input: SearchRecordsInput): BrainRecord[] => {
   const match = literalMatchQuery(parsed.query)
   const limit = fullResultLimit(parsed.limit)
   if (match.length > 0) {
-    return withPreparedDatabase(parsed, database =>
-      parseRecordRowsWithinBudget(searchRows(database, parsed, match, limit)),
+    return withPreparedDatabase(parsed, (database, corpus) =>
+      materializeRecordRows(searchRows(database, parsed, match, limit), corpus),
     )
   }
   resolveRepository(parsed)
@@ -2497,25 +1929,25 @@ export const searchCompactRecords = (input: SearchRecordsInput): CompactBrainRec
   const match = literalMatchQuery(parsed.query)
   compactResultLimit(parsed.limit)
   if (match.length > 0) {
-    return withPreparedDatabase(parsed, database => {
+    return withPreparedDatabase(parsed, (database, corpus) => {
       const budget = createResponseByteBudget('compactResponseBytes')
       budget.charge([])
-      return createCompactSearchReader(database, parsed, budget)(parsed.query, match)
+      return createCompactSearchReader(database, corpus, parsed, budget)(parsed.query, match)
     })
   }
   resolveRepository(parsed)
   return []
 }
 
-const createShowReader = (database: DatabaseSync, includeSuperseded: boolean | undefined) => {
+const createShowReader = (database: DatabaseSync, corpus: VerifiedCorpus, includeSuperseded: boolean | undefined) => {
   const activeClause = includeSuperseded === true ? '' : ' AND active = 1'
-  const source = `SELECT record_json FROM records WHERE id = ?${activeClause}`
+  const source = `SELECT id FROM records WHERE id = ?${activeClause}`
   cacheReadTestHooks.onShowPrepare?.(source)
   const statement = database.prepare(source)
   return (id: string) => {
     const row = statement.get(id) as RecordRow | undefined
     cacheReadTestHooks.afterShowRead?.(id)
-    return row === undefined ? null : parseRecordRow(row)
+    return row === undefined ? null : structuredClone(canonicalRecordFromRow(row, corpus))
   }
 }
 
@@ -2535,6 +1967,7 @@ const assertGatherBudgets = (input: GatherInput): LiteralSearch[] => {
 
 const readGatherFromDatabase = (
   database: DatabaseSync,
+  corpus: VerifiedCorpus,
   input: GatherInput,
   hydrated: HydrateResult | null,
   searches: readonly LiteralSearch[],
@@ -2542,9 +1975,9 @@ const readGatherFromDatabase = (
   const shows = input.shows ?? []
   const budget = createResponseByteBudget('gatherResponseBytes')
   budget.charge({ hydrated, records: [], searches: [] })
-  const showRecordForId = shows.length === 0 ? () => null : createShowReader(database, input.includeSuperseded)
+  const showRecordForId = shows.length === 0 ? () => null : createShowReader(database, corpus, input.includeSuperseded)
   const searchCompactRecordsForQuery =
-    searches.length === 0 ? () => [] : createCompactSearchReader(database, input, budget)
+    searches.length === 0 ? () => [] : createCompactSearchReader(database, corpus, input, budget)
   const shownRecords = new Map<string, BrainRecord | null>()
   const searchResults = new Map<string, readonly CompactBrainRecord[]>()
   const memoizedShowRecordForId = (id: string) => {
@@ -2600,8 +2033,14 @@ const gatherRecordsFromDatabase = (input: GatherInput, searches: readonly Litera
         return readFreshCache(
           root,
           heldLocation,
-          database =>
-            readGatherFromDatabase(database, input, { recordsIndexed: rebuild.result.recordsIndexed }, searches),
+          (database, corpus) =>
+            readGatherFromDatabase(
+              database,
+              corpus,
+              input,
+              { recordsIndexed: rebuild.result.recordsIndexed },
+              searches,
+            ),
           readState,
         )
       }
@@ -2627,7 +2066,7 @@ const gatherRecordsFromDatabase = (input: GatherInput, searches: readonly Litera
       () =>
         resolvePreparedCacheWithoutCorruptionRecovery(root, location, {
           kind: 'read',
-          read: database => readGatherFromDatabase(database, input, null, searches),
+          read: (database, corpus) => readGatherFromDatabase(database, corpus, input, null, searches),
           state: readState,
         }),
       { completion: { kind: 'retry-operation' }, lockMode: 'acquire', readState },

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1829,6 +1829,7 @@ export const showRecord = (input: ShowRecordInput): BrainRecord | null => {
   })
 }
 
+// Keep FTS outermost in both search joins; older SQLite otherwise repeats MATCH for every active record.
 const searchRows = (database: DatabaseSync, input: SearchRecordsInput, match: string, limit: number) => {
   if (match.length === 0) {
     return []
@@ -1844,7 +1845,7 @@ const searchRows = (database: DatabaseSync, input: SearchRecordsInput, match: st
     SELECT
       records.id
     FROM record_search
-    JOIN records ON records.rowid = record_search.rowid
+    CROSS JOIN records ON records.rowid = record_search.rowid
     WHERE ${conditions.join(' AND ')}
     ORDER BY bm25(record_search) ASC, records.created_at DESC, records.id DESC
     LIMIT ?
@@ -1898,7 +1899,7 @@ const createCompactSearchReader = (
       bm25(record_search) AS rank,
       snippet(record_search, 1, '[', ']', '...', 16) AS snippet
     FROM record_search
-    JOIN records ON records.rowid = record_search.rowid
+    CROSS JOIN records ON records.rowid = record_search.rowid
     WHERE ${conditions.join(' AND ')}
     ORDER BY rank ASC, records.created_at DESC, records.id DESC
     LIMIT ?

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -7474,6 +7474,34 @@ describe('SQLite cache and reads', () => {
     assert.deepEqual(api.searchRecords({ query: 'corruption', root }), [expected])
   })
 
+  test('recovers a missing ordering-index entry while canonical rows and FTS remain intact', () => {
+    const root = createRoot()
+    const expected = addCacheRecord(root)
+    const before = logicalCacheProjection(root)
+    mutateCache(root, database => {
+      database.enableDefensive(false)
+      database.exec(`
+        CREATE TABLE empty_projection(active INTEGER, created_at TEXT, id TEXT);
+        CREATE INDEX empty_order ON empty_projection(active, created_at DESC, id DESC);
+        PRAGMA writable_schema = ON;
+        UPDATE sqlite_schema SET rootpage = (SELECT rootpage FROM sqlite_schema WHERE name = 'empty_order')
+          WHERE name = 'records_active_order';
+        DELETE FROM sqlite_schema WHERE name IN ('empty_projection', 'empty_order');
+        PRAGMA writable_schema = OFF;
+      `)
+    })
+    assert.deepEqual(logicalCacheProjection(root), before)
+    let quarantines = 0
+    cacheLocationTestHooks.beforeQuarantineRename = path => {
+      if (basename(path) === 'brain.sqlite') {
+        quarantines += 1
+      }
+    }
+    assert.deepEqual(api.listRecords({ root }), [expected])
+    assert.equal(quarantines, 1)
+    assert.deepEqual(api.prepare({ root }), { hydrated: false, recordsIndexed: 1 })
+  })
+
   test('rejects oversized posting blocks and auxiliary values before native FTS validation', () => {
     for (const mutation of [
       'UPDATE record_search_data SET block = zeroblob(1052673) WHERE id > 10',
@@ -7497,7 +7525,7 @@ describe('SQLite cache and reads', () => {
         DatabaseSync.prototype,
         'prepare',
         function observe(this: DatabaseSync, sql: string) {
-          if (!recovered && sql.includes('pragma_integrity_check')) {
+          if (!recovered && sql.includes("pragma_integrity_check('record_search')")) {
             nativeChecksBeforeRecovery += 1
           }
           return prepare.call(this, sql)

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -271,12 +271,12 @@ const logicalCacheProjection = (root: string) => {
   try {
     return {
       metadata: database.prepare('SELECT key, value FROM metadata ORDER BY key').all(),
-      records: database
+      records: database.prepare('SELECT id, kind, subject, created_at, active FROM records ORDER BY id').all(),
+      search: database
         .prepare(
-          'SELECT id, kind, subject, source, created_at, path, active, summary, record_json FROM records ORDER BY id',
+          'SELECT records.id, text, preview FROM record_search JOIN records ON records.rowid = record_search.rowid ORDER BY records.id',
         )
         .all(),
-      search: database.prepare('SELECT id, text, preview FROM record_search ORDER BY id').all(),
     }
   } finally {
     database.close()
@@ -702,18 +702,12 @@ const overwriteCacheWithInternallyConsistentForgery = (
   ].join('\n')
   mutateCache(root, database => {
     database.exec('BEGIN IMMEDIATE')
+    database.prepare('UPDATE records SET id = ?, subject = ? WHERE id = ?').run(forged.id, forged.subject, canonical.id)
     database
       .prepare(
-        `UPDATE records
-         SET subject = ?, summary = ?, record_json = ?
-         WHERE id = ?`,
+        'UPDATE record_search SET text = ?, preview = ? WHERE rowid = (SELECT rowid FROM records WHERE rowid = (SELECT rowid FROM records WHERE id = ?))',
       )
-      .run(forged.subject, forgedSummary, JSON.stringify(forged), canonical.id)
-    database.prepare('UPDATE records SET id = ?, path = ? WHERE id = ?').run(forged.id, forged.path, canonical.id)
-    database.prepare('DELETE FROM record_search WHERE id = ?').run(canonical.id)
-    database
-      .prepare('INSERT INTO record_search(id, text, preview) VALUES (?, ?, ?)')
-      .run(forged.id, forgedSearchDocument, [forged.kind, forged.subject, forged.source, forgedSummary].join('\n'))
+      .run(forgedSearchDocument, [forged.kind, forged.subject, forged.source, forgedSummary].join('\n'), forged.id)
     // Copy the canonical raw fingerprint unchanged: metadata equality must not conceal forged rows.
 
     database.exec('COMMIT')
@@ -2782,13 +2776,51 @@ describe('cache filesystem containment', () => {
 })
 
 describe('SQLite cache and reads', () => {
+  test('serves independent canonical records through reassigned integer cache identities', () => {
+    const root = createRoot()
+    const record = addCacheRecord(root)
+    mutateCache(root, database => {
+      assert.deepEqual(
+        database
+          .prepare("SELECT name FROM pragma_table_info('records')")
+          .all()
+          .map(row => row.name),
+        ['rowid', 'id', 'kind', 'subject', 'created_at', 'active'],
+      )
+      database.exec(`
+        UPDATE records SET rowid = 9223372036854775807;
+        UPDATE record_search SET rowid = 9223372036854775807;
+      `)
+    })
+    let rebuilds = 0
+    cacheReadTestHooks.afterDisposableCacheRecoveryRebuild = () => {
+      rebuilds += 1
+    }
+    const listed = api.listRecords({ root })
+    const shown = api.showRecord({ id: record.id, root })
+    const searched = api.searchRecords({ query: 'recoverable cache row', root })
+    const gathered = api.gatherRecords({ root, shows: [record.id, record.id] })
+    assert.deepEqual(listed, [record])
+    assert.deepEqual(shown, record)
+    assert.deepEqual(searched, [record])
+    assert.deepEqual(gathered.records, [
+      { id: record.id, record },
+      { id: record.id, record },
+    ])
+    assert.equal(rebuilds, 0)
+    const changed = gathered.records[0]?.record
+    assert.ok(changed)
+    assert.ok(changed.payload !== null && typeof changed.payload === 'object' && !Array.isArray(changed.payload))
+    changed.payload.summary = 'Caller mutation'
+    assert.deepEqual(gathered.records[1]?.record, record)
+    assert.deepEqual(api.showRecord({ id: record.id, root }), record)
+  })
+
   const canonicalCacheEquivalenceCases = [
     {
       assertResult: (root: string, canonical: BrainRecord) => {
         assert.deepEqual(api.prepare({ root }), { hydrated: true, recordsIndexed: 1 })
-        const cached = logicalCacheProjection(root).records[0]?.record_json
-        assert.equal(typeof cached, 'string')
-        assert.deepEqual(JSON.parse(cached as string), canonical)
+        assert.deepEqual(api.showRecord({ id: canonical.id, root }), canonical)
       },
       name: 'prepare',
     },
@@ -2880,49 +2912,12 @@ describe('SQLite cache and reads', () => {
     })
     const before = logicalCacheProjection(root)
     mutateCache(root, database => {
-      const records = database
-        .prepare(
-          'SELECT id, kind, subject, source, created_at, path, active, summary, record_json FROM records ORDER BY rowid',
-        )
-        .all() as Array<{
-        active: number
-        created_at: string
-        id: string
-        kind: string
-        path: string
-        record_json: string
-        source: string
-        subject: string
-        summary: string | null
-      }>
-      const search = database.prepare('SELECT id, text, preview FROM record_search ORDER BY rowid').all() as Array<{
-        id: string
-        text: string
-        preview: string
-      }>
-      database.exec('BEGIN IMMEDIATE; DELETE FROM record_search; DELETE FROM records;')
-      const insertRecord = database.prepare(`
-        INSERT INTO records(id, kind, subject, source, created_at, path, active, summary, record_json)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      database.exec(`
+        BEGIN IMMEDIATE;
+        UPDATE records SET rowid = -rowid;
+        UPDATE record_search SET rowid = -rowid;
+        COMMIT;
       `)
-      const insertSearch = database.prepare('INSERT INTO record_search(id, text, preview) VALUES (?, ?, ?)')
-      for (const row of records.reverse()) {
-        insertRecord.run(
-          row.id,
-          row.kind,
-          row.subject,
-          row.source,
-          row.created_at,
-          row.path,
-          row.active,
-          row.summary,
-          row.record_json,
-        )
-      }
-      for (const row of search.reverse()) {
-        insertSearch.run(row.id, row.text, row.preview)
-      }
-      database.exec('COMMIT')
     })
     let rebuilds = 0
     cacheReadTestHooks.afterDisposableCacheRecoveryRebuild = () => {
@@ -3767,10 +3762,10 @@ describe('SQLite cache and reads', () => {
         writerInitialisations += 1
       }
     }
-    for (const version of ['1', '2']) {
+    for (const version of ['1', '2', '3']) {
       mutateCache(root, old => {
         old.exec(`
-          CREATE TEMP TABLE previous_search AS SELECT id, text FROM record_search;
+          CREATE TEMP TABLE previous_search AS SELECT records.id, text FROM record_search JOIN records ON records.rowid = record_search.rowid;
           DROP TABLE record_search;
           CREATE VIRTUAL TABLE record_search USING fts5(id UNINDEXED, text);
           INSERT INTO record_search(id, text) SELECT id, text FROM previous_search;
@@ -3786,7 +3781,7 @@ describe('SQLite cache and reads', () => {
       )
       assert.equal(writerInitialisations, Number(version))
       const upgraded = logicalCacheProjection(root).metadata
-      assert.equal(upgraded.find(row => row.key === 'schemaVersion')?.value, '3')
+      assert.equal(upgraded.find(row => row.key === 'schemaVersion')?.value, '4')
       assert.match(String(upgraded.find(row => row.key === 'recordFingerprint')?.value), /^[0-9a-f]{64}$/u)
       assert.deepEqual(prepare({ root }), { hydrated: false, recordsIndexed: 1 })
       assert.deepEqual(api.listRecords({ root }), [canonical])
@@ -3886,7 +3881,7 @@ describe('SQLite cache and reads', () => {
     )
     assert.equal((gathered as { hydrated?: unknown }).hydrated, null)
     assert.deepEqual(
-      gathered.records.map(entry => [entry.id, entry.record?.id ?? null]),
+      gathered.records.map(entry => [entry.id, entry.record === null ? null : entry.record.id]),
       [
         [second.id, second.id],
         [first.id, null],
@@ -4357,13 +4352,23 @@ describe('SQLite cache and reads', () => {
       })
     }
 
-    const searchRecords =
-      functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>[]>('searchRecords')
-    assertBudgetError(() => searchRecords({ limit: 5, query: 'response budget marker', root }), {
-      budget: 'fullResponseBytes',
-      field: 'response',
-      maximum: 4 * 1024 * 1024,
-    })
+    const cloning = mock.method(globalThis, 'structuredClone')
+    try {
+      for (const read of [
+        () => api.searchRecords({ limit: 5, query: 'response budget marker', root }),
+        () => api.listRecords({ limit: 5, root }),
+      ]) {
+        const before = cloning.mock.callCount()
+        assertBudgetError(read, {
+          budget: 'fullResponseBytes',
+          field: 'response',
+          maximum: 4 * 1024 * 1024,
+        })
+        assert.equal(cloning.mock.callCount() - before, 4)
+      }
+    } finally {
+      cloning.mock.restore()
+    }
 
     const gatherRecords = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>>('gatherRecords')
     assertBudgetError(
@@ -4577,22 +4582,14 @@ describe('SQLite cache and reads', () => {
           database.prepare('UPDATE records SET active = 0 WHERE id = ?').run(secondId)
           database
             .prepare(`
-              INSERT INTO records(id, kind, subject, source, created_at, path, active, summary, record_json)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+              INSERT INTO records(id, kind, subject, created_at, active)
+              VALUES (?, ?, ?, ?, ?)
             `)
-            .run(
-              replacement.id,
-              replacement.kind,
-              replacement.subject,
-              replacement.source,
-              replacement.createdAt,
-              replacement.path,
-              1,
-              'Snapshot generation three',
-              JSON.stringify(replacement),
-            )
+            .run(replacement.id, replacement.kind, replacement.subject, replacement.createdAt, 1)
           database
-            .prepare('INSERT INTO record_search(id, text) VALUES (?, ?)')
+            .prepare(
+              'INSERT INTO record_search(rowid, text) VALUES ((SELECT rowid FROM records WHERE rowid = (SELECT rowid FROM records WHERE id = ?)), ?)',
+            )
             .run(replacement.id, 'Snapshot generation three')
           database.exec('COMMIT')
         } catch (error) {
@@ -4660,22 +4657,14 @@ describe('SQLite cache and reads', () => {
           database.prepare('UPDATE records SET active = 0 WHERE id = ?').run(firstId)
           database
             .prepare(`
-              INSERT INTO records(id, kind, subject, source, created_at, path, active, summary, record_json)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+              INSERT INTO records(id, kind, subject, created_at, active)
+              VALUES (?, ?, ?, ?, ?)
             `)
-            .run(
-              replacement.id,
-              replacement.kind,
-              replacement.subject,
-              replacement.source,
-              replacement.createdAt,
-              replacement.path,
-              1,
-              'Search snapshot generation two',
-              JSON.stringify(replacement),
-            )
+            .run(replacement.id, replacement.kind, replacement.subject, replacement.createdAt, 1)
           database
-            .prepare('INSERT INTO record_search(id, text) VALUES (?, ?)')
+            .prepare(
+              'INSERT INTO record_search(rowid, text) VALUES ((SELECT rowid FROM records WHERE rowid = (SELECT rowid FROM records WHERE id = ?)), ?)',
+            )
             .run(replacement.id, replacement.searchText)
           database.exec('COMMIT')
         } catch (error) {
@@ -5388,7 +5377,7 @@ describe('SQLite cache and reads', () => {
       canonicalValidations += 1
       if (canonicalValidations === 2) {
         mutateCache(root, database => {
-          database.prepare("INSERT INTO record_search(id, text) VALUES ('injected-retry-row', 'untrusted')").run()
+          database.prepare("INSERT INTO record_search(rowid, text) VALUES (101, 'untrusted')").run()
         })
       }
     }
@@ -5412,10 +5401,7 @@ describe('SQLite cache and reads', () => {
     assert.equal(writerInitialisations, 1)
     const preserved = new DatabaseSync(databasePath, { readOnly: true })
     try {
-      assert.equal(
-        preserved.prepare("SELECT COUNT(*) AS count FROM record_search WHERE id = 'injected-retry-row'").get()?.count,
-        1,
-      )
+      assert.equal(preserved.prepare('SELECT COUNT(*) AS count FROM record_search WHERE rowid = 101').get()?.count, 1)
     } finally {
       preserved.close()
     }
@@ -5444,9 +5430,7 @@ describe('SQLite cache and reads', () => {
         }
         if (writerInitialisations === 2) {
           mutateCache(root, database => {
-            database
-              .prepare("INSERT INTO record_search(id, text) VALUES ('post-initialisation-row', 'untrusted')")
-              .run()
+            database.prepare("INSERT INTO record_search(rowid, text) VALUES (102, 'untrusted')").run()
           })
         }
       }
@@ -5462,11 +5446,7 @@ describe('SQLite cache and reads', () => {
     assert.equal(writerInitialisations, 2)
     const preserved = new DatabaseSync(databasePath, { readOnly: true })
     try {
-      assert.equal(
-        preserved.prepare("SELECT COUNT(*) AS count FROM record_search WHERE id = 'post-initialisation-row'").get()
-          ?.count,
-        1,
-      )
+      assert.equal(preserved.prepare('SELECT COUNT(*) AS count FROM record_search WHERE rowid = 102').get()?.count, 1)
     } finally {
       preserved.close()
     }
@@ -5907,50 +5887,53 @@ describe('SQLite cache and reads', () => {
     }
   })
 
-  test('accepts semantically equivalent legacy table definitions without rebuilding', () => {
+  test('quarantines semantically equivalent definitions outside the exact owned schema', () => {
     const root = createRoot()
     addCacheRecord(root)
-    let primaryQuarantines = 0
-    let writerInitialisations = 0
     mutateCache(root, database => {
       database.enableDefensive(false)
       database.exec('PRAGMA writable_schema = ON;')
       database
-        .prepare("UPDATE sqlite_schema SET sql = ? WHERE type = 'table' AND name = 'metadata'")
-        .run('CREATE TABLE IF NOT EXISTS "metadata" ("key" text PRIMARY KEY, "value" text NOT NULL)')
-      database
-        .prepare("UPDATE sqlite_schema SET sql = ? WHERE type = 'table' AND name = 'records'")
-        .run(`CREATE TABLE IF NOT EXISTS "records" (
-            "id" text PRIMARY KEY,
-            "kind" text NOT NULL,
-            "subject" text NOT NULL,
-            "source" text NOT NULL,
-            "created_at" text NOT NULL,
-            "path" text NOT NULL,
-            "active" integer NOT NULL CHECK ("active" IN (0, 1)),
-            "summary" text,
-            "record_json" text NOT NULL
-          )
-        `)
+        .prepare("UPDATE sqlite_schema SET sql = ? WHERE name = 'metadata'")
+        .run('CREATE TABLE "metadata" ("key" text PRIMARY KEY, "value" text NOT NULL)')
       database.exec('PRAGMA writable_schema = OFF;')
     })
+    let primaryQuarantines = 0
     cacheLocationTestHooks.beforeQuarantineRename = path => {
       if (basename(path) === 'brain.sqlite') {
         primaryQuarantines += 1
       }
     }
-    cacheReadTestHooks.duringDatabaseInitialisation = mode => {
-      if (mode === 'writer') {
-        writerInitialisations += 1
-      }
-    }
+    assert.deepEqual(api.prepare({ root }), { hydrated: true, recordsIndexed: 1 })
+    assert.equal(primaryQuarantines, 1)
+  })
 
-    const result = functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({
-      root,
-    })
-    assert.equal(primaryQuarantines, 0)
-    assert.equal(writerInitialisations, 0)
-    assert.deepEqual(result, { hydrated: false, recordsIndexed: 1 })
+  test('quarantines forged generation markers, extra objects and changed FTS shadow schemas', () => {
+    for (const mutation of [
+      'PRAGMA application_id = 0',
+      'PRAGMA user_version = 3',
+      "UPDATE metadata SET value = '3' WHERE key = 'schemaVersion'",
+      'CREATE TABLE private_extra(value TEXT)',
+      'CREATE TRIGGER private_trigger AFTER INSERT ON records BEGIN DELETE FROM records; END',
+      'ALTER TABLE record_search_docsize ADD COLUMN private_extra TEXT',
+    ]) {
+      const root = createRoot()
+      const record = addCacheRecord(root)
+      const before = readFileSync(join(root, record.path))
+      mutateCache(root, database => {
+        database.enableDefensive(false)
+        database.exec(mutation)
+      })
+      let quarantines = 0
+      cacheLocationTestHooks.beforeQuarantineRename = path => {
+        if (basename(path) === 'brain.sqlite') {
+          quarantines += 1
+        }
+      }
+      assert.deepEqual(api.listRecords({ root }), [record], mutation)
+      assert.equal(quarantines, 1, mutation)
+      assert.deepEqual(readFileSync(join(root, record.path)), before, mutation)
+    }
   })
 
   test('rebuilds same-name records tables with incompatible semantics', () => {
@@ -5958,71 +5941,51 @@ describe('SQLite cache and reads', () => {
       {
         name: 'records primary key',
         recordsDefinition: `
-          id TEXT,
+          rowid INTEGER PRIMARY KEY, id TEXT,
           kind TEXT NOT NULL,
           subject TEXT NOT NULL,
-          source TEXT NOT NULL,
           created_at TEXT NOT NULL,
-          path TEXT NOT NULL,
-          active INTEGER NOT NULL CHECK (active IN (0, 1)),
-          summary TEXT,
-          record_json TEXT NOT NULL
+          active INTEGER NOT NULL CHECK (active IN (0, 1))
         `,
       },
       {
         name: 'records nullability',
         recordsDefinition: `
-          id TEXT PRIMARY KEY,
+          rowid INTEGER PRIMARY KEY, id TEXT NOT NULL UNIQUE,
           kind TEXT,
           subject TEXT NOT NULL,
-          source TEXT NOT NULL,
           created_at TEXT NOT NULL,
-          path TEXT NOT NULL,
-          active INTEGER NOT NULL CHECK (active IN (0, 1)),
-          summary TEXT,
-          record_json TEXT NOT NULL
+          active INTEGER NOT NULL CHECK (active IN (0, 1))
         `,
       },
       {
         name: 'records declared type',
         recordsDefinition: `
-          id TEXT PRIMARY KEY,
+          rowid INTEGER PRIMARY KEY, id TEXT NOT NULL UNIQUE,
           kind TEXT NOT NULL,
-          subject TEXT NOT NULL,
-          source TEXT NOT NULL,
+          subject BLOB NOT NULL,
           created_at TEXT NOT NULL,
-          path TEXT NOT NULL,
-          active INTEGER NOT NULL CHECK (active IN (0, 1)),
-          summary BLOB,
-          record_json TEXT NOT NULL
+          active INTEGER NOT NULL CHECK (active IN (0, 1))
         `,
       },
       {
         name: 'records default',
         recordsDefinition: `
-          id TEXT PRIMARY KEY,
+          rowid INTEGER PRIMARY KEY, id TEXT NOT NULL UNIQUE,
           kind TEXT NOT NULL,
-          subject TEXT NOT NULL,
-          source TEXT NOT NULL,
+          subject TEXT NOT NULL DEFAULT 'private-schema-sentinel',
           created_at TEXT NOT NULL,
-          path TEXT NOT NULL,
-          active INTEGER NOT NULL CHECK (active IN (0, 1)),
-          summary TEXT DEFAULT 'private-schema-sentinel',
-          record_json TEXT NOT NULL
+          active INTEGER NOT NULL CHECK (active IN (0, 1))
         `,
       },
       {
         name: 'records active constraint',
         recordsDefinition: `
-          id TEXT PRIMARY KEY,
+          rowid INTEGER PRIMARY KEY, id TEXT NOT NULL UNIQUE,
           kind TEXT NOT NULL,
           subject TEXT NOT NULL,
-          source TEXT NOT NULL,
           created_at TEXT NOT NULL,
-          path TEXT NOT NULL,
-          active INTEGER NOT NULL CHECK (active IN (0, 1, 2)),
-          summary TEXT,
-          record_json TEXT NOT NULL
+          active INTEGER NOT NULL CHECK (active IN (0, 1, 2))
         `,
       },
     ] as const
@@ -6034,7 +5997,7 @@ describe('SQLite cache and reads', () => {
         database.exec(`
           CREATE TABLE replacement_records (${fixture.recordsDefinition});
           INSERT INTO replacement_records
-            SELECT id, kind, subject, source, created_at, path, active, summary, record_json FROM records;
+            SELECT rowid, id, kind, subject, created_at, active FROM records;
           DROP TABLE records;
           ALTER TABLE replacement_records RENAME TO records;
           CREATE INDEX records_active_order ON records(active, created_at DESC, id DESC);
@@ -6129,7 +6092,7 @@ describe('SQLite cache and reads', () => {
       },
       {
         mutate: (database: DatabaseSync) => {
-          database.exec('CREATE INDEX records_extra ON records(source);')
+          database.exec('CREATE INDEX records_extra ON records(created_at);')
         },
         name: 'additional application index',
       },
@@ -6184,27 +6147,27 @@ describe('SQLite cache and reads', () => {
   test('rebuilds caches with incompatible FTS5 semantics', () => {
     const cases = [
       {
-        definition: 'CREATE TABLE record_search(id TEXT, text TEXT, preview TEXT)',
+        definition: 'CREATE TABLE record_search(text TEXT, preview TEXT)',
         name: 'ordinary table',
       },
       {
-        definition: 'CREATE VIRTUAL TABLE record_search USING fts5(id, text, preview)',
-        name: 'indexed id',
-      },
-      {
-        definition: 'CREATE VIRTUAL TABLE record_search USING fts5(id UNINDEXED, text UNINDEXED, preview)',
+        definition: 'CREATE VIRTUAL TABLE record_search USING fts5(text UNINDEXED, preview)',
         name: 'unindexed text',
       },
       {
-        definition: 'CREATE VIRTUAL TABLE record_search USING fts5(text, id UNINDEXED, preview)',
+        definition: 'CREATE VIRTUAL TABLE record_search USING fts5(text, preview, detail=column)',
+        name: 'changed index detail',
+      },
+      {
+        definition: 'CREATE VIRTUAL TABLE record_search USING fts5(preview, text)',
         name: 'reversed columns',
       },
       {
-        definition: "CREATE VIRTUAL TABLE record_search USING fts5(id UNINDEXED, text, preview, tokenize='porter')",
+        definition: "CREATE VIRTUAL TABLE record_search USING fts5(text, preview, tokenize='porter')",
         name: 'changed tokenizer',
       },
       {
-        definition: 'CREATE VIRTUAL TABLE record_search USING fts5(id UNINDEXED, text, preview UNINDEXED)',
+        definition: 'CREATE VIRTUAL TABLE record_search USING fts5(text, preview UNINDEXED)',
         name: 'unindexed preview',
       },
     ] as const
@@ -6215,10 +6178,10 @@ describe('SQLite cache and reads', () => {
       mutateCache(root, database => {
         database.enableDefensive(false)
         database.exec(`
-          CREATE TEMP TABLE saved_search AS SELECT id, text, preview FROM record_search;
+          CREATE TEMP TABLE saved_search AS SELECT rowid, text, preview FROM record_search;
           DROP TABLE record_search;
           ${fixture.definition};
-          INSERT INTO record_search(id, text, preview) SELECT id, text, preview FROM saved_search;
+          INSERT INTO record_search(rowid, text, preview) SELECT rowid, text, preview FROM saved_search;
         `)
       })
 
@@ -6229,28 +6192,30 @@ describe('SQLite cache and reads', () => {
       )
     }
 
-    const validRoot = createRoot()
-    addCacheRecord(validRoot)
-    mutateCache(validRoot, database => {
+    const alternateDefinitionRoot = createRoot()
+    addCacheRecord(alternateDefinitionRoot)
+    mutateCache(alternateDefinitionRoot, database => {
       database.enableDefensive(false)
       database.exec(`
-        CREATE TEMP TABLE saved_search AS SELECT id, text, preview FROM record_search;
+        CREATE TEMP TABLE saved_search AS SELECT rowid, text, preview FROM record_search;
         DROP TABLE record_search;
         create virtual table "record_search" using FTS5(
-          "id" unindexed,
           "text",
           "preview"
         );
-        INSERT INTO record_search(id, text, preview) SELECT id, text, preview FROM saved_search;
+        INSERT INTO record_search(rowid, text, preview) SELECT rowid, text, preview FROM saved_search;
       `)
     })
-    assert.deepEqual(functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root: validRoot }), {
-      hydrated: false,
-      recordsIndexed: 1,
-    })
+    assert.deepEqual(
+      functionFromApi<(input: Record<string, unknown>) => unknown>('prepare')({ root: alternateDefinitionRoot }),
+      {
+        hydrated: true,
+        recordsIndexed: 1,
+      },
+    )
   })
 
-  test('recovers an unavailable private FTS module before introspecting columns', () => {
+  test('recovers an unavailable private FTS module without exposing its name', () => {
     const root = createRoot()
     const record = addCacheRecord(root)
     const privateSentinel = 'private_customer_module_sentinel'
@@ -6350,8 +6315,8 @@ describe('SQLite cache and reads', () => {
           UNION ALL
           SELECT value + 1 FROM generated WHERE value < 1001
         )
-        INSERT INTO record_search(id, text)
-        SELECT printf('metadata-less-%04d', value), 'untrusted search text'
+        INSERT INTO record_search(text)
+        SELECT 'untrusted search text'
         FROM generated;
       `)
     })
@@ -6424,8 +6389,8 @@ describe('SQLite cache and reads', () => {
     cacheReadTestHooks.afterDisposableCacheRecoveryRebuild = () => {
       recoveryRebuilds += 1
     }
-    cacheReadTestHooks.beforeIntegrityTextRead = name => {
-      if (name === 'metadata-columns' && mutations === 0) {
+    cacheReadTestHooks.afterIntegrityProbe = observation => {
+      if (observation.name === 'schema' && mutations === 0) {
         mutations += 1
         mutateCache(root, database => {
           database.exec('DROP INDEX records_kind_subject;')
@@ -6628,7 +6593,9 @@ describe('SQLite cache and reads', () => {
       const displacedRebuild = join(root, 'post-rebuild-owned.sqlite')
       copyFileSync(databasePath, successorSource)
       mutateCache(root, database => {
-        database.prepare("UPDATE record_search SET text = 'corrupt' WHERE id = ?").run(String(record.id))
+        database
+          .prepare("UPDATE record_search SET text = 'corrupt' WHERE rowid = (SELECT rowid FROM records WHERE id = ?)")
+          .run(String(record.id))
       })
       let recoveryRebuilds = 0
       let writerInitialisations = 0
@@ -6669,7 +6636,7 @@ describe('SQLite cache and reads', () => {
     const privateSentinel = 'private_schema_parser_sentinel'
     let schemaFailures = 0
     cacheReadTestHooks.afterIntegrityProbe = observation => {
-      if (observation.name === 'metadata-columns') {
+      if (observation.name === 'schema') {
         schemaFailures += 1
         throw Object.assign(new Error(`malformed database schema (${privateSentinel})`), {
           code: 'SQLITE_CORRUPT',
@@ -6980,65 +6947,23 @@ describe('SQLite cache and reads', () => {
   ] as const
 
   for (const { name, read } of readRecoveryCases) {
-    test(`rebuilds invalid cached row JSON during ${name}`, () => {
+    test(`rebuilds forged cached subject during ${name}`, () => {
       const root = createRoot()
       const record = addCacheRecord(root)
       mutateCache(root, database => {
-        database.prepare('UPDATE records SET record_json = ? WHERE id = ?').run('{not-json', String(record.id))
+        database.prepare('UPDATE records SET subject = ? WHERE id = ?').run('{not-json', String(record.id))
       })
 
       read(root, record)
     })
   }
 
-  test('normalises negative-zero confidence from an existing cache row before public reads', () => {
-    const root = createRoot()
-    const record = api.addRecord({
-      confidence: -0,
-      id: 'cached-negative-zero-confidence',
-      kind: 'context',
-      payload: { summary: 'Cached negative-zero confidence' },
-      root,
-      searchText: 'cached negative-zero confidence',
-      source: 'agent',
-      subject: 'cache.negative-zero-confidence',
-    })
-    mutateCache(root, database => {
-      const row = database.prepare('SELECT record_json FROM records WHERE id = ?').get(record.id) as
-        | { record_json?: unknown }
-        | undefined
-      assert.ok(row)
-      assert.equal(typeof row.record_json, 'string')
-      const cachedBytes = row.record_json as string
-      const negativeZeroBytes = cachedBytes.replace('"confidence":0', '"confidence":-0')
-      assert.notEqual(negativeZeroBytes, cachedBytes)
-      database.prepare('UPDATE records SET record_json = ? WHERE id = ?').run(negativeZeroBytes, record.id)
-    })
-    let writerInitialisations = 0
-    cacheReadTestHooks.duringDatabaseInitialisation = mode => {
-      if (mode === 'writer') {
-        writerInitialisations += 1
-      }
-    }
-
-    const cached = [
-      api.showRecord({ id: record.id, root }),
-      api.listRecords({ root }).find(candidate => candidate.id === record.id),
-      api.searchRecords({ query: 'cached negative-zero', root }).find(candidate => candidate.id === record.id),
-    ]
-    for (const candidate of cached) {
-      assert.ok(candidate)
-      assert.equal(Object.is(candidate.confidence, 0), true)
-    }
-    assert.equal(writerInitialisations, 0)
-  })
-
   test('quarantines one exact corrupt cache generation before rebuilding', () => {
     const root = createRoot()
     const record = addCacheRecord(root)
     mutateCache(root, database => {
       database
-        .prepare('UPDATE records SET record_json = CAST(zeroblob(?) AS TEXT) || ? WHERE id = ?')
+        .prepare('UPDATE records SET subject = CAST(zeroblob(?) AS TEXT) || ? WHERE id = ?')
         .run(1_052_673, 'private-cache-sentinel', String(record.id))
     })
     let primaryQuarantines = 0
@@ -7067,7 +6992,7 @@ describe('SQLite cache and reads', () => {
     const record = addCacheRecord(root)
     mutateCache(root, database => {
       database
-        .prepare('UPDATE records SET record_json = CAST(zeroblob(?) AS TEXT) || ? WHERE id = ?')
+        .prepare('UPDATE records SET subject = CAST(zeroblob(?) AS TEXT) || ? WHERE id = ?')
         .run(1_052_673, 'private-cache-sentinel', String(record.id))
     })
     let writerAttempts = 0
@@ -7109,11 +7034,11 @@ describe('SQLite cache and reads', () => {
     assert.equal(resultsServed, 0)
   })
 
-  test('normalises malformed cache JSON throughout a terminal retry cause chain', () => {
+  test('normalises forged cache subjects throughout a terminal retry cause chain', () => {
     const root = createRoot()
     const record = addCacheRecord(root)
     mutateCache(root, database => {
-      database.prepare('UPDATE records SET record_json = ? WHERE id = ?').run('{"first":,}', String(record.id))
+      database.prepare('UPDATE records SET subject = ? WHERE id = ?').run('{"first":,}', String(record.id))
     })
     const privateSentinel = 'private-ca'
     let databaseOpensAfterRecoveryStarted = 0
@@ -7124,7 +7049,7 @@ describe('SQLite cache and reads', () => {
           cacheLocationTestHooks.beforeDatabaseOpen = undefined
           mutateCache(root, database => {
             database
-              .prepare('UPDATE records SET record_json = ? WHERE id = ?')
+              .prepare('UPDATE records SET subject = ? WHERE id = ?')
               .run('private-cache-sentinel', String(record.id))
           })
         }
@@ -7332,11 +7257,11 @@ describe('SQLite cache and reads', () => {
     assert.equal(writerInitialisations, 1)
   })
 
-  test('rebuilds non-text cached record JSON before reading it', () => {
+  test('rebuilds a non-text cached subject before reading it', () => {
     const root = createRoot()
     const record = addCacheRecord(root)
     mutateCache(root, database => {
-      database.prepare('UPDATE records SET record_json = ? WHERE id = ?').run(42, String(record.id))
+      database.prepare('UPDATE records SET subject = ? WHERE id = ?').run(Buffer.from('forged'), String(record.id))
     })
 
     assert.deepEqual(
@@ -7347,30 +7272,7 @@ describe('SQLite cache and reads', () => {
     )
   })
 
-  test('rebuilds cached records with invalid shapes and runtime paths', () => {
-    const invalidRecordJson = (record: Record<string, unknown>) => [
-      JSON.stringify({ ...record, unexpected: true }),
-      JSON.stringify({ ...record, path: '/tmp/elsewhere.json' }),
-      JSON.stringify({ ...record, path: '../elsewhere.json' }),
-    ]
-
-    for (const recordJson of invalidRecordJson(addCacheRecord(createRoot()))) {
-      const root = roots.at(-1)
-      assert.ok(root)
-      mutateCache(root, database => {
-        database.prepare('UPDATE records SET record_json = ?').run(recordJson)
-      })
-      const records = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>[]>('listRecords')({
-        root,
-      })
-      assert.deepEqual(
-        records.map(record => record.id),
-        ['cache-record'],
-      )
-    }
-  })
-
-  test('rebuilds cached record columns that disagree with validated JSON', () => {
+  test('rebuilds cached filter columns that disagree with the canonical corpus', () => {
     const root = createRoot()
     const oldRecord = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>>('addRecord')({
       id: 'old-cache-record',
@@ -7437,7 +7339,7 @@ describe('SQLite cache and reads', () => {
   test('bounds schema and metadata before transferring untrusted text', () => {
     const cases = [
       {
-        expectedProbe: { name: 'metadata-columns', rows: 2 },
+        expectedProbe: { name: 'schema', rows: 11 },
         mutate: (database: DatabaseSync) => {
           database.exec(`
             CREATE TABLE replacement_metadata(key TEXT, private_metadata_sentinel TEXT);
@@ -7448,7 +7350,7 @@ describe('SQLite cache and reads', () => {
         name: 'oversized metadata column name',
       },
       {
-        expectedProbe: { name: 'record-search-schema', rows: 1 },
+        expectedProbe: { name: 'schema', rows: 12 },
         mutate: (database: DatabaseSync) => {
           database.enableDefensive(false)
           database.exec(`
@@ -7519,8 +7421,8 @@ describe('SQLite cache and reads', () => {
       'iterate',
       function* observedRows(this: StatementSync, ...parameters: Parameters<typeof iterate>) {
         for (const row of iterate.apply(this, parameters)) {
-          const recordRow = Object.hasOwn(row, 'id') && Object.hasOwn(row, 'active')
-          const searchRow = Object.hasOwn(row, 'id_bytes')
+          const recordRow = Object.hasOwn(row, 'id_bytes') && Object.hasOwn(row, 'active')
+          const searchRow = Object.hasOwn(row, 'search_rowid')
           if (recordRow || searchRow) {
             counts[recordRow ? 'records' : 'search'] += 1
             const { proxy, revoke } = Proxy.revocable(row, {})
@@ -7560,7 +7462,7 @@ describe('SQLite cache and reads', () => {
       database.prepare('UPDATE record_search SET text = ?').run(wrongTerms)
       assert.deepEqual(statistics(), before)
       database.enableDefensive(false)
-      database.prepare('UPDATE record_search_content SET c1 = ?').run(stored.text)
+      database.prepare('UPDATE record_search_content SET c0 = ?').run(stored.text)
     })
     let rebuilds = 0
     cacheReadTestHooks.afterDisposableCacheRecoveryRebuild = () => {
@@ -7611,32 +7513,8 @@ describe('SQLite cache and reads', () => {
     }
   })
 
-  test('accepts reordered cached JSON with equivalent signed-zero values without rebuilding', () => {
-    const root = createRoot()
-    const expected = api.addRecord({
-      confidence: 0,
-      id: 'cached-json-normalisation',
-      kind: 'context',
-      payload: { numbers: [0, { zero: 0 }], summary: 'Numeric cache equivalence' },
-      root,
-      source: 'agent',
-      subject: 'cache.normalisation',
-    })
-    mutateCache(root, database => {
-      const row = database.prepare('SELECT record_json FROM records').get()
-      assert.ok(typeof row?.record_json === 'string')
-      const parsed = JSON.parse(row.record_json) as Record<string, unknown>
-      const reordered = Object.fromEntries(Object.entries(parsed).reverse())
-      const encoded = JSON.stringify(reordered).replaceAll('":0', '":-0').replace('[0,', '[-0,')
-      database.prepare('UPDATE records SET record_json = ?').run(encoded)
-    })
-
-    assert.deepEqual(api.prepare({ root }), { hydrated: false, recordsIndexed: 1 })
-    assert.deepEqual(api.listRecords({ root }), [expected])
-  })
-
-  test('rejects invalid cached JSON and scalar bytes that decode to canonical replacement characters', () => {
-    for (const column of ['record_json', 'subject']) {
+  test('rejects invalid scalar bytes that decode to canonical replacement characters', () => {
+    for (const column of ['subject']) {
       const root = createRoot()
       const expected = api.addRecord({
         id: 'cached-record-encoding',
@@ -7667,18 +7545,16 @@ describe('SQLite cache and reads', () => {
   })
 
   test('keeps rejecting canonical scalar text that cannot round-trip through SQLite UTF-8', () => {
-    const root = createRoot()
-    api.addRecord({
-      id: 'unpaired-scalar',
-      kind: 'context',
-      payload: { summary: 'Unpaired scalar encoding' },
-      root,
-      source: 'agent',
-      subject: 'cache.\ud800',
-    })
-
-    assert.deepEqual(api.prepare({ root }), { hydrated: true, recordsIndexed: 1 })
-    assert.throws(() => api.listRecords({ root }), { code: 'INTERNAL_ERROR' })
+    for (const fields of [
+      { payload: {}, source: 'agent', subject: 'cache.\ud800' },
+      { payload: {}, source: '\ud800', subject: 'cache.source' },
+      { payload: { summary: '\ud800' }, source: 'agent', subject: 'cache.summary' },
+    ]) {
+      const root = createRoot()
+      api.addRecord({ id: 'unpaired-scalar', kind: 'context', root, ...fields })
+      assert.deepEqual(api.prepare({ root }), { hydrated: true, recordsIndexed: 1 })
+      assert.throws(() => api.listRecords({ root }), { code: 'INTERNAL_ERROR' })
+    }
   })
 
   test('bounds cached record validation before transferring untrusted rows', () => {
@@ -7689,16 +7565,11 @@ describe('SQLite cache and reads', () => {
           database.exec(`
             DELETE FROM records;
             WITH RECURSIVE generated(value) AS (
-              SELECT 1
-              UNION ALL
-              SELECT value + 1 FROM generated WHERE value < 1001
+              SELECT 1 UNION ALL SELECT value + 1 FROM generated WHERE value < 1001
             )
-            INSERT INTO records(id, kind, subject, source, created_at, path, active, summary, record_json)
-            SELECT
-              printf('overflow-%04d', value), 'context', 'cache.overflow', 'test',
-              '2026-08-16T00:00:00.000Z', printf('encephalon/context/overflow-%04d.json', value),
-              1, NULL, '{}'
-            FROM generated;
+            INSERT INTO records(id, kind, subject, created_at, active)
+            SELECT printf('overflow-%04d', value), 'context', 'cache.overflow',
+              '2026-08-16T00:00:00.000Z', 1 FROM generated;
           `)
         },
         name: '1,001 rows',
@@ -7706,52 +7577,32 @@ describe('SQLite cache and reads', () => {
       {
         expectedRows: 1,
         mutate: (database: DatabaseSync) => {
-          database.prepare('UPDATE records SET record_json = CAST(zeroblob(?) AS TEXT)').run(1_052_673)
+          database.prepare('UPDATE records SET subject = CAST(zeroblob(?) AS TEXT)').run(1_048_577)
         },
-        name: 'oversized record JSON containing NUL',
+        name: 'oversized scalar containing NUL',
       },
       {
-        expectedRows: 13,
+        expectedRows: 9,
         mutate: (database: DatabaseSync) => {
           database.exec(`
             DELETE FROM records;
             WITH RECURSIVE generated(value) AS (
-              SELECT 1
-              UNION ALL
-              SELECT value + 1 FROM generated WHERE value < 13
+              SELECT 1 UNION ALL SELECT value + 1 FROM generated WHERE value < 9
             )
-            INSERT INTO records(id, kind, subject, source, created_at, path, active, summary, record_json)
-            SELECT
-              printf('aggregate-%04d', value), 'context', 'cache.aggregate', 'test',
-              '2026-08-16T00:00:00.000Z', printf('encephalon/context/aggregate-%04d.json', value),
-              1, NULL, CAST(zeroblob(1048576) AS TEXT)
-            FROM generated;
-            UPDATE metadata SET value = '13' WHERE key = 'recordsIndexed';
+            INSERT INTO records(id, kind, subject, created_at, active)
+            SELECT printf('aggregate-%04d', value), 'context', CAST(zeroblob(1048576) AS TEXT),
+              '2026-08-16T00:00:00.000Z', 1 FROM generated;
+            UPDATE metadata SET value = '9' WHERE key = 'recordsIndexed';
           `)
         },
-        name: 'aggregate record JSON above 12 MiB',
+        name: 'aggregate scalar text above 8 MiB',
       },
       {
-        expectedRows: 25,
+        expectedRows: 1,
         mutate: (database: DatabaseSync) => {
-          database.exec(`
-            CREATE TEMP TABLE original_record AS SELECT * FROM records;
-            DELETE FROM records;
-            WITH RECURSIVE generated(value) AS (
-              SELECT 1
-              UNION ALL
-              SELECT value + 1 FROM generated WHERE value < 25
-            )
-            INSERT INTO records(id, kind, subject, source, created_at, path, active, summary, record_json)
-            SELECT
-              printf('aggregate-text-%04d-', value) || CAST(zeroblob(1048500) AS TEXT),
-              kind, subject, source, created_at, path, active, summary, record_json
-            FROM original_record CROSS JOIN generated;
-            DROP TABLE original_record;
-            UPDATE metadata SET value = '25' WHERE key = 'recordsIndexed';
-          `)
+          database.prepare('UPDATE records SET id = ?').run('x'.repeat(256))
         },
-        name: 'aggregate denormalised record text above its bound',
+        name: 'oversized identity',
       },
       {
         expectedRows: 1,
@@ -7761,7 +7612,6 @@ describe('SQLite cache and reads', () => {
         name: 'hostile 64-bit active integer',
       },
     ] as const
-
     for (const { expectedRows, mutate, name } of cases) {
       const root = createRoot()
       const record = addCacheRecord(root)
@@ -7804,8 +7654,8 @@ describe('SQLite cache and reads', () => {
               UNION ALL
               SELECT value + 1 FROM generated WHERE value < 1001
             )
-            INSERT INTO record_search(id, text, preview)
-            SELECT printf('overflow-%04d', value), 'overflow search text', 'overflow preview'
+            INSERT INTO record_search(rowid, text, preview)
+            SELECT value, 'overflow search text', 'overflow preview'
             FROM generated;
           `)
         },
@@ -7835,9 +7685,9 @@ describe('SQLite cache and reads', () => {
       {
         expectedRows: 1,
         mutate: (database: DatabaseSync) => {
-          database.prepare('UPDATE record_search SET id = ?').run('x'.repeat(256))
+          database.prepare('UPDATE record_search SET text = ?').run(Buffer.from('untrusted'))
         },
-        name: 'oversized textual FTS ID',
+        name: 'non-text full document',
       },
       {
         expectedRows: 12,
@@ -7849,8 +7699,8 @@ describe('SQLite cache and reads', () => {
               UNION ALL
               SELECT value + 1 FROM generated WHERE value < 12
             )
-            INSERT INTO record_search(id, text, preview)
-            SELECT printf('cache-record-%02d', value), CAST(zeroblob(6242305) AS TEXT), 'bounded preview'
+            INSERT INTO record_search(rowid, text, preview)
+            SELECT value, CAST(zeroblob(6242305) AS TEXT), 'bounded preview'
             FROM generated;
           `)
         },
@@ -7877,20 +7727,6 @@ describe('SQLite cache and reads', () => {
           assert.ok(latest)
           return latest
         },
-      },
-      {
-        expectedRows: 1,
-        mutate: (database: DatabaseSync) => {
-          database.exec('UPDATE record_search SET id = 9223372036854775807;')
-        },
-        name: 'FTS integer ID',
-      },
-      {
-        expectedRows: 1,
-        mutate: (database: DatabaseSync) => {
-          database.exec("UPDATE record_search SET id = x'63616368652d7265636f7264';")
-        },
-        name: 'FTS BLOB ID',
       },
     ]
 
@@ -7955,60 +7791,25 @@ describe('SQLite cache and reads', () => {
     addCacheRecord(root)
     mutateCache(root, database => {
       database.exec(`
-        CREATE TEMP TABLE boundary_record AS SELECT * FROM records;
         DELETE FROM records;
         DELETE FROM record_search;
         WITH RECURSIVE generated(value) AS (
-          SELECT 1
-          UNION ALL
-          SELECT value + 1 FROM generated WHERE value < 1000
-        ), candidates AS (
-          SELECT
-            printf('boundary-%04d', value) AS id,
-            kind,
-            printf('cache.boundary.%04d', value) AS subject,
-            source,
-            created_at,
-            printf('encephalon/context/boundary-%04d.json', value) AS path,
-            active,
-            summary,
-            CASE WHEN value <= 608 THEN 12485 ELSE 12484 END AS target_bytes,
-            json_set(
-              record_json,
-              '$.id', printf('boundary-%04d', value),
-              '$.subject', printf('cache.boundary.%04d', value),
-              '$.path', printf('encephalon/context/boundary-%04d.json', value),
-              '$.payload.padding', ''
-            ) AS base_json
-          FROM boundary_record CROSS JOIN generated
+          SELECT 1 UNION ALL SELECT value + 1 FROM generated WHERE value < 1000
         )
-        INSERT INTO records(id, kind, subject, source, created_at, path, active, summary, record_json)
-        SELECT
-          id,
-          kind,
-          subject,
-          source,
-          created_at,
-          path,
-          active,
-          summary,
-          json_set(
-            base_json,
-            '$.payload.padding',
-            replace(hex(zeroblob(target_bytes - length(CAST(base_json AS BLOB)))), '00', 'x')
-          )
-        FROM candidates;
-        WITH RECURSIVE generated(value) AS (
-          SELECT 1
-          UNION ALL
-          SELECT value + 1 FROM generated WHERE value < 1000
-        )
-        INSERT INTO record_search(id, text)
-        SELECT printf('boundary-%04d', value), 'boundary search text'
-        FROM generated;
+        INSERT INTO records(id, kind, subject, created_at, active)
+        SELECT printf('boundary-%04d', value), 'context',
+          replace(hex(zeroblob(CASE WHEN value <= 608 THEN 8345 ELSE 8344 END)), '00', 'x'),
+          '2026-08-16T00:00:00.000Z', 1 FROM generated;
         UPDATE metadata SET value = '1000' WHERE key = 'recordsIndexed';
-        DROP TABLE boundary_record;
       `)
+      assert.equal(
+        database
+          .prepare(
+            'SELECT SUM(octet_length(id) + octet_length(kind) + octet_length(subject) + octet_length(created_at)) AS bytes FROM records',
+          )
+          .get()?.bytes,
+        8 * 1024 * 1024,
+      )
     })
     const observations = observeCacheIntegrity()
 
@@ -8054,7 +7855,7 @@ describe('SQLite cache and reads', () => {
     let indexProbes = 0
     let mutations = 0
     cacheReadTestHooks.afterIntegrityProbe = observation => {
-      if (observation.name === 'records-indexes') {
+      if (observation.name === 'schema') {
         indexProbes += 1
         if (indexProbes === 1) {
           mutations += 1
@@ -8062,7 +7863,7 @@ describe('SQLite cache and reads', () => {
           const database = new DatabaseSync(cacheDatabasePath(root))
           try {
             database.exec('PRAGMA journal_mode = WAL; BEGIN IMMEDIATE;')
-            database.prepare('UPDATE records SET record_json = ? WHERE id = ?').run(successor, String(record.id))
+            database.prepare('UPDATE records SET subject = ? WHERE id = ?').run(successor, String(record.id))
             database.exec('DROP INDEX records_kind_subject;')
             database.exec('COMMIT')
           } finally {
@@ -8147,7 +7948,11 @@ describe('SQLite cache and reads', () => {
       'utf8',
     )
     mutateCache(root, database => {
-      database.prepare("UPDATE record_search SET text = 'x' || substr(text, 2) WHERE id = ?").run(String(record.id))
+      database
+        .prepare(
+          "UPDATE record_search SET text = 'x' || substr(text, 2) WHERE rowid = (SELECT rowid FROM records WHERE id = ?)",
+        )
+        .run(String(record.id))
     })
     const observations = observeCacheIntegrity()
     let exactQuarantines = 0
@@ -8195,7 +8000,9 @@ describe('SQLite cache and reads', () => {
     const rebuilt = new DatabaseSync(databasePath, { readOnly: true })
     try {
       const row = rebuilt
-        .prepare('SELECT CAST(text AS BLOB) AS bytes FROM record_search WHERE id = ?')
+        .prepare(
+          'SELECT CAST(text AS BLOB) AS bytes FROM record_search WHERE rowid = (SELECT rowid FROM records WHERE id = ?)',
+        )
         .get(String(record.id)) as {
         bytes?: unknown
       }
@@ -8228,9 +8035,15 @@ describe('SQLite cache and reads', () => {
       canonicalBytes.subarray(replacementOffset + replacementBytes.length),
     ])
     mutateCache(root, database => {
-      database.prepare('UPDATE record_search SET text = CAST(? AS TEXT) WHERE id = ?').run(invalidBytes, id)
+      database
+        .prepare(
+          'UPDATE record_search SET text = CAST(? AS TEXT) WHERE rowid = (SELECT rowid FROM records WHERE id = ?)',
+        )
+        .run(invalidBytes, id)
       const row = database
-        .prepare('SELECT text, CAST(text AS BLOB) AS bytes FROM record_search WHERE id = ?')
+        .prepare(
+          'SELECT text, CAST(text AS BLOB) AS bytes FROM record_search WHERE rowid = (SELECT rowid FROM records WHERE id = ?)',
+        )
         .get(id) as { bytes?: unknown; text?: unknown }
       assert.equal(row.text, canonical)
       assert.equal(row.bytes instanceof Uint8Array, true)
@@ -8268,7 +8081,11 @@ describe('SQLite cache and reads', () => {
     assert.equal(writerInitialisations, 1)
     const rebuilt = new DatabaseSync(cacheDatabasePath(root), { readOnly: true })
     try {
-      const row = rebuilt.prepare('SELECT CAST(text AS BLOB) AS bytes FROM record_search WHERE id = ?').get(id) as {
+      const row = rebuilt
+        .prepare(
+          'SELECT CAST(text AS BLOB) AS bytes FROM record_search WHERE rowid = (SELECT rowid FROM records WHERE id = ?)',
+        )
+        .get(id) as {
         bytes?: unknown
       }
       assert.equal(row.bytes instanceof Uint8Array, true)
@@ -8282,7 +8099,7 @@ describe('SQLite cache and reads', () => {
     const cases = [
       {
         mutate: (database: DatabaseSync, id: string) => {
-          database.prepare('DELETE FROM record_search WHERE id = ?').run(id)
+          database.prepare('DELETE FROM record_search WHERE rowid = (SELECT rowid FROM records WHERE id = ?)').run(id)
         },
         name: 'missing row',
       },
@@ -8290,15 +8107,19 @@ describe('SQLite cache and reads', () => {
         mutate: (database: DatabaseSync, id: string) => {
           database
             .prepare(
-              'INSERT INTO record_search(id, text, preview) SELECT id, text, preview FROM record_search WHERE id = ?',
+              'INSERT INTO record_search(text, preview) SELECT text, preview FROM record_search WHERE rowid = (SELECT rowid FROM records WHERE id = ?)',
             )
             .run(id)
         },
-        name: 'duplicate ID',
+        name: 'duplicate document',
       },
       {
         mutate: (database: DatabaseSync, id: string) => {
-          database.prepare("UPDATE record_search SET id = 'orphan-search-row' WHERE id = ?").run(id)
+          database
+            .prepare(
+              'UPDATE record_search SET rowid = -rowid WHERE rowid = (SELECT rowid FROM records WHERE rowid = (SELECT rowid FROM records WHERE id = ?))',
+            )
+            .run(id)
         },
         name: 'same-count orphan',
       },
@@ -8353,21 +8174,27 @@ describe('SQLite cache and reads', () => {
     const cases = [
       {
         mutate: (database: DatabaseSync, first: { id: string; text: string }, second: { id: string; text: string }) => {
-          database.prepare('UPDATE record_search SET text = ? WHERE id = ?').run(second.text, first.id)
-          database.prepare('UPDATE record_search SET text = ? WHERE id = ?').run(first.text, second.id)
+          database
+            .prepare('UPDATE record_search SET text = ? WHERE rowid = (SELECT rowid FROM records WHERE id = ?)')
+            .run(second.text, first.id)
+          database
+            .prepare('UPDATE record_search SET text = ? WHERE rowid = (SELECT rowid FROM records WHERE id = ?)')
+            .run(first.text, second.id)
         },
         name: 'swapped canonical texts',
       },
       {
         mutate: (database: DatabaseSync, first: { id: string; text: string }, second: { id: string; text: string }) => {
-          database.prepare('DELETE FROM record_search WHERE id = ?').run(second.id)
+          database
+            .prepare('DELETE FROM record_search WHERE rowid = (SELECT rowid FROM records WHERE id = ?)')
+            .run(second.id)
           database
             .prepare(
-              'INSERT INTO record_search(id, text, preview) SELECT id, text, preview FROM record_search WHERE id = ?',
+              'INSERT INTO record_search(rowid, text, preview) SELECT 9999, text, preview FROM record_search WHERE rowid = (SELECT rowid FROM records WHERE id = ?)',
             )
             .run(first.id)
         },
-        name: 'duplicate first ID with second ID missing',
+        name: 'orphan duplicate with second ID missing',
       },
     ] as const
 
@@ -8383,7 +8210,11 @@ describe('SQLite cache and reads', () => {
         subject: 'cache.validation.two',
       })
       mutateCache(root, database => {
-        const rows = database.prepare('SELECT id, text FROM record_search ORDER BY id').all() as Array<{
+        const rows = database
+          .prepare(
+            'SELECT records.id, text FROM record_search JOIN records ON records.rowid = record_search.rowid ORDER BY records.id',
+          )
+          .all() as Array<{
           id: string
           text: string
         }>

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -4441,6 +4441,43 @@ describe('SQLite cache and reads', () => {
     }
   })
 
+  test('drives full and compact searches from FTS matches before record lookups', () => {
+    const root = createRoot()
+    const record = api.addRecord({
+      kind: 'context',
+      payload: { summary: 'needle' },
+      root,
+      source: 'agent',
+      subject: 'search.join-order',
+    })
+    const plans: string[][] = []
+    const { prepare } = DatabaseSync.prototype
+    const observer = mock.method(DatabaseSync.prototype, 'prepare', function (this: DatabaseSync, source: string) {
+      if (source.includes('record_search MATCH ?')) {
+        const plan = prepare.call(this, `EXPLAIN QUERY PLAN ${source}`).all('needle', 20)
+        plans.push(plan.map(row => String(row.detail)))
+      }
+      return prepare.call(this, source)
+    })
+    try {
+      assert.deepEqual(
+        api.searchRecords({ query: 'needle', root }).map(result => result.id),
+        [record.id],
+      )
+      assert.deepEqual(
+        api.searchCompactRecords({ query: 'needle', root }).map(result => result.id),
+        [record.id],
+      )
+      assert.equal(plans.length, 2)
+      assert.ok(
+        plans.every(plan => plan[0]?.includes('record_search')),
+        JSON.stringify(plans),
+      )
+    } finally {
+      observer.mock.restore()
+    }
+  })
+
   test('charges compact response containers in their composing callers', () => {
     const root = createRoot()
     const query = 'structural ownership marker'


### PR DESCRIPTION
## Summary

Reduce the disposable SQLite cache to its search and ordering projection. Full records now come from the operation's accepted `VerifiedCorpus`, and the cache no longer stores or reparses complete record JSON.

## Problem

The previous cache duplicated canonical records alongside their FTS documents. Strict reads validated that duplicate store before materialising records from it, despite already holding the authoritative canonical snapshot.

## Design

- Retain integer row identity for FTS joins, public ID for canonical lookup, kind/subject for filters, created time for deterministic ordering, and active state for supersession filtering. Remove cached JSON, source, path and summary columns.
- Stream ordered IDs and resolve them through `VerifiedCorpus.byId`; charge the existing full-record byte budget before cloning independent public values. Compact search combines canonical metadata with the bounded FTS preview and existing rank.
- Keep FTS first in full and compact search joins. A query-plan regression covers the minimum Node/SQLite runtime, whose optimiser otherwise repeats MATCH for each active record.
- Use schema 4 with fixed application ID/user version and an exact, bounded comparison against the schema generated by the trusted writer on the running SQLite version. Remove the semantic DDL tokenizer and cached-record parser.
- Preserve strict scalar, active-state, generation and FTS equivalence. Verify ordinary index contents as well as FTS postings: an index with a missing entry must trigger recovery instead of silently omitting a canonical result.

## Scope

Minimal cache representation, canonical result materialisation, exact schema admission, old-cache recovery, complementary corruption/ordering/budget regressions, release compatibility schema expectations, and three append-only architecture records. The diff removes 591 net lines.

## Deliberately excluded

Gather duplicate pre-charging remains MAR-2790. Production work observers, bundle sharing and CI restructuring remain their subsequent tickets. Ordinary content-bearing FTS already meets the size target; no external/contentless FTS or new durability setting is introduced. WAL remains `synchronous=FULL`.

## Compatibility

Public API/CLI shapes, literal payload matching, rank, preview bounds, ordering, filters, null results, independent mutable values and limits remain compatible. Node 24.15.0 remains the minimum, with zero runtime dependencies. Existing filesystem identity, containment, sidecar, lock, quarantine and one-rebuild protections remain in place.

The exact retained candidate passes published 0.3.0 upgrade/downgrade (schema 2 → 4 → 2), previous-main upgrade/downgrade (3 → 4 → 3), and the existing published 0.2.0 gate (1 → 4 → 1). Canonical records and artifacts remain byte-identical across each migration. Previous-main full, compact and gather outputs compare exactly; six packed CLI operations also recover from forged FTS postings.

## Performance

Base: `b5203c6a49e0deb81a57d630487716633995f4d3`.
Head: `06c3d861a724ddb380a1ba561c7cf2702afa9467`.

Matched local campaign: Apple M5 Pro, darwin/arm64, Node v24.15.0; 20 measured rounds and two warm-ups per operation/side, unchanged harness `7143ad061631aba5380340cebdd622c3c1052dd2ea5a861180b94dbb530531a2`. Both sides use the same 1,000 records, 100 artifacts, 100 large payloads, supersession depth 100 and 3,580,039 canonical JSON bytes. All 600 raw reports and 53 metric comparisons pass.

**Target met:** total SQLite bytes 8,364,032 → 4,689,920 (**43.93% smaller**, required ≥30%); amplification 2.336× → 1.310×. Peak strict-read RSS 141,672,448 → 137,150,464 bytes (3.19% lower; required no increase).

| Operation | Median ms, base → head | p95 ms, base → head | Peak RSS bytes, base → head |
| --- | ---: | ---: | ---: |
| strictCacheValidation | 132.595 → 127.737 | 148.239 → 132.573 | 141,672,448 → 137,150,464 |
| list | 131.861 → 126.329 | 136.147 → 128.909 | 141,623,296 → 136,593,408 |
| show | 131.606 → 126.766 | 138.401 → 132.049 | 143,917,056 → 136,151,040 |
| fullSearch | 136.364 → 129.789 | 156.389 → 156.473 | 144,277,504 → 138,067,968 |
| gather | 139.953 → 133.916 | 145.446 → 137.957 | 142,639,104 → 137,068,544 |
| coldHydrate | 218.279 → 203.753 | 223.833 → 209.204 | 142,540,800 → 136,642,560 |

Strict-read total-time spread: range 28.082 → 7.112 ms; variance 49.382 → 3.563 ms². Median phase breakdown: list: preparation 110.418 → 105.494 ms, query/projection 0.330 → 0.209 ms; show: preparation 110.281 → 105.819 ms, query/projection 0.167 → 0.115 ms; fullSearch: preparation 112.094 → 106.905 ms, query/projection 2.718 → 0.667 ms; gather: preparation 111.637 → 106.737 ms, query/projection 7.009 → 6.166 ms.

javascriptBytes: 916,337 → 880,519 bytes; declarationBytes: 26,546 → 26,546 bytes; tarballBytes: 366,649 → 360,663 bytes.

Raw local evidence and independently checked acceptance floors are retained in `/private/tmp/encephalon-mar2789-matched-06c3d86-node24`. Exact-head CI will repeat the matched campaign on Linux and run platform correctness coverage.

## Verification

- `bun install --frozen-lockfile`.
- `bun run lint`, `bun run typecheck`, `bun run test` (827 passed, three platform skips), and `bun run test:tooling` (91 passed). Runtime tests took 54.0 seconds; tooling tests took 157.2 seconds locally.
- `bun run build`, `bun run check:generated`, `bun run check:package`, and `bun run benchmark:check`.
- `bun run check:package --retain-tarball package-artifacts`, then `bun run check:publish package-artifacts/encephalon-0.3.0.tgz` (dry run only) and `bun run check:compatibility package-artifacts/encephalon-0.3.0.tgz`.
- Additional Node 24.15.0 packed-package checks: published 0.3.0 and previous-main migration round trips, 32 CLI checks, and targeted schema/row-identity/index-integrity regressions.
- `node dist/cli.mjs validate --root .`: 50 valid canonical records; `git diff --check` passed.
- Independent review reproduced an ordinary-index omission; the regression failed before the native index check and passed afterwards. No unresolved local findings remain.

Retained candidate: 360,663 bytes; SHA-256 `eaffe29be64f33e3c1c46cd8960dc3c3b2cd0c93ec8893136f3fe28763fdd9c9`. All package gates use these exact bytes, including the minimum-runtime join-order correction.

## Risk and rollback

The first access rebuilds predecessor cache formats. Malformed projections or index contents follow existing bounded quarantine/rebuild recovery. Rollback restores the previous package, which rebuilds its own disposable schema; canonical data does not require migration.

## Linear

https://linear.app/marcoappio/issue/MAR-2789/cache-reduce-sqlite-to-the-minimal-search-and-ordering-projection



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reduces SQLite to a disposable search and ordering projection while materialising authoritative records from the accepted canonical corpus.
- Replaces cached full-record JSON with integer-linked record and FTS projections.
- Adds exact schema, ordinary-index, FTS, and canonical-equivalence validation with recovery for predecessor or corrupted caches.
- Forces FTS-first execution for full and compact searches on the minimum supported SQLite runtime.
- Updates schema compatibility expectations and adds corruption, ordering, budget, and query-plan regressions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/cache.ts | Replaces duplicated record storage with a strictly validated projection, resolves public records from VerifiedCorpus, and preserves FTS-first integer joins. |
| test/cache.test.ts | Adds and updates regressions for schema admission, projection integrity, corruption recovery, ordering, budgets, and minimum-runtime query plans. |
| scripts/release-compatibility.ts | Updates upgrade and downgrade compatibility assertions from cache schema 3 to schema 4. |
| scripts/release-compatibility.test.ts | Updates compatibility fixtures and expected migration reports for schema 4. |
| encephalon/architecture/07a820c8-c399-4c7c-8bbc-7a20be8683f0.json | Records the canonical-corpus and minimal-cache architecture decision. |
| encephalon/architecture/59c66755-8eb0-4808-91cd-5ccc26bcbccc.json | Records the requirement to validate ordinary SQLite indexes before trusting projected results. |
| encephalon/architecture/b7ab828a-ffcc-43f0-9640-5975cc515da1.json | Records the FTS-first join-order decision for the minimum supported runtime. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Corpus as VerifiedCorpus
    participant Cache as SQLite projection
    Caller->>Corpus: Validate canonical snapshot
    Caller->>Cache: Open and validate schema/indexes
    Caller->>Cache: Query ordered IDs or FTS matches
    Cache-->>Caller: IDs, rank, and bounded preview
    Caller->>Corpus: Resolve IDs through byId
    Caller->>Caller: Charge response budget and clone
    Caller-->>Caller: Return independent public values
```
</details>

<sub>Reviews (2): Last reviewed commit: ["\[MAR-2789\] Keep FTS first on the minimum..."](https://github.com/isaachinman/encephalon/commit/06c3d861a724ddb380a1ba561c7cf2702afa9467) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62692398)</sub>

<!-- /greptile_comment -->