### PR TITLE
[MAR-2790] Reserve memoised gather output before cloning

### DIFF
--- a/encephalon/architecture/f15451c0-ff87-48d6-abb5-40f18accb8cf.json
+++ b/encephalon/architecture/f15451c0-ff87-48d6-abb5-40f18accb8cf.json
@@ -1,0 +1,18 @@
+{
+  "createdAt": "2026-09-10T18:19:00.032Z",
+  "id": "f15451c0-ff87-48d6-abb5-40f18accb8cf",
+  "kind": "architecture",
+  "payload": {
+    "summary": "Gather reserves the complete memoised occurrence cost before copying a duplicate, while first distinct searches remain streamed against the shared response budget.",
+    "rules": [
+      "The existing logical byte contract counts UTF-8 strings and property names plus eight bytes per scalar or container. Raw canonical file size and JSON serialisation length are different contracts and must not replace gather accounting.",
+      "Memoise a canonical show reference and its complete logical envelope cost only for requested IDs, including missing IDs. Charge each occurrence before constructing its public envelope or cloning its record; never expose the accepted canonical reference.",
+      "Measure and charge each first-query compact row once before retaining it in the streamed result array. Save the sum with the empty search envelope cost, which already includes the results array node.",
+      "Exact query strings identify memo entries because kind, supersession and limit are fixed for the gather. Charge a duplicate search envelope and all rows in one step before allocating its result array or copying rows. Preserve independent output objects and duplicate order.",
+      "Keep the ledger, measured costs and both memos inside one verified attempt. A failed attempt discards all partial state; recovery starts fresh. Do not add an eager whole-corpus sizing pass or persist costs between operations."
+    ]
+  },
+  "searchText": "gather memoised duplicate precharge clone allocation logical response budget streaming MAR-2790",
+  "source": "agent",
+  "subject": "gather.response-accounting"
+}

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -48,7 +48,7 @@ import {
   type VerifiedCorpus,
 } from './records.ts'
 import { resolveRepository } from './repository.ts'
-import { createResponseByteBudget, type ResponseByteBudget } from './response-budget.ts'
+import { createResponseByteBudget, logicalResponseBytes, type ResponseByteBudget } from './response-budget.ts'
 import { validateArtifactPath } from './schema.ts'
 import { literalMatchQuery, MAX_NFC_UTF8_EXPANSION_FACTOR } from './search-text.ts'
 import { classifySQLiteError } from './sqlite-error.ts'
@@ -1907,14 +1907,17 @@ const createCompactSearchReader = (
   cacheReadTestHooks.onCompactSearchPrepare?.(source)
   const statement = database.prepare(source)
   return (query: string, match: string) => {
-    if (match.length === 0) {
-      return []
+    if (match.length > 0) {
+      let bytes = 0
+      const records = Array.from(statement.iterate(match, ...kindParameters, limit) as Iterable<CompactRow>, row => {
+        const record = compactRecordFromRow(row, corpus)
+        bytes += budget.chargeAndMeasure(record)
+        return record
+      })
+      cacheReadTestHooks.afterCompactSearchRead?.(query)
+      return { bytes, records }
     }
-    const records = Array.from(statement.iterate(match, ...kindParameters, limit) as Iterable<CompactRow>, row =>
-      budget.charge(compactRecordFromRow(row, corpus)),
-    )
-    cacheReadTestHooks.afterCompactSearchRead?.(query)
-    return records
+    return { bytes: 0, records: [] }
   }
 }
 
@@ -1939,7 +1942,7 @@ export const searchCompactRecords = (input: SearchRecordsInput): CompactBrainRec
     return withPreparedDatabase(parsed, (database, corpus) => {
       const budget = createResponseByteBudget('compactResponseBytes')
       budget.charge([])
-      return createCompactSearchReader(database, corpus, parsed, budget)(parsed.query, match)
+      return createCompactSearchReader(database, corpus, parsed, budget)(parsed.query, match).records
     })
   }
   resolveRepository(parsed)
@@ -1954,7 +1957,7 @@ const createShowReader = (database: DatabaseSync, corpus: VerifiedCorpus, includ
   return (id: string) => {
     const row = statement.get(id) as RecordRow | undefined
     cacheReadTestHooks.afterShowRead?.(id)
-    return row === undefined ? null : structuredClone(canonicalRecordFromRow(row, corpus))
+    return row === undefined ? null : canonicalRecordFromRow(row, corpus)
   }
 }
 
@@ -1984,38 +1987,43 @@ const readGatherFromDatabase = (
   budget.charge({ hydrated, records: [], searches: [] })
   const showRecordForId = shows.length === 0 ? () => null : createShowReader(database, corpus, input.includeSuperseded)
   const searchCompactRecordsForQuery =
-    searches.length === 0 ? () => [] : createCompactSearchReader(database, corpus, input, budget)
-  const shownRecords = new Map<string, BrainRecord | null>()
-  const searchResults = new Map<string, readonly CompactBrainRecord[]>()
+    searches.length === 0
+      ? () => ({ bytes: 0, records: [] })
+      : createCompactSearchReader(database, corpus, input, budget)
+  const shownRecords = new Map<string, Readonly<{ bytes: number; record: BrainRecord | null }>>()
+  const searchResults = new Map<string, Readonly<{ bytes: number; result: GatherResult['searches'][number] }>>()
   const memoizedShowRecordForId = (id: string) => {
-    if (shownRecords.has(id)) {
-      const record = shownRecords.get(id) ?? null
-      return record === null ? null : structuredClone(record)
+    const cached = shownRecords.get(id)
+    if (cached !== undefined) {
+      return cached
     }
     const record = showRecordForId(id)
-    shownRecords.set(id, record)
-    return record
+    const measured = { bytes: logicalResponseBytes({ id, record }), record }
+    shownRecords.set(id, measured)
+    return measured
   }
-  const memoizedCompactRecordsForQuery = (search: LiteralSearch) => {
-    if (searchResults.has(search.query)) {
-      return (searchResults.get(search.query) ?? []).map(record => budget.charge({ ...record }))
+  const memoizedSearchForQuery = (search: LiteralSearch) => {
+    const cached = searchResults.get(search.query)
+    if (cached !== undefined) {
+      budget.chargeBytes(cached.bytes)
+      return { ...cached.result, results: cached.result.results.map(record => ({ ...record })) }
     }
-    const records = searchCompactRecordsForQuery(search.query, search.match)
+    const envelope = { kind: input.kind ?? null, query: search.query, results: [] }
+    const envelopeBytes = budget.chargeAndMeasure(envelope)
+    const { bytes, records } = searchCompactRecordsForQuery(search.query, search.match)
     cacheReadTestHooks.afterGatherSearchEvaluation?.(search.query)
-    searchResults.set(search.query, records)
-    return records
+    const result = { ...envelope, results: records }
+    searchResults.set(search.query, { bytes: envelopeBytes + bytes, result })
+    return result
   }
   return {
     hydrated,
-    records: shows.map(id => budget.charge({ id, record: memoizedShowRecordForId(id) })),
-    searches: searches.map(search => {
-      const envelope = budget.charge({
-        kind: input.kind ?? null,
-        query: search.query,
-        results: [],
-      })
-      return { ...envelope, results: memoizedCompactRecordsForQuery(search) }
+    records: shows.map(id => {
+      const { bytes, record } = memoizedShowRecordForId(id)
+      budget.chargeBytes(bytes)
+      return { id, record: record === null ? null : structuredClone(record) }
     }),
+    searches: searches.map(memoizedSearchForQuery),
   }
 }
 

--- a/src/response-budget.ts
+++ b/src/response-budget.ts
@@ -9,6 +9,7 @@ export type ResponseBudgetKey = Extract<keyof typeof OPERATION_BUDGETS, `${strin
 /** @internal */
 export type ResponseByteBudget = {
   charge: <Value>(value: Value) => Value
+  chargeAndMeasure: (value: unknown) => number
   chargeBytes: (bytes: number) => void
 }
 
@@ -60,11 +61,17 @@ export const createResponseByteBudget = (budgetKey: ResponseBudgetKey): Response
     return failBudget(budgetKey, message)
   }
 
-  const charge = <Value>(value: Value) => {
-    chargeBytes(logicalResponseBytes(value))
+  const chargeAndMeasure = (value: unknown) => {
+    const bytes = logicalResponseBytes(value)
+    chargeBytes(bytes)
     responseBudgetTestHooks.afterCharge?.(budgetKey, value)
+    return bytes
+  }
+
+  const charge = <Value>(value: Value) => {
+    chargeAndMeasure(value)
     return value
   }
 
-  return Object.freeze({ charge, chargeBytes })
+  return Object.freeze({ charge, chargeAndMeasure, chargeBytes })
 }

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -4371,18 +4371,24 @@ describe('SQLite cache and reads', () => {
     }
 
     const gatherRecords = functionFromApi<(input: Record<string, unknown>) => Record<string, unknown>>('gatherRecords')
-    assertBudgetError(
-      () =>
-        gatherRecords({
-          root,
-          shows: Array.from({ length: 5 }, () => 'large-response-0'),
-        }),
-      {
-        budget: 'gatherResponseBytes',
-        field: 'response',
-        maximum: 4 * 1024 * 1024,
-      },
-    )
+    const gatherCloning = mock.method(globalThis, 'structuredClone')
+    try {
+      assertBudgetError(
+        () =>
+          gatherRecords({
+            root,
+            shows: Array.from({ length: 5 }, () => 'large-response-0'),
+          }),
+        {
+          budget: 'gatherResponseBytes',
+          field: 'response',
+          maximum: 4 * 1024 * 1024,
+        },
+      )
+      assert.equal(gatherCloning.mock.callCount(), 4, 'the rejected duplicate must not clone its record')
+    } finally {
+      gatherCloning.mock.restore()
+    }
     const gathered = gatherRecords({ limit: 5, root, searches: ['response budget marker'] }) as {
       searches: Array<{ results: unknown[] }>
     }
@@ -4511,6 +4517,55 @@ describe('SQLite cache and reads', () => {
       budgetKey: 'gatherResponseBytes',
       value: { kind: null, query, results: [] },
     })
+  })
+
+  test('rejects a complete duplicate search before copying any of its rows', () => {
+    const root = createRoot()
+    const query = 'duplicate search allocation'
+    const ids = ['duplicate-large-a', 'duplicate-large-b', 'duplicate-large-c']
+    for (const id of ids) {
+      api.addRecord({
+        id,
+        kind: 'context',
+        payload: { summary: 'x '.repeat(300 * 1024) },
+        root,
+        source: 'agent',
+        subject: `${query}.${id}`,
+      })
+    }
+    const observed = new Set<string>()
+    let copiedRows = 0
+    responseBudgetTestHooks.afterCharge = (budgetKey, value) => {
+      if (
+        budgetKey === 'gatherResponseBytes' &&
+        value !== null &&
+        typeof value === 'object' &&
+        'snippet' in value &&
+        'id' in value &&
+        typeof value.id === 'string' &&
+        'summary' in value &&
+        typeof value.summary === 'string' &&
+        !observed.has(value.id)
+      ) {
+        observed.add(value.id)
+        const { summary } = value
+        Object.defineProperty(value, 'summary', {
+          enumerable: true,
+          get: () => {
+            copiedRows += 1
+            return summary
+          },
+        })
+      }
+    }
+
+    assertBudgetError(() => api.gatherRecords({ limit: 3, root, searches: [query, query, query] }), {
+      budget: 'gatherResponseBytes',
+      field: 'response',
+      maximum: 4 * 1024 * 1024,
+    })
+    assert.deepEqual([...observed].sort(), ids)
+    assert.equal(copiedRows, 3, 'only the accepted duplicate may copy the three original rows')
   })
 
   test('shares one 4 MiB gather response budget across complete repeated results', () => {


### PR DESCRIPTION
## Summary

Gather now reserves the complete logical cost of a memoised occurrence before cloning its record or copying its search results. A rejected fifth large show previously cloned the record; it now stops after the four accepted clones. A rejected third large search previously started copying rows; it now rejects before creating that duplicate array.

## Problem

Exact-work memoisation avoided repeated queries but still recursively sized each duplicate output and allocated rejected copies before checking the shared 4 MiB response budget.

## Design

- Memoise the accepted canonical reference and complete show-envelope cost once per requested ID, including missing IDs. Charge each occurrence before cloning its independently mutable public record.
- Return the logical row-byte sum from the existing streaming compact reader. `chargeAndMeasure` keeps one sizing walk and the existing post-success test notification; standalone compact search retains its public array result.
- Charge a first search envelope before streaming its rows. Save that envelope cost plus the admitted row sum, then reserve the complete amount before copying each duplicate query result.
- Keep every memo, measured cost and ledger inside the verified attempt so recovery discards partial state together.

## Scope

Two production modules, one strengthened clone regression, one complementary compact-copy regression and architecture record `f15451c0-ff87-48d6-abb5-40f18accb8cf`.

## Deliberately excluded

No changes to SQL, cache schema, filesystem verification, public limits, canonical storage, benchmark fixtures or later-ticket work.

## Compatibility

The existing logical UTF-8/node/container accounting, exact 4 MiB acceptance, one-byte rejection, public error details, duplicates, ordering, nulls, empty searches, rank/snippet values and independent mutable results are preserved. The first distinct search remains checked row by row before retaining each result. Runtime dependencies remain zero; Node 24.15.0 remains supported.

Actual published 0.3.0 → candidate → 0.3.0 passes with schema 2 → 4 → 2 and all six durable files byte-identical. The exact preceding main package → candidate → preceding main passes with schema 4 throughout and identical full/compact/gather results. Packed CLI checks include six wrong-FTS recovery routes and 32 normal/replacement/missing-artifact checks, plus exact API/CLI equality at 64 shows and 16 searches, accepted near-limit duplicates and exact safe errors for rejected large duplicates. Publish verification is dry-run only.

## Performance

Matched final campaign against base `ad31ee4a3fac1186d0385a55620545702294a2bb` and head `5569fef04495a1aa9eed4d6e9fafc72d3574e967`: Apple M5 Pro, darwin/arm64, Node24.15.0; 20 measured samples plus two warmups per operation/side; unchanged harness `7143ad061631aba5380340cebdd622c3c1052dd2ea5a861180b94dbb530531a2`. Same 1,000 records, 100 artifacts, 100 large payloads, depth 100 and 3,580,039 canonical JSON bytes. All 600 raw reports and 53 metric comparisons pass.

| Operation | Median ms, base → head | p95 ms, base → head | Peak RSS bytes, base → head |
| --- | ---: | ---: | ---: |
| coldHydrate | 206.188 → 205.797 | 232.498 → 231.734 | 136,855,552 → 137,052,160 |
| unchangedPrepare | 135.517 → 137.170 | 153.209 → 147.639 | 138,477,568 → 139,902,976 |
| stalePrepare | 285.876 → 283.753 | 297.231 → 300.816 | 158,515,200 → 158,793,728 |
| list | 127.823 → 128.655 | 134.866 → 135.648 | 137,052,160 → 138,543,104 |
| show | 128.558 → 129.107 | 137.815 → 146.121 | 137,773,056 → 138,608,640 |
| compactSearch | 130.752 → 129.021 | 139.004 → 135.295 | 137,904,128 → 137,707,520 |
| fullSearch | 129.614 → 129.589 | 135.714 → 138.982 | 136,921,088 → 139,247,616 |
| gather | 134.382 → 134.473 | 141.213 → 138.921 | 138,346,496 → 137,461,760 |
| largePayloadSearch | 133.564 → 133.655 | 145.715 → 156.470 | 136,871,936 → 137,527,296 |
| maximumPayloadSearch | 134.210 → 135.172 | 140.311 → 143.518 | 148,324,352 → 146,046,976 |
| payloadOnlySearch | 133.338 → 133.983 | 144.723 → 140.578 | 149,880,832 → 147,144,704 |
| missingSearch | 128.159 → 128.485 | 133.254 → 133.666 | 137,641,984 → 137,822,208 |
| listMaximum | 145.142 → 143.137 | 160.249 → 157.769 | 145,965,056 → 143,179,776 |
| validateArtifacts | 77.363 → 78.353 | 84.599 → 83.088 | 126,369,792 → 128,450,560 |
| strictCacheValidation | 129.234 → 129.383 | 136.606 → 132.274 | 136,626,176 → 137,052,160 |

Gather median query/projection time: 6.191 → 5.948ms; preparation/integrity: 106.932 → 107.425ms. Total-time spread: range 36.334 → 10.350ms; variance 60.875 → 5.523ms².

1000:cache/totalBytes: 4,689,920 → 4,689,920; package/javascriptBytes: 880,519 → 881,633; package/declarationBytes: 26,546 → 26,546; package/tarballBytes: 360,663 → 360,919.

On the accepted 1,000-record fixture with 64 shows and 16 searches:

| Work/allocation evidence | Base | Candidate |
| --- | ---: | ---: |
| Logical-size node visits | 3,204 | 350 |
| Arrays/tuples created by object sizing | 3,236 | 351 |
| Distinct show lookups / search queries | 2 / 2 | 2 / 2 |
| Required successful record clones / compact-row copies | 32 / 280 | 32 / 280 |
| Maximum query-phase heap growth, 20 + 2 matched samples | 777,144 B | 225,848 B |

Sizing visits fall 89.08%; maximum query-phase heap growth falls 70.94%. Exact output hashes match. Counters exist only in isolated diagnostic source copies. The separate heap diagnostic uses uninstrumented exact sources, alternating fresh Node 24 processes and the accepted fixture; it collects garbage immediately before the existing result-read boundary and requires zero collections during the measured read. This supports the allocation result; ordinary latency/RSS acceptance uses the unchanged common benchmark harness.

## Verification

- Lint, all type checks, 828 runtime tests (three platform skips), 91 tooling tests, build, generated files, package checks, benchmark check and 51-record canonical validation pass.
- Both allocation regressions demonstrably fail on the actual base and pass on the candidate. Existing exact-boundary, Unicode, ordering/isolation, empty/missing memo and partial-recovery tests pass.
- Published/intermediate upgrade and downgrade checks, packed CLI checks and publish dry-run pass.
- Independent initial design and focused implementation reviews found no actionable defect; full local diff reviewed for scope and integration.
- Exact-head multi-platform CI and explicit Greptile 5/5 are required before merge, followed by successful merged-main CI.

## Risk and rollback

The main risk is omitting an envelope/container cost or reusing a mutable memo. Costs use the existing generic logical contract once per distinct value, first queries remain streamed, and exact-boundary/isolation/retry coverage exercises the composed result. Reverting this change restores the old composition without a data migration.

## Linear

[MAR-2790](https://linear.app/marcoappio/issue/MAR-2790/gather-charge-memoised-output-sizes-before-cloning-duplicate-results)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Gather now measures and reserves each memoized show or search occurrence against the shared response budget before allocating its public copy.
- Memoizes canonical show references with their complete logical envelope cost.
- Streams and measures first-query compact rows, then precharges duplicate search results before copying them.
- Extends response-budget accounting with a combined charge-and-measure operation.
- Adds exact-boundary and rejected-allocation regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no concrete changed-code defect remains after checking accounting equivalence, caller compatibility, and result isolation.

The revised implementation preserves the existing logical response-byte contract while charging memoized occurrences before allocation, and all internal callers consume the new reader result shape correctly.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/cache.ts | Refactors gather show and compact-search memoization to reserve complete logical costs before cloning or copying while preserving streamed first-query accounting and independent outputs. |
| src/response-budget.ts | Adds chargeAndMeasure as a thin composition of existing logical sizing, budget charging, and post-success notification behavior. |
| test/cache.test.ts | Strengthens regressions to verify rejected duplicate shows and searches do not perform unnecessary clone or row-copy allocations. |
| encephalon/architecture/f15451c0-ff87-48d6-abb5-40f18accb8cf.json | Records the intended logical-accounting, memoization, allocation-order, isolation, and retry invariants. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Gather occurrence] --> B{Memoized?}
  B -- No --> C[Read canonical show or stream search rows]
  C --> D[Measure and charge logical cost]
  D --> E[Store canonical result and total cost]
  B -- Yes --> F[Charge stored total cost]
  E --> G[Clone or copy public result]
  F --> G
  D -- Budget exceeded --> H[Reject before allocation]
  F -- Budget exceeded --> H
```
</details>

<sub>Reviews (1): Last reviewed commit: ["\[MAR-2790\] Reserve memoised gather outpu..."](https://github.com/isaachinman/encephalon/commit/5569fef04495a1aa9eed4d6e9fafc72d3574e967) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62723620)</sub>

<!-- /greptile_comment -->